### PR TITLE
ci: fix installing sd tool needed for deployment

### DIFF
--- a/.github/workflows/deploy_git_tag.yml
+++ b/.github/workflows/deploy_git_tag.yml
@@ -25,7 +25,8 @@ jobs:
       # CLI to replace strings in files. The CLI recommends using `cargo install` which is slow. This Action is fast because it downloads pre-built binaries.
       # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.
       - name: Install sd CLI to use later in the workflow
-        uses: kenji-miyake/setup-sd@v1
+        # uses: kenji-miyake/setup-sd@v1
+        uses: levibostian/setup-sd@add-file-extension # Using fork until upstream Action has bug fixed in it. 
 
       - name: Deploy git tag via semantic release
         uses: cycjimmy/semantic-release-action@v4


### PR DESCRIPTION
The iOS SDK experienced a deployment failure on `main` because of a GH Action that we depend on. 

I installed a workaround in the iOS SDK until the GH action gets fixed. This PR applies the same workaround here. 
