### PR TITLE
fix: support null handling in nested structures

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.5.5"
+    def cioVersion = "4.5.6"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/apps/amiapp_flutter/pubspec.lock
+++ b/apps/amiapp_flutter/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.1.2"
+    version: "2.1.4"
   dbus:
     dependency: transitive
     description:


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-955/[bug]-passing-nested-null-attribute-crashes-android-in-react-native