### PR TITLE
chore: configure ios user agent client source

### DIFF
--- a/ios/Classes/Bridge/SdkClientConfiguration.swift
+++ b/ios/Classes/Bridge/SdkClientConfiguration.swift
@@ -8,7 +8,8 @@ extension SdkClient {
     
     /// Configures and overrides the shared `SdkClient` instance with provided parameters.
     ///
-    /// - Parameter args: Dictionary containing values required for `SdkClient` protocol.
+    /// - Parameters:
+    ///  - using: Dictionary containing values required for `SdkClient` protocol.
     /// - Returns: Configured `SdkClient` instance. Returns the existing shared client if required parameters are missing.
     @available(iOSApplicationExtension, unavailable)
     @discardableResult

--- a/ios/Classes/Bridge/SdkClientConfiguration.swift
+++ b/ios/Classes/Bridge/SdkClientConfiguration.swift
@@ -1,0 +1,28 @@
+import CioInternalCommon
+
+/// Extension on `SdkClient` to provide configuration functionality.
+///
+/// **Note**: Due to Swift limitations with static methods in protocol extensions, static functions
+/// in this extension should be called using `CustomerIOSdkClient.` to ensure correct behavior.
+extension SdkClient {
+    
+    /// Configures and overrides the shared `SdkClient` instance with provided parameters.
+    ///
+    /// - Parameter args: Dictionary containing values required for `SdkClient` protocol.
+    /// - Returns: Configured `SdkClient` instance. Returns the existing shared client if required parameters are missing.
+    @available(iOSApplicationExtension, unavailable)
+    @discardableResult
+    static func configure(using args: [String: Any?]) -> SdkClient {
+        guard let source = args["source"] as? String,
+              let version = args["version"] as? String
+        else {
+            DIGraphShared.shared.logger.error("Missing required parameters for SdkClient configuration in args: \(args)")
+            return DIGraphShared.shared.sdkClient
+        }
+
+        let client = CustomerIOSdkClient(source: source, sdkVersion: version)
+        DIGraphShared.shared.override(value: client, forType: SdkClient.self)
+        
+        return DIGraphShared.shared.sdkClient
+    }
+}

--- a/ios/Classes/SwiftCustomerIoPlugin.swift
+++ b/ios/Classes/SwiftCustomerIoPlugin.swift
@@ -168,6 +168,9 @@ public class SwiftCustomerIoPlugin: NSObject, FlutterPlugin {
     
     private func initialize(params : Dictionary<String, AnyHashable>){
         do {
+            // Configure and override SdkClient for Flutter before initializing native SDK
+            CustomerIOSdkClient.configure(using: params)
+            // Initialize native SDK with provided config
             let sdkConfigBuilder = try SDKConfigBuilder.create(from: params)
             CustomerIO.initialize(withConfig: sdkConfigBuilder.build())
             


### PR DESCRIPTION
part of [MBL-635](https://linear.app/customerio/issue/MBL-635/user-agents)

### Changes

- Added `SdkClientConfiguration.swift` to configure and override `SdkClient`
- Overrode `SdkClient` before initializing native iOS SDK, enabling native iOS to use this configuration for creating the user agent

### User Agent

#### Before Changes

```
Customer.io iOS Client/3.5.1 (arm64; iOS 18.0) io.customer.amiapp.flutter/1.0.0
```

#### After Changes

```
Customer.io Flutter Client/1.5.2 (arm64; iOS 18.0) io.customer.amiapp.flutter/1.0.0
```