### PR TITLE
chore: send slack notification on sample app build

### DIFF
--- a/.github/workflows/reusable-build-sample-apps.yml
+++ b/.github/workflows/reusable-build-sample-apps.yml
@@ -33,12 +33,14 @@ jobs:
         with:
           fetch-depth: 0 # Workaround for bug https://github.com/actions/checkout/issues/1471
 
-      - name: Get latest SDK version
-        if: ${{ inputs.use_latest_sdk_version == true }}
-        id: latest-sdk-version-step
+      - name: Capture Git Context
+        shell: bash
+        id: git-context
         run: |
-          latest_tag=$(git describe --tags --abbrev=0)
-          echo "LATEST_TAG=$latest_tag" >> "$GITHUB_OUTPUT"
+          echo "BRANCH_NAME=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
+          COMMIT_HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
+          echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> $GITHUB_ENV
+          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Set Default Firebase Distribution Groups
         shell: bash
@@ -50,6 +52,7 @@ jobs:
           PUBLIC_BUILDS_GROUP: public
           # Input variables
           CURRENT_BRANCH: ${{ github.ref }}
+          USE_LATEST_SDK_VERSION: ${{ inputs.use_latest_sdk_version }}
         run: |
           # Initialize with the default distribution group
           distribution_groups=("$ALL_BUILDS_GROUP")
@@ -100,16 +103,13 @@ jobs:
         with:
           subdirectory: apps/${{ matrix.sample-app.name }}
           lane: "update_flutter_android_app_version"
-          options: ${{ inputs.use_latest_sdk_version == true && format('{{"version_name":"{0}"}}', steps.latest-sdk-version-step.outputs.LATEST_TAG) || '' }}
+          options: ${{ inputs.use_latest_sdk_version == true && format('{{"version_name":"{0}"}}', env.LATEST_TAG) || '' }}
         env:
           SDK_VERSION_NAME: ${{ env.SDK_VERSION_NAME }}
           APP_VERSION_NAME: ${{ env.APP_VERSION_NAME }}
           APP_VERSION_CODE: ${{ env.APP_VERSION_CODE }}
 
       - name: Setup workspace credentials in flutter environment files
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-          COMMIT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           ENV_FILE=".env"
           touch "$ENV_FILE"
@@ -117,13 +117,13 @@ jobs:
           echo "CDP_API_KEY=${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_CDP_API_KEY', matrix.sample-app.name)] }}" >> "$ENV_FILE"
           echo "SITE_ID=${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_SITE_ID', matrix.sample-app.name)] }}" >> "$ENV_FILE"
           echo "WORKSPACE_NAME=${{ matrix.sample-app.cio-workspace-name }}" >> "$ENV_FILE"
-          echo "BRANCH_NAME=$BRANCH_NAME" >> "$ENV_FILE"
-          echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> "$ENV_FILE"
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "untagged")
+          echo "BRANCH_NAME=${{ env.BRANCH_NAME }}" >> "$ENV_FILE"
+          echo "COMMIT_HASH=${{ env.COMMIT_HASH }}" >> "$ENV_FILE"
+          LAST_TAG="${LATEST_TAG:-untagged}"
           COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
           echo "COMMITS_AHEAD_COUNT=$COMMITS_AHEAD" >> "$ENV_FILE"
           if [ "${{ inputs.use_latest_sdk_version }}" == "true" ]; then
-            echo "SDK_VERSION=${{ steps.latest-sdk-version-step.outputs.LATEST_TAG }}" >> "$ENV_FILE"
+            echo "SDK_VERSION=${{ env.LATEST_TAG }}" >> "$ENV_FILE"
           fi
 
       # Make sure to fetch dependencies only after updating the version numbers and workspace credentials
@@ -154,6 +154,33 @@ jobs:
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
         continue-on-error: true # continue to build iOS app even if Android build fails
 
+      - name: Determine SDK Version
+        shell: bash
+        id: determine-sdk-version
+        run: |
+          if [[ "${{ inputs.use_latest_sdk_version }}" == "true" ]]; then
+            echo "APP_SDK_BUILD_VERSION=${{ env.LATEST_TAG }}" >> $GITHUB_ENV
+          else
+            echo "APP_SDK_BUILD_VERSION=${{ env.SDK_VERSION_NAME }}" >> $GITHUB_ENV
+          fi
+
+      - name: Send Slack Notification for Sample App Builds (Android)
+        if: always()
+        uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1
+        with:
+          build_status: ${{ steps.android_build.outcome }}
+          app_icon_emoji: ":flutter:"
+          app_name: "Flutter"
+          firebase_app_id: ${{ secrets[format('SAMPLE_APPS_{0}_FIREBASE_APP_ID_ANDROID', matrix.sample-app.name)] }}
+          firebase_distribution_groups: ${{ env.firebase_distribution_groups }}
+          git_context: "${{ env.BRANCH_NAME }} (${{ env.COMMIT_HASH }})"
+          icon_url: "https://img.icons8.com/color/512/flutter.png"
+          instructions_guide_link: ${{ secrets.SAMPLE_APPS_INSTRUCTIONS_GUIDE_LINK }}
+          platform: "android"
+          sdk_name: "Flutter SDK"
+          sdk_version: ${{ env.APP_SDK_BUILD_VERSION }}
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   build-ios-sample-app:
     strategy:
       fail-fast: false # if one sample app fails to build, let the other sample apps continue to build and not cancel them.
@@ -177,12 +204,14 @@ jobs:
         with:
           fetch-depth: 0 # Workaround for bug https://github.com/actions/checkout/issues/1471
 
