### PR TITLE
fix: send native to flutter messages on main thread

### DIFF
--- a/ios/Classes/SwiftCustomerIoPlugin.swift
+++ b/ios/Classes/SwiftCustomerIoPlugin.swift
@@ -185,14 +185,18 @@ public class SwiftCustomerIoPlugin: NSObject, FlutterPlugin {
         DispatchQueue.main.async {
             MessagingInApp.shared.initialize(eventListener: CustomerIOInAppEventListener(
                 invokeMethod: {method,args in
-                    self.invokeMethodInBackground(method, args)
+                    self.invokeMethod(method, args)
                 })
             )
         }
     }
     
-    func invokeMethodInBackground(_ method: String, _ args: Any?) {
-        DispatchQueue.global(qos: .background).async {
+    func invokeMethod(_ method: String, _ args: Any?) {
+        // When sending messages from native code to Flutter, it's required to do it on main thread.
+        // Learn more:
+        // * https://docs.flutter.dev/platform-integration/platform-channels#channels-and-platform-threading
+        // * https://linear.app/customerio/issue/MBL-358/
+        DispatchQueue.main.async {
             self.methodChannel.invokeMethod(method, arguments: args)
         }
     }


### PR DESCRIPTION
Ticket: https://linear.app/customerio/issue/MBL-358/

When the native iOS in-app module communicates with the Flutter SDK, it currently does so on the native background thread. According to [flutter docs](https://docs.flutter.dev/platform-integration/platform-channels#channels-and-platform-threading), it should be the main thread. 

# Testing 

* In Flutter sample app, do things that would make the in-app global event listener to trigger. Before this bug fix, you should see error show up in Xcode console. After the bug fix, you should no longer see the error. 
* I searched the Flutter source code where everywhere that `invokeMethodInBackground` is called to see if there were any other places where we could be having native code communicate to Flutter SDK and I only found the 1 place that I modified. 