### PR TITLE
chore: wrap unit calls with boolean result

### DIFF
--- a/android/src/main/kotlin/io/customer/customer_io/CustomerIOExtensions.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/CustomerIOExtensions.kt
@@ -26,7 +26,12 @@ internal fun <R> MethodCall.invokeNative(
     try {
         @Suppress("UNCHECKED_CAST")
         val params = this.arguments as? Map<String, Any> ?: emptyMap()
-        result.success(performAction(params))
+        val actionResult = performAction(params)
+        if (actionResult is Unit) {
+            result.success(true)
+        } else {
+            result.success(actionResult)
+        }
     } catch (ex: Exception) {
         result.error(this.method, ex.localizedMessage, ex)
     }


### PR DESCRIPTION
fixes: #141 
part of [MBL-494](https://linear.app/customerio/issue/MBL-494/button-with-dismiss-behavior-do-not-close-in-app-message-on-some)

### Changes

- Return `boolean` value for unit calls as native calls must return some value