### PR TITLE
chore: Trigger sample apps public builds after deployment is successful

### DIFF
--- a/.github/workflows/build-sample-app-for-sdk-release.yml
+++ b/.github/workflows/build-sample-app-for-sdk-release.yml
@@ -2,6 +2,7 @@ name: Publish test apps for SDK release
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build-sample-apps:

--- a/.github/workflows/tag-and-deploy.yml
+++ b/.github/workflows/tag-and-deploy.yml
@@ -190,8 +190,5 @@ jobs:
 
   publish-sample-apps-public-builds:
     needs: deploy-to-pub-dev
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger sample apps public builds
-        uses: ./.github/workflows/build-sample-app-for-sdk-release.yml
-        
+    uses: ./.github/workflows/build-sample-app-for-sdk-release.yml
+    secrets: inherit

--- a/.github/workflows/tag-and-deploy.yml
+++ b/.github/workflows/tag-and-deploy.yml
@@ -187,3 +187,11 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  publish-sample-apps-public-builds:
+    needs: deploy-to-pub-dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sample apps public builds
+        uses: ./.github/workflows/build-sample-app-for-sdk-release.yml
+        


### PR DESCRIPTION
Closes: [MBL-1053](https://linear.app/customerio/issue/MBL-1053/auto-create-testbed-releases-for-every-sdk-release)

This PR triggers a sample apps public release build after the SDK has been deployed successfully so that internal stakeholders always have up to date versions to test with.

### Note
I am not entirely sure if the package will be immediately available after publishing before it can be used to build the sample app or we need a delay. Starting out with immediate trigger and we can revise later if the build fails.