### PR TITLE
ci: use latest version of deploy tool

### DIFF
--- a/.github/workflows/deploy_git_tag.yml
+++ b/.github/workflows/deploy_git_tag.yml
@@ -31,14 +31,9 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         id: semantic-release
         with:
-          # version numbers below can be in many forms: M, M.m, M.m.p
-          # version should be greater than the 22.0.1 (https://github.com/semantic-release/semantic-release/releases/tag/v22.0.1)
-          # because previous version had a bug in commit analyzer
-          semantic_version: 22.0.5
+          semantic_version: latest
           extra_plugins: |
             conventional-changelog-conventionalcommits
-            @semantic-release/changelog
-            @semantic-release/git
             @semantic-release/github
             @semantic-release/exec
         env:


### PR DESCRIPTION
Similar to other PRs in other repos, I suggest we use latest version of tool instead of a hard-coded version. 