### PR TITLE
chore: update sample app groups

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -66,21 +66,23 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set Default Firebase Distribution Groups
+        shell: bash
+        env:
+          # Distribution group constants
+          ALL_BUILDS_GROUP: all-builds
+          FEATURE_BUILDS_GROUP: feature-branch
+          NEXT_BUILDS_GROUP: next
+          PUBLIC_BUILDS_GROUP: public
+          # Input variables
+          CURRENT_BRANCH: ${{ github.ref }}
         run: |
-          # Define all the possible distribution groups
-          ALL_BUILDS_GROUP="all-builds"
-          FEATURE_BUILDS_GROUP="feature-branch"
-          STABLE_BUILDS_GROUP="next"
-          
           # Initialize with the default distribution group
           distribution_groups=("$ALL_BUILDS_GROUP")
           
-          # Determine current app type and Git context
-          current_branch="${GITHUB_REF}"
-          
           # Append distribution groups based on branch and context
-          [[ "$current_branch" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
-          [[ "$current_branch" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
+          [[ "$CURRENT_BRANCH" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+          [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("NEXT_BUILDS_GROUP")
+          [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("PUBLIC_BUILDS_GROUP")
           
           # Export the groups as an environment variable
           echo "firebase_distribution_groups=$(IFS=','; echo "${distribution_groups[*]}")" >> $GITHUB_ENV

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -65,6 +65,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set Default Firebase Distribution Groups
+        run: |
+          # Define all the possible distribution groups
+          ALL_BUILDS_GROUP="all-builds"
+          FEATURE_BUILDS_GROUP="feature-branch"
+          STABLE_BUILDS_GROUP="next"
+          
+          # Initialize with the default distribution group
+          distribution_groups=("$ALL_BUILDS_GROUP")
+          
+          # Determine current app type and Git context
+          current_branch="${GITHUB_REF}"
+          
+          # Append distribution groups based on branch and context
+          [[ "$current_branch" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+          [[ "$current_branch" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
+          
+          # Export the groups as an environment variable
+          echo "firebase_distribution_groups=$(IFS=','; echo "${distribution_groups[*]}")" >> $GITHUB_ENV
+
       # Install CLI tools, Ruby, and Ruby dependencies for Fastlane
 
       - name: Install CLI tools used in CI script
@@ -136,6 +156,7 @@ jobs:
         with:
           subdirectory: apps/${{ matrix.sample-app }}
           lane: 'android build'
+          options: '{"distribution_groups": "${{ env.firebase_distribution_groups }}"}'
         env:
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
         continue-on-error: true # continue to build iOS app even if Android build fails
@@ -162,6 +183,7 @@ jobs:
         with:
           subdirectory: apps/${{ matrix.sample-app }}
           lane: "ios build"
+          options: '{"distribution_groups": "${{ env.firebase_distribution_groups }}"}'
         env:
           GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}

--- a/apps/fastlane/helpers/build_helper.rb
+++ b/apps/fastlane/helpers/build_helper.rb
@@ -5,7 +5,7 @@ require_relative 'github_helper.rb'
 platform :android do
   lane :build do |values|
     build_notes = get_build_notes()
-    test_groups = get_build_test_groups()
+    test_groups = get_build_test_groups(distribution_groups: values[:distribution_groups])
     app_package_name = CredentialsManager::AppfileConfig.try_fetch_value(:package_name) # get package_name from Appfile
 
     # Firebase app id is required. Fetch it from google-services.json file using app_package_name
@@ -75,7 +75,7 @@ platform :ios do
 
       firebase_app_distribution(
         service_credentials_file: service_credentials_file_path,
-        groups: get_build_test_groups(),
+        groups: get_build_test_groups(distribution_groups: arguments[:distribution_groups]),
         release_notes: get_build_notes()
       )
     end
@@ -115,22 +115,12 @@ lane :get_build_notes do
   build_notes # return value
 end
 
-lane :get_build_test_groups do 
-  test_groups = ['all-builds'] # send all builds to group 'all-builds'. Therefore, set it here and we will not remove it. 
-  test_groups.append("feature-branch") # Feature branch will be used when a PR is merged into a feature branch. We will need to add a check for this.
-  github = GitHub.new()
-    
-  # To avoid giving potentially unstable builds of our sample apps to certain members of the organization, we only send builds to "stable" group uncertain certain situations. 
-  # If a commit is merged into main, it's considered stable because we deploy to production on merges to main. 
-  if github.is_commit_pushed && github.push_branch == "main"
-    test_groups.append("stable-builds") 
-    test_groups.append("next") # Next group will depricate the 'stable` builds group'.
-    test_groups.append("public") # Temp send to public group until we actually build from the deployed SDK.
-  end
-
-  test_groups = test_groups.join(", ")
+lane :get_build_test_groups do |arguments|
+  # Firebase App Distribution expects a comma separated string of test group names.
+  # If no groups are passed in, then set test groups to an empty string.
+  test_groups = arguments[:distribution_groups] || ""
 
   UI.important("Test group names that will be added to this build: #{test_groups}")
 
-  test_groups # return value 
-end 
+  test_groups # return value
+end


### PR DESCRIPTION
part of: [MBL-710](https://linear.app/customerio/issue/MBL-710/single-app-per-platform-distributed-to-firebase)

### Changes

- Updated `Build Sample Apps` action to push sample app to relevant channels
- Modified `get_build_test_groups` lane to decouple from GitHub and accept arguments for passing Firebase distribution groups when distributing sample apps

Please refer to linked ticket for detailed expectations regarding channel distribution.