### PR TITLE
chore: update docs link text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the official Customer.io Flutter plugin.
 
 # Getting started 
 
-You'll find our [complete SDK documentation](https://customer.io/docs/sdk/flutter/). 
+You'll find our complete [SDK documentation here](https://customer.io/docs/sdk/flutter/). 
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the official Customer.io Flutter plugin.
 
 # Getting started 
 
-You'll find our [complete SDK documentation at https://customer.io/docs/sdk/flutter/](https://customer.io/docs/sdk/flutter/). 
+You'll find our [complete SDK documentation](https://customer.io/docs/sdk/flutter/). 
 
 # Contributing
 


### PR DESCRIPTION
The current get started guide with the link on pub.dev doesn't link to the correct hompeage it goes to a page that is not found.