-      - name: Get latest SDK version
-        if: ${{ inputs.use_latest_sdk_version == true }}
-        id: latest-sdk-version-step
+      - name: Capture Git Context
+        shell: bash
+        id: git-context
         run: |
-          latest_tag=$(git describe --tags --abbrev=0)
-          echo "LATEST_TAG=$latest_tag" >> "$GITHUB_OUTPUT"
+          echo "BRANCH_NAME=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
+          COMMIT_HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
+          echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> $GITHUB_ENV
+          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Set Default Firebase Distribution Groups
         shell: bash
@@ -194,6 +223,7 @@ jobs:
           PUBLIC_BUILDS_GROUP: public
           # Input variables
           CURRENT_BRANCH: ${{ github.ref }}
+          USE_LATEST_SDK_VERSION: ${{ inputs.use_latest_sdk_version }}
         run: |
           # Initialize with the default distribution group
           distribution_groups=("$ALL_BUILDS_GROUP")
@@ -245,16 +275,13 @@ jobs:
         with:
           subdirectory: apps/${{ matrix.sample-app.name }}
           lane: "update_flutter_ios_app_version"
-          options: ${{ inputs.use_latest_sdk_version == true && format('{{"version_name":"{0}"}}', steps.latest-sdk-version-step.outputs.LATEST_TAG) || '' }}
+          options: ${{ inputs.use_latest_sdk_version == true && format('{{"version_name":"{0}"}}', env.LATEST_TAG) || '' }}
         env:
           SDK_VERSION_NAME: ${{ env.SDK_VERSION_NAME }}
           APP_VERSION_NAME: ${{ env.APP_VERSION_NAME }}
           APP_VERSION_CODE: ${{ env.APP_VERSION_CODE }}
 
       - name: Setup workspace credentials in flutter environment files
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-          COMMIT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           ENV_FILE=".env"
           touch "$ENV_FILE"
@@ -262,13 +289,13 @@ jobs:
           echo "CDP_API_KEY=${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_CDP_API_KEY', matrix.sample-app.name)] }}" >> "$ENV_FILE"
           echo "SITE_ID=${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_SITE_ID', matrix.sample-app.name)] }}" >> "$ENV_FILE"
           echo "WORKSPACE_NAME=${{ matrix.sample-app.cio-workspace-name }}" >> "$ENV_FILE"
-          echo "BRANCH_NAME=$BRANCH_NAME" >> "$ENV_FILE"
-          echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> "$ENV_FILE"
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "untagged")
+          echo "BRANCH_NAME=${{ env.BRANCH_NAME }}" >> "$ENV_FILE"
+          echo "COMMIT_HASH=${{ env.COMMIT_HASH }}" >> "$ENV_FILE"
+          LAST_TAG="${LATEST_TAG:-untagged}"
           COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
           echo "COMMITS_AHEAD_COUNT=$COMMITS_AHEAD" >> "$ENV_FILE"
           if [ "${{ inputs.use_latest_sdk_version }}" == "true" ]; then
-            echo "SDK_VERSION=${{ steps.latest-sdk-version-step.outputs.LATEST_TAG }}" >> "$ENV_FILE"
+            echo "SDK_VERSION=${{ env.LATEST_TAG }}" >> "$ENV_FILE"
           fi
 
       - name: Setup workspace credentials in iOS environment files
@@ -316,3 +343,30 @@ jobs:
         env:
           GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
+
+      - name: Determine SDK Version
+        shell: bash
+        id: determine-sdk-version
+        run: |
+          if [[ "${{ inputs.use_latest_sdk_version }}" == "true" ]]; then
+            echo "APP_SDK_BUILD_VERSION=${{ env.LATEST_TAG }}" >> $GITHUB_ENV
+          else
+            echo "APP_SDK_BUILD_VERSION=${{ env.SDK_VERSION_NAME }}" >> $GITHUB_ENV
+          fi
+
+      - name: Send Slack Notification for Sample App Builds (iOS)
+        if: always()
+        uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1
+        with:
+          build_status: ${{ steps.ios_build.outcome }}
+          app_icon_emoji: ":flutter:"
+          app_name: "Flutter"
+          firebase_app_id: ${{ secrets[format('SAMPLE_APPS_{0}_FIREBASE_APP_ID_IOS', matrix.sample-app.name)] }}
+          firebase_distribution_groups: ${{ env.firebase_distribution_groups }}
+          git_context: "${{ env.BRANCH_NAME }} (${{ env.COMMIT_HASH }})"
+          icon_url: "https://img.icons8.com/color/512/flutter.png"
+          instructions_guide_link: ${{ secrets.SAMPLE_APPS_INSTRUCTIONS_GUIDE_LINK }}
+          platform: "ios"
+          sdk_name: "Flutter SDK"
+          sdk_version: ${{ env.APP_SDK_BUILD_VERSION }}
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/apps/fastlane/helpers/version_helper.rb
+++ b/apps/fastlane/helpers/version_helper.rb
@@ -9,6 +9,8 @@ lane :generate_new_version do |options|
     branch_name = github.pr_source_branch
   elsif github.is_commit_pushed
     branch_name = github.push_branch
+  else
+    branch_name = options[:branch_name] || "manual-release"
   end
 
   # Replace '/' with '-' to avoid issues with unsupported characters in version name


### PR DESCRIPTION
part of: [MBL-750](https://linear.app/customerio/issue/MBL-750/slack-notifications-on-new-builds)

### Changes

- Integrated common GitHub Action to send slack notifications when a sample app build completes
- Updated relevant GitHub Action and lane to extract necessary values for triggering the notification

**_Example messages can be seen in slack channels used for notifications_**