### PR TITLE
chore: register device token

### DIFF
--- a/android/src/main/kotlin/io/customer/customer_io/CustomerIoPlugin.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/CustomerIoPlugin.kt
@@ -184,11 +184,10 @@ class CustomerIoPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     private fun registerDeviceToken(params: Map<String, Any>) {
-        // TODO: Fix registerDeviceToken implementation
-        /*
-        val token = params.getString(Keys.Tracking.TOKEN)
+        val token = requireNotNull(params.getAsTypeOrNull<String>(Keys.Tracking.TOKEN)) {
+            "Device token is missing in params: $params"
+        }
         CustomerIO.instance().registerDeviceToken(token)
-         */
     }
 
     private fun trackMetric(params: Map<String, Any>) {

--- a/ios/Classes/SwiftCustomerIoPlugin.swift
+++ b/ios/Classes/SwiftCustomerIoPlugin.swift
@@ -133,20 +133,22 @@ public class SwiftCustomerIoPlugin: NSObject, FlutterPlugin {
     
     private func setProfileAttributes(params : Dictionary<String, AnyHashable>){
         guard let attributes = params[Keys.Tracking.traits] as? Dictionary<String, AnyHashable>
-        else { return }
+        else {
+            logger.error("Missing attributes in: \(params) for key: \(Keys.Tracking.traits)")
+            return
+        }
+        
         CustomerIO.shared.profileAttributes = attributes
     }
     
     private func registerDeviceToken(params : Dictionary<String, AnyHashable>){
-        // TODO: Fix registerDeviceToken implementation
-        /*
-         guard let token = params[Keys.Tracking.token] as? String
-         else {
-         return
-         }
-         
-         CustomerIO.shared.registerDeviceToken(token)
-         */
+        guard let token = params[Keys.Tracking.token] as? String
+        else {
+            logger.error("Missing token in: \(params) for key: \(Keys.Tracking.token)")
+            return
+        }
+        
+        CustomerIO.shared.registerDeviceToken(token)
     }
     
     private func trackMetric(params : Dictionary<String, AnyHashable>){

--- a/test/customer_io_test.dart
+++ b/test/customer_io_test.dart
@@ -136,6 +136,12 @@ void main() {
             .called(1);
       });
 
+      test('registerDeviceToken() calls platform', () {
+        const token = 'abc';
+        CustomerIO.instance.registerDeviceToken(deviceToken: token);
+        verify(mockPlatform.registerDeviceToken(deviceToken: token)).called(1);
+      });
+
       test('track() correct arguments are passed', () {
         const name = 'itemAddedToCart';
         final givenAttributes = {'name': 'John Doe'};


### PR DESCRIPTION
closes: [MBL-638: Register Device](https://linear.app/customerio/issue/MBL-638/register-device)

changes:
- added support for register device token manually 

```
CustomerIO.instance.registerDeviceToken(deviceToken: token);
```