### PR TITLE
chore: fix ios native sdk version

### DIFF
--- a/apps/amiapp_flutter/ios/Podfile
+++ b/apps/amiapp_flutter/ios/Podfile
@@ -43,7 +43,7 @@ target 'Runner' do
   use_modular_headers!
   
   # Uncomment only 1 of the lines below to install a version of the iOS SDK
-  pod 'CustomerIO/MessagingPushFCM', '~> 3.5' # install production build
+  pod 'customer_io/fcm', :path => '.symlinks/plugins/customer_io/ios' # install podspec bundled with the plugin
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: "fcm")
   # install_non_production_ios_sdk_git_branch(branch_name: 'levi/v2-multiple-push-handlers', is_app_extension: false, push_service: "fcm")
 
@@ -52,8 +52,9 @@ end
 
 target 'NotificationServiceExtension' do
   use_frameworks!
-  # Uncomment only 1 of the lines below to install a version of the iOS SDK
-  pod 'CustomerIO/MessagingPushFCM', '~> 3.5' # install production build
+  # Ideally, installing non-production SDK to main target should be enough
+  # We may not need to install non-production SDK to app extension separately
+  pod 'customer_io_richpush/fcm', :path => '.symlinks/plugins/customer_io/ios' # install podspec bundled with the plugin
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: true, push_service: "fcm")
   # install_non_production_ios_sdk_git_branch(branch_name: 'levi/v2-multiple-push-handlers', is_app_extension: true, push_service: "fcm")
 end

--- a/ios/customer_io.podspec
+++ b/ios/customer_io.podspec
@@ -5,6 +5,8 @@
 require 'yaml'
 
 podspec_config = YAML.load_file('../pubspec.yaml')
+# The native_sdk_version is the version of iOS native SDK that the Flutter plugin is compatible with.
+native_sdk_version = podspec_config['flutter']['plugin']['platforms']['ios']['native_sdk_version']
 
 Pod::Spec.new do |s|
   s.name        = podspec_config['name']
@@ -17,8 +19,26 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'
-  s.dependency "CustomerIO/DataPipelines", '~> 3'
-  s.dependency "CustomerIO/MessagingInApp", '~> 3'
+
+  # Native SDK dependencies that are required for the Flutter plugin to work.
+  s.dependency "CustomerIO/DataPipelines", native_sdk_version
+  s.dependency "CustomerIO/MessagingInApp", native_sdk_version
+
+  # If we do not specify a default_subspec, then *all* dependencies inside of *all* the subspecs will be downloaded by cocoapods.
+  # We want customers to opt into push dependencies especially because the FCM subpsec downloads Firebase dependencies.
+  # APN customers should not install Firebase dependencies at all.
+  s.default_subspec = "nopush"
+
+  s.subspec 'nopush' do |ss|
+    # This is the default subspec designed to not install any push dependencies. Customer should choose APN or FCM.
+    # The SDK at runtime currently requires the MessagingPush module so we do include it here.
+    ss.dependency "CustomerIO/MessagingPush", native_sdk_version
+  end
+
+  # Note: Subspecs inherit all dependencies specified the parent spec (this file).
+  s.subspec 'fcm' do |ss|
+    ss.dependency "CustomerIO/MessagingPushFCM", native_sdk_version
+  end
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/customer_io_richpush.podspec
+++ b/ios/customer_io_richpush.podspec
@@ -1,0 +1,37 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+# Run `pod lib lint customer_io_richpush.podspec` to validate before publishing.
+#
+require 'yaml'
+
+podspec_config = YAML.load_file('../pubspec.yaml')
+# The native_sdk_version is the version of iOS native SDK that the Flutter plugin is compatible with.
+native_sdk_version = podspec_config['flutter']['plugin']['platforms']['ios']['native_sdk_version']
+
+# Used by customers to install native iOS dependencies inside their Notification Service Extension (NSE) target to setup rich push.
+# Note: We need a unique podspec for rich push because the other podspecs in this project install too many dependencies that should not be installed inside of a NSE target.
+# We need this podspec which installs minimal dependencies that are only included in the NSE target.
+Pod::Spec.new do |s|
+  s.name        = "customer_io_richpush"
+  s.version     = podspec_config['version']
+  s.summary     = podspec_config['description']
+  s.homepage    = podspec_config['homepage']
+  s.license     = { :file => '../LICENSE' }
+  s.author      = { "CustomerIO Team" => "win@customer.io" }
+  s.source      = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.dependency 'Flutter'
+  s.platform = :ios, '13.0'
+
+  # Careful when declaring dependencies here. All dependencies will be included in the App Extension target in Xcode, not the host iOS app.
+  # s.dependency "X", "X"
+
+  # Subspecs allow customers to choose between multiple options of what type of version of this rich push package they would like to install.
+  s.subspec 'fcm' do |ss|
+    ss.dependency "CustomerIO/MessagingPushFCM", native_sdk_version
+  end
+
+  # Flutter.framework does not contain a i386 slice.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.swift_version = '5.0'
+end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,3 +42,4 @@ flutter:
         pluginClass: CustomerIoPlugin
       ios:
         pluginClass: CustomerIoPlugin
+        native_sdk_version: 3.5.1


### PR DESCRIPTION
closes [MBL-622](https://linear.app/customerio/issue/MBL-622/fix-ios-native-sdk-version-in-flutter-sdk)

### Changes

- Added `native_sdk_version` in `pubspec.yaml` to specify iOS SDK version
- Updated `customer_io.podspec` to reference `native_sdk_version` from `pubspec.yaml`
- Modified `customer_io.podspec` to include FCM as a subspec for customer Podfile reference
- Created `customer_io_richpush.podspec` using `native_sdk_version`, with FCM as subspec for NSE reference in customer Podfile
- Updated sample app's Podfile


### Customer App Podfile

#### Before Changes

```
target 'Runner' do
  pod 'CustomerIO/MessagingPushFCM', '~> 3.5.1'
end

target 'NotificationServiceExtension' do
  pod 'CustomerIO/MessagingPushFCM', '~> 3.5.1'
end
```

#### After Changes

```
target 'Runner' do
  pod 'customer_io/fcm', :path => '.symlinks/plugins/customer_io/ios'
end

target 'NotificationServiceExtension' do
  pod 'customer_io_richpush/fcm', :path => '.symlinks/plugins/customer_io/ios'
end
```