### PR TITLE
fix: Fix in-app module initialization to use region US by default

### DIFF
--- a/ios/Classes/MessagingInApp/CustomerIOInAppMessaging.swift
+++ b/ios/Classes/MessagingInApp/CustomerIOInAppMessaging.swift
@@ -40,10 +40,23 @@ public class CustomerIOInAppMessaging: NSObject, FlutterPlugin {
     }
 
     func configureModule(params: [String: AnyHashable]) {
-        if let inAppConfig = try? MessagingInAppConfigBuilder.build(from: params) {
-            MessagingInApp.initialize(withConfig: inAppConfig)
-            MessagingInApp.shared.setEventListener(CustomerIOInAppEventListener(invokeDartMethod: invokeDartMethod))
+        guard let rawInAppConfig = params["inApp"] else {
+            return
         }
+        guard let inAppConfig = rawInAppConfig as? [String: Any] else {
+            DIGraphShared.shared.logger.error("[InApp] Failed to initialize module: invalid config structure")
+            return
+        }
+        
+        guard let siteId = inAppConfig["siteId"] as? String else {
+            DIGraphShared.shared.logger.error("[InApp] Failed to initialize module missing: siteId")
+            return
+        }
+        let rawRegion = inAppConfig["region"] as? String ?? ""
+        let region = Region.getRegion(from: rawRegion)
+
+        MessagingInApp.initialize(withConfig: MessagingInAppConfigBuilder(siteId: siteId, region: region).build())
+        MessagingInApp.shared.setEventListener(CustomerIOInAppEventListener(invokeDartMethod: invokeDartMethod))
     }
 
     func invokeDartMethod(_ method: String, _ args: Any?) {


### PR DESCRIPTION
Closes: [MBL-1052](https://linear.app/customerio/issue/MBL-1052/flutter-sdk-region-is-not-set-correctly-by-default)

## Problem
In case of a customer omitting the `region` property from their SDK config, initializing in-app module failed.

The flutter bridge to iOS native SDK that is initializing In-App module is using an extension `MessagingInAppConfigBuilder.from([String: Any?])`. It was attempting to create `MessagingInAppConfigOptions` but it silently failed when an error is thrown.

## Solution
- I've added some logic to extract `siteId` and `region` from the Flutter config before passing it in the bridge to iOS native calls.
- The logic will print appropriate error logs in case module initialization fails
- The bridge now uses the more robust typed constructor of `MessagingInAppConfigBuilder` to build `MessagingInAppConfigOptions`

## How to test?
In the Flutter sample app remove the [region](https://github.com/customerio/customerio-flutter/blob/39bd65ae0bb0f7de3b8aa09bfbca96734e0e1f52/apps/amiapp_flutter/lib/src/customer_io.dart#L67) from the Flutter config and try running the app

The app should start normally and in-app module should be initialized successfully and you are able to receive in-app messages.
