### PR TITLE
chore: test multiple push event handlers in sample app

### DIFF
--- a/apps/amiapp_flutter/ios/Flutter/AppFrameworkInfo.plist
+++ b/apps/amiapp_flutter/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/apps/amiapp_flutter/ios/Podfile
+++ b/apps/amiapp_flutter/ios/Podfile
@@ -43,9 +43,9 @@ target 'Runner' do
   use_modular_headers!
   
   # Uncomment only 1 of the lines below to install a version of the iOS SDK
-  pod 'CustomerIO/MessagingPushFCM', '~> 2.11' # install production build
+  pod 'CustomerIO/MessagingPushFCM', '~> 2.13' # install production build
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: "fcm")
-  install_non_production_ios_sdk_git_branch(branch_name: 'levi/v2-multiple-push-handlers', is_app_extension: false, push_service: "fcm")
+  # install_non_production_ios_sdk_git_branch(branch_name: 'levi/v2-multiple-push-handlers', is_app_extension: false, push_service: "fcm")
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
@@ -53,9 +53,9 @@ end
 target 'NotificationServiceExtension' do
   use_frameworks!
   # Uncomment only 1 of the lines below to install a version of the iOS SDK
-  pod 'CustomerIO/MessagingPushFCM', '~> 2.11' # install production build
+  pod 'CustomerIO/MessagingPushFCM', '~> 2.13' # install production build
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: true, push_service: "fcm")
-  install_non_production_ios_sdk_git_branch(branch_name: 'levi/v2-multiple-push-handlers', is_app_extension: true, push_service: "fcm")
+  # install_non_production_ios_sdk_git_branch(branch_name: 'levi/v2-multiple-push-handlers', is_app_extension: true, push_service: "fcm")
 end
 
 post_install do |installer|

--- a/apps/amiapp_flutter/ios/Podfile
+++ b/apps/amiapp_flutter/ios/Podfile
@@ -1,7 +1,10 @@
-# Import Ruby functions from native SDK to more easily allow installing non-production SDK builds.
+# ------------- 
+# This code only used internally for Customer.io testing
 require 'open-uri'
-IO.copy_stream(URI.open('https://raw.githubusercontent.com/customerio/customerio-ios/main/scripts/cocoapods_override_sdk.rb'), "/tmp/override_cio_sdk.rb")
+IO.copy_stream(URI.open('https://raw.githubusercontent.com/customerio/customerio-ios/v2/scripts/cocoapods_override_sdk.rb'), "/tmp/override_cio_sdk.rb")
 load "/tmp/override_cio_sdk.rb"
+# end of internal Customer.io testing code
+# ------------- 
 
 # Uncomment this line to define a global platform for your project
 platform :ios, '13.0'
@@ -42,7 +45,7 @@ target 'Runner' do
   # Uncomment only 1 of the lines below to install a version of the iOS SDK
   pod 'CustomerIO/MessagingPushFCM', '~> 2.11' # install production build
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: "fcm")
-  # install_non_production_ios_sdk_git_branch(branch_name: 'name-of-ios-sdk-branch', is_app_extension: false, push_service: "fcm")
+  install_non_production_ios_sdk_git_branch(branch_name: 'levi/v2-multiple-push-handlers', is_app_extension: false, push_service: "fcm")
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
@@ -52,7 +55,7 @@ target 'NotificationServiceExtension' do
   # Uncomment only 1 of the lines below to install a version of the iOS SDK
   pod 'CustomerIO/MessagingPushFCM', '~> 2.11' # install production build
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: true, push_service: "fcm")
-  # install_non_production_ios_sdk_git_branch(branch_name: 'name-of-ios-sdk-branch', is_app_extension: true, push_service: "fcm")
+  install_non_production_ios_sdk_git_branch(branch_name: 'levi/v2-multiple-push-handlers', is_app_extension: true, push_service: "fcm")
 end
 
 post_install do |installer|

