### PR TITLE
chore: rename android classes and method extensions

### DIFF
--- a/android/src/main/kotlin/io/customer/customer_io/CustomerIOExtensions.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/CustomerIOExtensions.kt
@@ -4,17 +4,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
 /**
- * Returns the value corresponding to the given key after casting to the generic type provided, or
- * null if such key is not present in the map or value cannot be casted to the given type.
- */
-internal inline fun <reified T> Map<String, Any>.getAsTypeOrNull(key: String): T? {
-    if (containsKey(key)) {
-        return get(key) as? T
-    }
-    return null
-}
-
-/**
  * Invokes lambda method that can be used to call matching native method conveniently. The lambda
  * expression receives function parameters as arguments and should return the desired result. Any
  * exception in the lambda will cause the invoked method to fail with error.

--- a/android/src/main/kotlin/io/customer/customer_io/bridge/NativeModuleBridge.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/bridge/NativeModuleBridge.kt
@@ -1,4 +1,4 @@
-package io.customer.customer_io
+package io.customer.customer_io.bridge
 
 import io.customer.sdk.CustomerIOBuilder
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -11,7 +11,7 @@ import io.flutter.plugin.common.MethodChannel
  * should be treated as module in Flutter SDK and should be used to hold all relevant methods at
  * single place.
  */
-internal interface CustomerIOPluginModule : MethodChannel.MethodCallHandler, ActivityAware {
+internal interface NativeModuleBridge : MethodChannel.MethodCallHandler, ActivityAware {
     /**
      * Unique name of module to identify between other modules
      */

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/CustomerIOInAppMessaging.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/CustomerIOInAppMessaging.kt
@@ -1,10 +1,10 @@
 package io.customer.customer_io.messaginginapp
 
 import android.app.Activity
-import io.customer.customer_io.CustomerIOPluginModule
+import io.customer.customer_io.bridge.NativeModuleBridge
 import io.customer.customer_io.constant.Keys
-import io.customer.customer_io.getAsTypeOrNull
 import io.customer.customer_io.invokeNative
+import io.customer.customer_io.utils.getAs
 import io.customer.messaginginapp.MessagingInAppModuleConfig
 import io.customer.messaginginapp.ModuleMessagingInApp
 import io.customer.messaginginapp.di.inAppMessaging
@@ -27,7 +27,7 @@ import java.lang.ref.WeakReference
  */
 internal class CustomerIOInAppMessaging(
     pluginBinding: FlutterPlugin.FlutterPluginBinding,
-) : CustomerIOPluginModule, MethodChannel.MethodCallHandler, ActivityAware {
+) : NativeModuleBridge, MethodChannel.MethodCallHandler, ActivityAware {
     override val moduleName: String = "InAppMessaging"
     override val flutterCommunicationChannel: MethodChannel =
         MethodChannel(pluginBinding.binaryMessenger, "customer_io_messaging_in_app")
@@ -74,8 +74,8 @@ internal class CustomerIOInAppMessaging(
         builder: CustomerIOBuilder,
         config: Map<String, Any>
     ) {
-        val siteId = config.getAsTypeOrNull<String>("siteId")
-        val regionRawValue = config.getAsTypeOrNull<String>("region")
+        val siteId = config.getAs<String>("siteId")
+        val regionRawValue = config.getAs<String>("region")
         val givenRegion = regionRawValue.let { Region.getRegion(it) }
 
         if (siteId.isNullOrBlank()) {

--- a/android/src/main/kotlin/io/customer/customer_io/messagingpush/PushMessagingExtensions.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messagingpush/PushMessagingExtensions.kt
@@ -1,7 +1,7 @@
 package io.customer.customer_io.messagingpush
 
 import com.google.firebase.messaging.RemoteMessage
-import io.customer.customer_io.getAsTypeOrNull
+import io.customer.customer_io.utils.getAs
 
 /**
  * Safely transforms any value to string
@@ -23,8 +23,8 @@ private fun Any.toStringOrNull(): String? = try {
  * string for it.
  */
 internal fun Map<String, Any>.toFCMRemoteMessage(destination: String): RemoteMessage {
-    val notification = getAsTypeOrNull<Map<String, Any>>("notification")
-    val data = getAsTypeOrNull<Map<String, Any>>("data")
+    val notification = getAs<Map<String, Any>>("notification")
+    val data = getAs<Map<String, Any>>("data")
     val messageParams = buildMap {
         notification?.let { result -> putAll(result) }
         // Adding `data` after `notification` so `data` params take more value as we mainly use
@@ -42,10 +42,10 @@ internal fun Map<String, Any>.toFCMRemoteMessage(destination: String): RemoteMes
                 value.toStringOrNull()?.let { v -> addData(key, v) }
             }
         }
-        getAsTypeOrNull<String>("messageId")?.let { id -> setMessageId(id) }
-        getAsTypeOrNull<String>("messageType")?.let { type -> setMessageType(type) }
-        getAsTypeOrNull<String>("collapseKey")?.let { key -> setCollapseKey(key) }
-        getAsTypeOrNull<Int>("ttl")?.let { time -> ttl = time }
+        getAs<String>("messageId")?.let { id -> setMessageId(id) }
+        getAs<String>("messageType")?.let { type -> setMessageType(type) }
+        getAs<String>("collapseKey")?.let { key -> setCollapseKey(key) }
+        getAs<Int>("ttl")?.let { time -> ttl = time }
         return@with build()
     }
 }

--- a/android/src/main/kotlin/io/customer/customer_io/utils/MapExtensions.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/utils/MapExtensions.kt
@@ -1,0 +1,12 @@
+package io.customer.customer_io.utils
+
+/**
+ * Returns the value corresponding to the given key after casting to the generic type provided, or
+ * null if such key is not present in the map or value cannot be casted to the given type.
+ */
+internal inline fun <reified T> Map<String, Any>.getAs(key: String): T? {
+    if (containsKey(key)) {
+        return get(key) as? T
+    }
+    return null
+}

--- a/android/src/main/kotlin/io/customer/customer_io/utils/StringExtensions.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/utils/StringExtensions.kt
@@ -1,0 +1,6 @@
+package io.customer.customer_io.utils
+
+/**
+ * Extension function to return the string if it is not null or blank.
+ */
+internal fun String?.takeIfNotBlank(): String? = takeIf { !it.isNullOrBlank() }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ flutter:
     platforms:
       android:
         package: io.customer.customer_io
-        pluginClass: CustomerIoPlugin
+        pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIoPlugin
         native_sdk_version: 3.5.1


### PR DESCRIPTION
part of: [MBL-657](https://linear.app/customerio/issue/MBL-657/refactor-and-clean-up-android-code-in-flutter-sdk)

### Changes

- Moved extensions to dedicated files for better organization
- Renamed `getAsTypeOrNull` to `getAs` for simplicity while retaining functionality
- Renamed `CustomerIoPlugin` to `CustomerIOPlugin` to align with naming conventions
- Renamed `CustomerIOPluginModule` to `NativeModuleBridge` for clarity, as it's an internal class and `CustomerIO` prefix looked redundant