### PR TITLE
chore: sample app with flutter view usage

### DIFF
--- a/apps/amiapp_flutter/lib/src/app.dart
+++ b/apps/amiapp_flutter/lib/src/app.dart
@@ -10,6 +10,7 @@ import 'data/screen.dart';
 import 'screens/attributes.dart';
 import 'screens/dashboard.dart';
 import 'screens/events.dart';
+import 'screens/inline_messages.dart';
 import 'screens/login.dart';
 import 'screens/settings.dart';
 import 'theme/sizes.dart';
@@ -137,6 +138,11 @@ class _AmiAppState extends State<AmiApp> {
               name: Screen.profileAttributes.name,
               path: Screen.profileAttributes.path,
               builder: (context, state) => AttributesScreen.profile(),
+            ),
+            GoRoute(
+              name: Screen.inlineMessages.name,
+              path: Screen.inlineMessages.path,
+              builder: (context, state) => const InlineMessagesScreen(),
             ),
           ],
         ),

--- a/apps/amiapp_flutter/lib/src/data/screen.dart
+++ b/apps/amiapp_flutter/lib/src/data/screen.dart
@@ -10,7 +10,8 @@ enum Screen {
   customEvents(name: 'Custom Event', path: 'events/custom'),
   deviceAttributes(name: 'Custom Device Attribute', path: 'attributes/device'),
   profileAttributes(
-      name: 'Custom Profile Attribute', path: 'attributes/profile');
+      name: 'Custom Profile Attribute', path: 'attributes/profile'),
+  inlineMessages(name: 'Inline Messages Test', path: 'inline-messages');
 
   const Screen({
     required this.name,

--- a/apps/amiapp_flutter/lib/src/screens/dashboard.dart
+++ b/apps/amiapp_flutter/lib/src/screens/dashboard.dart
@@ -287,6 +287,7 @@ enum _ActionItem {
   customEvent,
   deviceAttributes,
   profileAttributes,
+  inlineMessages,
   showPushPrompt,
   showLocalPush,
   signOut,
@@ -303,6 +304,8 @@ extension _ActionNames on _ActionItem {
         return 'Set Device Attribute';
       case _ActionItem.profileAttributes:
         return 'Set Profile Attribute';
+      case _ActionItem.inlineMessages:
+        return 'Test Inline Messages';
       case _ActionItem.showPushPrompt:
         return 'Show Push Prompt';
       case _ActionItem.showLocalPush:
@@ -322,6 +325,8 @@ extension _ActionNames on _ActionItem {
         return 'Device Attribute Button';
       case _ActionItem.profileAttributes:
         return 'Profile Attribute Button';
+      case _ActionItem.inlineMessages:
+        return 'Inline Messages Button';
       case _ActionItem.showPushPrompt:
         return 'Show Push Prompt Button';
       case _ActionItem.showLocalPush:
@@ -341,6 +346,8 @@ extension _ActionNames on _ActionItem {
         return Screen.deviceAttributes;
       case _ActionItem.profileAttributes:
         return Screen.profileAttributes;
+      case _ActionItem.inlineMessages:
+        return Screen.inlineMessages;
       case _ActionItem.showPushPrompt:
         return null;
       case _ActionItem.showLocalPush:

--- a/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
+++ b/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
@@ -1,0 +1,123 @@
+import 'package:customer_io/customer_io_widgets.dart';
+import 'package:flutter/material.dart';
+
+import '../components/container.dart';
+
+class InlineMessagesScreen extends StatelessWidget {
+  const InlineMessagesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AppContainer(
+      appBar: AppBar(
+        title: const Text('Inline Message Test'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            // Top inline message
+            _buildInlineMessageSection('inline-top'),
+            
+            // Skeleton loading content 1
+            _buildSkeletonContent(),
+            
+            // Middle inline message
+            _buildInlineMessageSection('inline-middle'),
+            
+            // Skeleton loading content 2
+            _buildSkeletonContent(),
+            
+            // Bottom inline message
+            _buildInlineMessageSection('inline-bottom'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInlineMessageSection(String elementId) {
+    return Builder(
+      builder: (context) {
+        return SizedBox(
+          height: 120, // Good height for inline messages
+          width: double.infinity,
+          child: InlineInAppMessageView(
+            elementId: elementId,
+            onAction: (actionValue, actionName, {messageId, deliveryId}) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                    'Action: $actionName, Value: $actionValue'
+                    '${messageId != null ? ', Message ID: $messageId' : ''}'
+                    '${deliveryId != null ? ', Delivery ID: $deliveryId' : ''}',
+                  ),
+                ),
+              );
+            },
+            progressTint: Theme.of(context).primaryColor,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSkeletonContent() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Left skeleton block
+        Expanded(
+          flex: 2,
+          child: AspectRatio(
+            aspectRatio: 1.0,
+            child: Container(
+              decoration: BoxDecoration(
+                color: Colors.grey[400],
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 16),
+        // Right skeleton content
+        Expanded(
+          flex: 2,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Top skeleton bars
+              Container(
+                height: 16,
+                decoration: BoxDecoration(
+                  color: Colors.grey[400],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Container(
+                height: 16,
+                width: double.infinity * 0.7,
+                decoration: BoxDecoration(
+                  color: Colors.grey[400],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              const SizedBox(height: 16),
+              // Bottom skeleton block
+              AspectRatio(
+                aspectRatio: 1.5,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.grey[400],
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-1172/demo-and-test-in-flutter-sample-app

## Changes

  - New Screen: InlineMessagesScreen with 3 inline message placeholders and skeleton content
  - Navigation: Added "Test Inline Messages" button to dashboard
  - Element IDs: inline-top, inline-middle, inline-bottom for testing different message placements
  - Layout: Alternating inline message views and skeleton loading blocks mimicking real content
  - Platform Views: Proper sizing constraints (120px height) to prevent layout errors while allowing native content display

## Note

  - Auto Resizing of the view is still under progress hence you will see default size of placeholders. Once thats done the inline placeholders will be 0 by default

![Screenshot_1749905805](https://github.com/user-attachments/assets/f84a2644-4063-4f29-b2f5-a2f334069e48)
