### PR TITLE
chore: update Fastfile to publish to new distribution groups

### DIFF
--- a/apps/fastlane/helpers/build_helper.rb
+++ b/apps/fastlane/helpers/build_helper.rb
@@ -116,13 +116,15 @@ lane :get_build_notes do
 end
 
 lane :get_build_test_groups do
-  test_groups = ['all-builds'] # send all builds to group 'all-builds'. Therefore, set it here and we will not remove it.
+  test_groups = ['all-builds', 'feature-branch'] # send all builds to group 'all-builds'. Therefore, set it here and we will not remove it.
   github = GitHub.new()
 
   # To avoid giving potentially unstable builds of our sample apps to certain members of the organization, we only send builds to "stable" group uncertain certain situations.
   # If a commit is merged into main, it's considered stable because we deploy to production on merges to main.
   if github.is_commit_pushed && github.push_branch == "main"
     test_groups.append("stable-builds")
+    test_groups.append("next")
+    test_groups.append("public") # Temporarily push to public group as well until we have new job to actually build from the released version
   end
 
   test_groups = test_groups.join(", ")


### PR DESCRIPTION
This PR adds the Firebase Distribution groups for 'feature-branch', 'next', and 'public' in addition to the current 'all-builds' and 'stable-builds' groups.