### PR TITLE
chore: fix sdk version in sample app build info

### DIFF
--- a/apps/amiapp_flutter/lib/src/utils/build_info.dart
+++ b/apps/amiapp_flutter/lib/src/utils/build_info.dart
@@ -42,7 +42,8 @@ class BuildInfoMetadata {
   @override
   String toString() {
     return '''
-    SDK Version: $sdkVersion \tApp Version: $appVersion
+    SDK Version: $sdkVersion
+    App Version: $appVersion
     Build Date: $buildDate
     Branch: $gitMetadata
     Default Workspace: $defaultWorkspace

--- a/apps/fastlane/Fastfile
+++ b/apps/fastlane/Fastfile
@@ -29,7 +29,7 @@ lane :update_flutter_sdk_version do |options|
   version_name = options[:version_name] || ENV['SDK_VERSION_NAME']
 
   UI.message("Updating sdk version to #{version_name} in #{project_path}")
-  update_pubspec_version(project_path, version_name)
+  sh("cd #{project_path} && ./scripts/update-version.sh \"#{version_name}\"")
 end
 
 # Lane to update Flutter app version


### PR DESCRIPTION
### Changes

- Replaced `update_pubspec_version` function call with `update-version` script to ensure a consistent SDK version update across all relevant files
- Previously, `update_pubspec_version` only updated `pubspec.yaml` causing a mismatch in SDK info displayed in sample app's build info

### Screenshots

| Before | After
| - | - |
| ![before](https://github.com/user-attachments/assets/3b0e4b2c-2add-44bb-ac1f-16f684965bb3) | ![after](https://github.com/user-attachments/assets/50b16424-8e15-42f5-af02-252bdcc78e7a) |