### PR TITLE
chore: initialize messaging push module

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -117,8 +117,7 @@ jobs:
       - name: Setup workspace credentials in iOS environment files
         run: |
           cp "ios/Env.swift.example" "ios/Env.swift"
-          sd 'siteId: String = ".*"' "siteId: String = \"${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_SITE_ID', matrix.sample-app)] }}\"" "ios/Env.swift"
-          sd 'apiKey: String = ".*"' "apiKey: String = \"${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_API_KEY', matrix.sample-app)] }}\"" "ios/Env.swift"
+          sd 'cdpApiKey: String = ".*"' "cdpApiKey: String = \"${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_CDP_API_KEY', matrix.sample-app)] }}\"" "ios/Env.swift"
 
       # Make sure to fetch dependencies only after updating the version numbers and workspace credentials
 

--- a/apps/amiapp_flutter/ios/Env.swift.example
+++ b/apps/amiapp_flutter/ios/Env.swift.example
@@ -1,6 +1,5 @@
 import Foundation
 
 class Env {
-    static let siteId: String = "siteid"
-    static let apiKey: String = "apikey"
+    static let cdpApiKey: String = "cdpApiKey"
 }

--- a/apps/amiapp_flutter/ios/NotificationServiceExtension/NotificationService.swift
+++ b/apps/amiapp_flutter/ios/NotificationServiceExtension/NotificationService.swift
@@ -13,13 +13,11 @@ class NotificationService: UNNotificationServiceExtension {
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
         print("NotificationService didReceive called")
 
-        // TODO: Fix SDK initialization
-        /*
-        CustomerIO.initialize(siteId: Env.siteId, apiKey: Env.apiKey, region: .US) { config in
-            config.autoTrackDeviceAttributes = true
-            config.logLevel = .debug
-        }
-         */
+        MessagingPushFCM.initializeForExtension(
+            withConfig: MessagingPushConfigBuilder(cdpApiKey: Env.cdpApiKey)
+                .logLevel(.debug)
+                .build()
+        )
         
         MessagingPush.shared.didReceive(request, withContentHandler: contentHandler)
     }

--- a/apps/amiapp_flutter/ios/Runner/AppDelegate.swift
+++ b/apps/amiapp_flutter/ios/Runner/AppDelegate.swift
@@ -20,10 +20,10 @@ import FirebaseCore
 
         Messaging.messaging().delegate = self
         
-        // TODO: Fix MessagingPush initialization
-        /*
-        MessagingPushFCM.initialize(configOptions: nil)
-         */
+        MessagingPushFCM.initialize(
+            withConfig: MessagingPushConfigBuilder()
+                .build()
+        )
         
         // Sets a 3rd party push event handler for the app besides the Customer.io SDK and FlutterFire.
         // Setting the AppDelegate to be the handler will internally use `flutter_local_notifications` to handle the push event.

--- a/apps/amiapp_flutter/lib/main.dart
+++ b/apps/amiapp_flutter/lib/main.dart
@@ -31,7 +31,11 @@ void main() async {
   // Setup flutter_local_notifications plugin to send local notifications and receive callbacks for them.
   var initSettingsAndroid = const AndroidInitializationSettings("app_icon");
   // The default settings will show local push notifications while app in foreground with plugin.
-  var initSettingsIOS = const DarwinInitializationSettings();
+  var initSettingsIOS = const DarwinInitializationSettings(
+    requestAlertPermission: false,
+    requestBadgePermission: false,
+    requestSoundPermission: false,
+  );
   var initSettings = InitializationSettings(
     android: initSettingsAndroid,
     iOS: initSettingsIOS,

--- a/apps/amiapp_flutter/lib/src/screens/settings.dart
+++ b/apps/amiapp_flutter/lib/src/screens/settings.dart
@@ -50,7 +50,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   void initState() {
-    CustomerIO.instance.pushMessaging.getRegisteredDeviceToken().then((value) =>
+    CustomerIO.pushMessaging.getRegisteredDeviceToken().then((value) =>
         setState(() => _deviceTokenValueController.text = value ?? ''));
 
     final cioConfig = widget._customerIOSDK.sdkConfig;

--- a/lib/customer_io.dart
+++ b/lib/customer_io.dart
@@ -61,7 +61,15 @@ class CustomerIO {
   }
 
   /// Access push messaging functionality
-  CustomerIOMessagingPushPlatform get pushMessaging => _pushMessaging;
+  static CustomerIOMessagingPushPlatform get pushMessaging {
+    if (_instance == null) {
+      throw StateError(
+        'CustomerIO SDK must be initialized before accessing push module.\n'
+            'Call CustomerIO.initialize() first.',
+      );
+    }
+    return _instance!._pushMessaging;
+  }
 
   /// Access in-app messaging functionality
   CustomerIOMessagingInAppPlatform get inAppMessaging => _inAppMessaging;


### PR DESCRIPTION
part of: [MBL-662](https://linear.app/customerio/issue/MBL-662/initialize-push-module-in-flutter-sdk)

### Changes

- Updated `pushMessaging` to static property, allowing customers to access it without using `instance`
- Initialized `MessagingPush` module in `AppDelegate` and NSE
- Disabled push permission request on iOS app launch to align with Flutter Android and other platforms
- Updated build sample apps workflow to configure `CdpApiKey` in iOS `Env` file and updated example iOS `Env` file

### API Update

#### Before

```dart
CustomerIO.instance.pushMessaging.getRegisteredDeviceToken()
```

#### After

```dart
CustomerIO.pushMessaging.getRegisteredDeviceToken()
```