### PR TITLE
chore: update sample app name

### DIFF
--- a/apps/amiapp_flutter/android/app/src/main/AndroidManifest.xml
+++ b/apps/amiapp_flutter/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <application
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:label="Flutter Sample">
+        android:label="Flutter">
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/apps/amiapp_flutter/ios/Runner/Info.plist
+++ b/apps/amiapp_flutter/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Flutter Sample</string>
+	<string>Flutter</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/apps/amiapp_flutter/lib/src/screens/login.dart
+++ b/apps/amiapp_flutter/lib/src/screens/login.dart
@@ -67,7 +67,7 @@ class _LoginScreenState extends State<LoginScreen> {
               padding: const EdgeInsets.symmetric(vertical: 32.0),
               child: Center(
                 child: Text(
-                  'Flutter FCM Ami App',
+                  'Flutter (FCM)',
                   style: Theme.of(context).textTheme.titleLarge,
                 ),
               ),

--- a/apps/amiapp_flutter/pubspec.lock
+++ b/apps/amiapp_flutter/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.0"
   dbus:
     dependency: transitive
     description:


### PR DESCRIPTION
part of: [MBL-742](https://linear.app/customerio/issue/MBL-742/has-easy-to-understand-app-name)

### Changes

- Renamed app from `Flutter Sample` to `Flutter`
- Updated app name on the Login Screen for consistency
- Lock file updates

Please refer to linked ticket for more details about these changes.

### Screenshots  

**Launcher**

_iOS_

![Simulator Screenshot - iPhone 16 - Flutter](https://github.com/user-attachments/assets/4968fb41-e25d-4f68-86e8-8466b30107f5)

_Android_

![Screenshot_20250107_142901-crop](https://github.com/user-attachments/assets/b4cecac1-3eba-46a6-be3b-01e759e3b125)

**Login Screen**

![Simulator Screenshot - iPhone 16 - 2025-01-07 at 13 55 12](https://github.com/user-attachments/assets/a1497cb4-cba2-4275-affd-4d5b4cfde49f)