--- a/apps/amiapp_flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/amiapp_flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				9A84F275275010D6B13C39B0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -368,6 +369,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		9A84F275275010D6B13C39B0 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		FB05793FCEE3100A134F8366 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/apps/amiapp_flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/amiapp_flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -241,7 +241,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					302D7E30295BEE78005CBB29 = {

--- a/apps/amiapp_flutter/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/apps/amiapp_flutter/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/apps/amiapp_flutter/ios/Runner/AppDelegate.swift
+++ b/apps/amiapp_flutter/ios/Runner/AppDelegate.swift
@@ -27,7 +27,9 @@ import FirebaseCore
         }
         MessagingPushFCM.initialize(configOptions: nil)
         
-        UNUserNotificationCenter.current().delegate = self
+        // Sets a 3rd party push event handler for the app besides the Customer.io SDK and FlutterFire.
+        // Setting the AppDelegate to be the handler will internally use `flutter_local_notifications` to handle the push event.
+        UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
 
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
@@ -39,39 +41,6 @@ import FirebaseCore
     
     override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         MessagingPush.shared.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
-    }
-    
-    // Function called when a push notification is clicked or swiped away.
-    override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        // Track a Customer.io event for testing purposes to more easily track when this function is called.
-        CustomerIO.shared.track(
-            name: "push clicked",
-            data: ["push": [
-                "title": response.notification.request.content.title,
-                "body": response.notification.request.content.body,
-                "userInfo": response.notification.request.content.userInfo
-            ]]
-        )
-
-        completionHandler()
-    }
-    
-    override func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        // Track a Customer.io event for testing purposes to more easily track when this function is called.
-        CustomerIO.shared.track(
-            name: "push should show app in foreground",
-            data: ["push": [
-                    "title": notification.request.content.title,
-                    "body": notification.request.content.body,
-                    "userInfo": notification.request.content.userInfo
-            ]]
-        )
-
-        if #available(iOS 14.0, *) {
-            completionHandler([.banner, .badge, .sound])
-        } else {
-            completionHandler([.alert, .badge, .sound])
-        }
     }
 }
 

--- a/apps/amiapp_flutter/ios/Runner/AppDelegate.swift
+++ b/apps/amiapp_flutter/ios/Runner/AppDelegate.swift
@@ -26,6 +26,8 @@ import FirebaseCore
             config.logLevel = .debug
         }
         MessagingPushFCM.initialize(configOptions: nil)
+        
+        UNUserNotificationCenter.current().delegate = self
 
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
@@ -37,6 +39,39 @@ import FirebaseCore
     
     override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         MessagingPush.shared.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+    }
+    
+    // Function called when a push notification is clicked or swiped away.
+    override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        // Track a Customer.io event for testing purposes to more easily track when this function is called.
+        CustomerIO.shared.track(
+            name: "push clicked",
+            data: ["push": [
+                "title": response.notification.request.content.title,
+                "body": response.notification.request.content.body,
+                "userInfo": response.notification.request.content.userInfo
+            ]]
+        )
+
+        completionHandler()
+    }
+    
+    override func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        // Track a Customer.io event for testing purposes to more easily track when this function is called.
+        CustomerIO.shared.track(
+            name: "push should show app in foreground",
+            data: ["push": [
+                    "title": notification.request.content.title,
+                    "body": notification.request.content.body,
+                    "userInfo": notification.request.content.userInfo
+            ]]
+        )
+
+        if #available(iOS 14.0, *) {
+            completionHandler([.banner, .badge, .sound])
+        } else {
+            completionHandler([.alert, .badge, .sound])
+        }
     }
 }
 

--- a/apps/amiapp_flutter/lib/main.dart
+++ b/apps/amiapp_flutter/lib/main.dart
@@ -1,5 +1,7 @@
+import 'package:customer_io/customer_io.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 import 'src/app.dart';
 import 'src/auth.dart';
