### PR TITLE
feat: add CustomerIORouteObserver for optimized route tracking

### DIFF
--- a/apps/amiapp_flutter/lib/src/app.dart
+++ b/apps/amiapp_flutter/lib/src/app.dart
@@ -1,4 +1,5 @@
 import 'package:customer_io/customer_io.dart';
+import 'package:customer_io/customer_io_observer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
@@ -60,6 +61,7 @@ class _AmiAppState extends State<AmiApp> {
       debugLogDiagnostics: true,
       initialLocation: Screen.dashboard.path,
       refreshListenable: _auth,
+      observers: [CustomerIORouteObserver()],
       routes: [
         GoRoute(
           name: Screen.login.name,
@@ -155,9 +157,6 @@ class _AmiAppState extends State<AmiApp> {
       return value;
     });
     _customerIOSDK.addListener(_handleSDKConfigurationsChanged);
-
-    // Listen to screen changes for observing screens
-    _router.addListener(() => _onRouteChanged());
 
     super.initState();
   }

--- a/lib/customer_io_observer.dart
+++ b/lib/customer_io_observer.dart
@@ -1,0 +1,96 @@
+import 'package:customer_io/customer_io.dart';
+import 'package:flutter/widgets.dart';
+
+/// Signature for a function that extracts a screen name from [RouteSettings].
+typedef ScreenNameExtractor = String? Function(RouteSettings settings);
+
+String? defaultNameExtractor(RouteSettings settings) => settings.name;
+
+/// [RouteFilter] allows to filter out routes that should not be tracked.
+typedef RouteFilter = bool Function(Route<dynamic>? route);
+
+bool defaultRouteFilter(Route<dynamic>? route) => route is PageRoute;
+
+/// A [NavigatorObserver] that sends events to CustomerIO when the
+/// currently active [ModalRoute] changes.
+/// When a route is pushed or popped, and if [routeFilter] is true,
+/// [nameExtractor] is used to extract a name  from [RouteSettings] of the now
+/// active route and that name is sent to CustomerIO.
+///
+/// The following operations will result in sending a screen view event:
+/// ```dart
+/// Navigator.pushNamed(context, '/contact/123');
+///
+/// Navigator.push<void>(context, MaterialPageRoute(
+///   settings: RouteSettings(name: '/contact/123'),
+///   builder: (_) => ContactDetail(123)));
+///
+/// Navigator.pushReplacement<void>(context, MaterialPageRoute(
+///   settings: RouteSettings(name: '/contact/123'),
+///   builder: (_) => ContactDetail(123)));
+///
+/// Navigator.pop(context);
+/// ```
+///
+/// To use it, add it to the `navigatorObservers` of your [Navigator], e.g. if
+/// you're using a [MaterialApp]:
+/// ```dart
+/// MaterialApp(
+///   home: MyAppHome(),
+///   navigatorObservers: [
+///     CustomerIORouteObserver(),
+///   ],
+/// );
+/// ```
+///
+/// You can also track screen views within your [ModalRoute] by implementing
+/// [RouteAware<ModalRoute<dynamic>>] and subscribing it to [CustomerIORouteObserver]. See the
+/// [RouteObserver<ModalRoute<dynamic>>] docs for an example.
+
+class CustomerIORouteObserver extends RouteObserver<ModalRoute<dynamic>> {
+  /// Creates a [NavigatorObserver] that sends events to CustomerIO.
+  ///
+  /// When a route is pushed or popped, [nameExtractor] is used to extract a
+  /// name from [RouteSettings] of the now-active route and that name is sent to
+  /// CustomerIO. Defaults to `defaultNameExtractor`.
+  CustomerIORouteObserver({
+    this.nameExtractor = defaultNameExtractor,
+    this.routeFilter = defaultRouteFilter,
+  });
+
+  final ScreenNameExtractor nameExtractor;
+  final RouteFilter routeFilter;
+
+  void _sendScreenView(Route<dynamic> route) {
+    final String? screenName = nameExtractor(route.settings);
+    if (screenName != null) {
+      CustomerIO.screen(name: screenName);
+    }
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    if (routeFilter(route)) {
+      _sendScreenView(route);
+    }
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    if (newRoute != null && routeFilter(newRoute)) {
+      _sendScreenView(newRoute);
+    }
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    if (previousRoute != null &&
+        routeFilter(previousRoute) &&
+        routeFilter(route)) {
+      _sendScreenView(previousRoute);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces `CustomerIORouteObserver`, a route observer that automatically tracks screen views and reports them to Customer.io. The observer integrates seamlessly with GoRouter or MaterialApp, thus eliminating the need for manual tracking logic.

## Changes

- Implemented `CustomerIORouteObserver` that extends `NavigatorObserver`.
- Integrated the observer with GoRouter.
- Removed manual route tracking and listeners.


This PR aims to address [Issue #87](https://github.com/customerio/customerio-flutter/issues/87)
