### PR TITLE
ci: changes Slack deployment message channel

### DIFF
--- a/.github/workflows/deploy_git_tag.yml
+++ b/.github/workflows/deploy_git_tag.yml
@@ -51,7 +51,7 @@ jobs:
               "text": "Flutter SDK git tag created",
               "username": "Flutter deployment bot",
               "icon_url": "https://img.icons8.com/color/512/flutter.png",
-              "channel": "#squad-mobile",
+              "channel": "#mobile-deployments",
               "blocks": [
                 {
                   "type": "section",
@@ -86,7 +86,7 @@ jobs:
               "text": "Flutter SDK deployment failure",
               "username": "Flutter deployment bot",
               "icon_url": "https://img.icons8.com/color/512/flutter.png",
-              "channel": "#squad-mobile",
+              "channel": "#mobile-deployments",
               "blocks": [
                 {
                   "type": "section",

--- a/.github/workflows/deploy_pubspec.yml
+++ b/.github/workflows/deploy_pubspec.yml
@@ -33,7 +33,7 @@ jobs:
               "text": "Flutter SDK deployed to pub.dev",
               "username": "Flutter deployment bot",
               "icon_url": "https://img.icons8.com/color/512/flutter.png",
-              "channel": "#squad-mobile",
+              "channel": "#mobile-deployments",
               "blocks": [
                 {
                   "type": "section",
@@ -68,7 +68,7 @@ jobs:
               "text": "Flutter SDK deployment failure",
               "username": "Flutter deployment bot",
               "icon_url": "https://img.icons8.com/color/512/flutter.png",
-              "channel": "#squad-mobile",
+              "channel": "#mobile-deployments",
               "blocks": [
                 {
                   "type": "section",

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -27,7 +27,7 @@ jobs:
               "text": "Flutter SDK deployment failure",
               "username": "Flutter deployment bot",
               "icon_url": "https://img.icons8.com/color/512/flutter.png",
-              "channel": "#squad-mobile",
+              "channel": "#mobile-deployments",
               "blocks": [
                   {
                       "type": "section",


### PR DESCRIPTION
Changes the Slack channel for deployment messages to the new mobile-deployments channel

See https://github.com/customerio/issues/issues/9014