### PR TITLE
ci: ensure task fails if any build fails

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -132,6 +132,7 @@ jobs:
         uses: customerio/customerio-android/.github/actions/setup-android@main
 
       - name: Build and upload Android app via Fastlane
+        id: android_build
         uses: maierj/fastlane-action@v3.1.0
         with:
           subdirectory: apps/${{ matrix.sample-app }}
@@ -157,6 +158,7 @@ jobs:
         run: pod install --project-directory=ios
 
       - name: Build and upload iOS app via Fastlane
+        id: ios_build
         uses: maierj/fastlane-action@v3.1.0
         with:
           subdirectory: apps/${{ matrix.sample-app }}
@@ -164,6 +166,13 @@ jobs:
         env:
           GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
+
+      - name: Check build statuses and mark failure
+        run: |
+          if [ "${{ steps.android_build.outcome }}" != "success" ] || [ "${{ steps.ios_build.outcome }}" != "success" ]; then
+            echo "One or more builds failed."
+            exit 1
+          fi
 
       - name: Update sample builds PR comment with build information
         if: ${{ github.event_name == 'pull_request' }}

--- a/apps/fastlane/helpers/version_helper.rb
+++ b/apps/fastlane/helpers/version_helper.rb
@@ -13,14 +13,30 @@ lane :generate_new_version do |options|
 
   # Replace '/' with '-' to avoid issues with unsupported characters in version name
   branch_name = branch_name.gsub('/', '-')
-  timestamp = current_time.strftime("%Y%m%d.%H%M%S")
+  # Extract ticket number from branch name
+  ticket_number_in_branch_name = branch_name.scan(/\d+/).join
+  # If no ticket number found, set it to 0
+  ticket_number_in_branch_name = ticket_number_in_branch_name.empty? ? "0" : ticket_number_in_branch_name
 
-  sdk_version_name = "#{timestamp}.0-#{branch_name}"
+  # Format the components individually and remove leading zeros
+  year = current_time.year.to_s
+  month = current_time.month.to_s
+  day = current_time.day.to_s
+  hour = current_time.hour.to_s
+  minute = current_time.min.to_s
+  second = current_time.sec.to_s
+
+  # Combine them into the desired format
+  major = "#{year}#{month}#{day}"
+  minor = "#{hour}#{minute}#{second}"
+  patch = ticket_number_in_branch_name.to_s
+
+  sdk_version_name = "#{major}.#{minor}.#{patch}"
 
   if github.is_pull_request
     app_version_name = "#{github.pr_number}.#{github.pr_commits}.0"
   else
-    app_version_name = sdk_version_name
+    app_version_name = "#{sdk_version_name}-#{branch_name}"
   end
   app_version_code = (current_time.to_f / 60).to_i
 


### PR DESCRIPTION
### Changes

- Modified build sample apps task to fail if either Android or iOS build fails
- Updated `version_helper.rb` to align with React Native and prevent failure when time starts with `0`

### Notes

- Created PR as I observed an issue in Data Pipelines support changes where tasks didn't fail on individual build failures, leading to false positives.
- Once merged to `main`, I'll merge this change to the Data Pipelines feature branch.