@@ -7,6 +9,8 @@ import 'src/auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'firebase_options.dart';
+
+final FlutterLocalNotificationsPlugin localNotificationsPlugin = FlutterLocalNotificationsPlugin();
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -22,6 +26,23 @@ void main() async {
     alert: true,
     badge: true,
     sound: true,
+  );
+
+  // Setup flutter_local_notifications plugin to send local notifications and receive callbacks for them.
+  var initSettingsAndroid = const AndroidInitializationSettings("app_icon");
+  // The default settings will show local push notifications while app in foreground with plugin.
+  var initSettingsIOS = const DarwinInitializationSettings();
+  var initSettings = InitializationSettings(
+    android: initSettingsAndroid,
+    iOS: initSettingsIOS,
+  );
+  await localNotificationsPlugin.initialize(
+    initSettings,
+    onDidReceiveNotificationResponse: (NotificationResponse notificationResponse) async {
+      // Callback from `flutter_local_notifications` plugin for when a local notification is clicked.
+      // Unfortunately, we are only able to get the payload object for the local push, not anything else such as title or body.
+      CustomerIO.track(name: "local push notification clicked", attributes: {"payload": notificationResponse.payload});
+    }
   );
 
   // Load SDK configurations

--- a/apps/amiapp_flutter/lib/src/screens/dashboard.dart
+++ b/apps/amiapp_flutter/lib/src/screens/dashboard.dart
@@ -6,6 +6,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 import '../auth.dart';
 import '../components/container.dart';
@@ -238,7 +239,7 @@ class _ActionList extends StatelessWidget {
                     style: FilledButton.styleFrom(
                       minimumSize: sizes.buttonDefault(),
                     ),
-                    onPressed: () {
+                    onPressed: () async {
                       switch (item) {
                         case _ActionItem.randomEvent:
                           _sendRandomEvent(context);
@@ -248,6 +249,13 @@ class _ActionList extends StatelessWidget {
                           break;
                         case _ActionItem.signOut:
                           authState.signOut();
+                          break;
+                        case _ActionItem.showLocalPush:
+                          const NotificationDetails notificationDetails =
+                          NotificationDetails();
+                          FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+                          FlutterLocalNotificationsPlugin();
+                          await flutterLocalNotificationsPlugin.show(0, 'Show Local Push', 'Show Local Push Button', notificationDetails, payload: 'item x');
                           break;
                         default:
                           final Screen? screen = item.targetScreen();
@@ -276,6 +284,7 @@ enum _ActionItem {
   deviceAttributes,
   profileAttributes,
   showPushPrompt,
+  showLocalPush,
   signOut,
 }
 
@@ -292,6 +301,8 @@ extension _ActionNames on _ActionItem {
         return 'Set Profile Attribute';
       case _ActionItem.showPushPrompt:
         return 'Show Push Prompt';
+      case _ActionItem.showLocalPush:
+        return 'Show local push';
       case _ActionItem.signOut:
         return 'Log Out';
     }
@@ -309,6 +320,8 @@ extension _ActionNames on _ActionItem {
         return 'Profile Attribute Button';
       case _ActionItem.showPushPrompt:
         return 'Show Push Prompt Button';
+      case _ActionItem.showLocalPush:
+        return 'Show Local Push Button';
       case _ActionItem.signOut:
         return 'Log Out Button';
     }
@@ -325,6 +338,8 @@ extension _ActionNames on _ActionItem {
       case _ActionItem.profileAttributes:
         return Screen.profileAttributes;
       case _ActionItem.showPushPrompt:
+        return null;
+      case _ActionItem.showLocalPush:
         return null;
       case _ActionItem.signOut:
         return null;

--- a/apps/amiapp_flutter/pubspec.yaml
+++ b/apps/amiapp_flutter/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   package_info_plus: ^4.0.2
   firebase_core: ^2.24.2
   firebase_messaging: ^14.7.9
+  flutter_local_notifications: ^17.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-383/[bug]-customer-unable-to-handle-push-notification-event-on-ios-with

Tests [this iOS bug fix](https://github.com/customerio/customerio-ios/pull/743) in FCM sample app, while also testing local push notifications in the app. 

This PR: 
- displays local push notifications, which we use for QA testing local push
- adds a push event handler for local push in `AppDelegate`. 

After this PR, the FCM sample app will have 3 push event handlers: CIO SDK, flutterfire, and the host iOS app (AppDelegate). This environment allows us to test the iOS bug that is caused when there are at least 2 push event handlers installed in an app. 

Testing:
* Local push QA regression tests. 
* Non-CIO FCM push QA regression tests (send a FCM push from Firebase console instead of Fly). 
For all QA tests, we expect that both flutterfire and the host app are able to handle the push events. 
