### PR TITLE
feat: support for android gradle plugin 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:8.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,15 +26,16 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'io.customer.customer_io'
     compileSdkVersion 33
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "3.9.2"
+    def cioVersion = "3.10.0"
     implementation "io.customer.android:tracking:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.customer.customer_io"></manifest>
+<manifest />

--- a/apps/amiapp_flutter/android/app/build.gradle
+++ b/apps/amiapp_flutter/android/app/build.gradle
@@ -6,6 +6,7 @@ plugins {
 }
 
 android {
+    namespace 'io.customer.amiapp_flutter'
     compileSdkVersion 33
     ndkVersion flutter.ndkVersion
 

--- a/apps/amiapp_flutter/android/app/src/main/AndroidManifest.xml
+++ b/apps/amiapp_flutter/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.customer.amiapp_flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 

--- a/apps/amiapp_flutter/android/app/src/profile/AndroidManifest.xml
+++ b/apps/amiapp_flutter/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.customer.amiapp_flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/apps/amiapp_flutter/android/build.gradle
+++ b/apps/amiapp_flutter/android/build.gradle
@@ -2,7 +2,10 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://maven.gist.build' }
+        // For locally deployed builds
+        mavenLocal()
+        // For snapshot builds
+        maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
     }
 }
 

--- a/apps/amiapp_flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/amiapp_flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip

--- a/apps/amiapp_flutter/android/settings.gradle
+++ b/apps/amiapp_flutter/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.2.0" apply false
+    id "com.android.application" version "8.3.1" apply false
     id "org.jetbrains.kotlin.android" version "1.7.21" apply false
     id "com.google.gms.google-services" version "4.3.15" apply false
 }


### PR DESCRIPTION
closes: [MBL-232](https://linear.app/customerio/issue/MBL-232/flutter-sdk-compatibility-with-gradle-8)
blocked by: release of https://github.com/customerio/customerio-android/pull/296

### Highlights

- Support for Android Gradle Plugin 8.0
- JDK Version is updated to `17` from `1.8`

### Changes

- Updated flutter plugin to make it compatible with changes for Android Gradle Plugin 8.0 in native SDK
- Updated sample app to use same gradle plugin version

### Tasks

- [ ] Updated Android SDK version to actual expected value