### PR TITLE
chore: Log error if swift bridge fails to create MessagingInAppConfigBuilder

### DIFF
--- a/ios/Classes/MessagingInApp/CustomerIOInAppMessaging.swift
+++ b/ios/Classes/MessagingInApp/CustomerIOInAppMessaging.swift
@@ -43,6 +43,8 @@ public class CustomerIOInAppMessaging: NSObject, FlutterPlugin {
         if let inAppConfig = try? MessagingInAppConfigBuilder.build(from: params) {
             MessagingInApp.initialize(withConfig: inAppConfig)
             MessagingInApp.shared.setEventListener(CustomerIOInAppEventListener(invokeDartMethod: invokeDartMethod))
+        } else {
+            DIGraphShared.shared.logger.error("[InApp] Failed to initialize module: invalid config")
         }
     }
 


### PR DESCRIPTION
Closes: [MBL-1052](https://linear.app/customerio/issue/MBL-1052/flutter-sdk-region-is-not-set-correctly-by-default)

## Problem
In case of a customer omitting the `region` property from their SDK config, initializing in-app module failed.

The flutter bridge to iOS native SDK that is initializing In-App module is using an extension `MessagingInAppConfigBuilder.from([String: Any?])`. It was attempting to create `MessagingInAppConfigOptions` but it silently failed when an error is thrown.

## Solution
The Flutter bridge shouldn't silently fail and should log an error that initializing in-app module has failed
