### PR TITLE
chore:  use shared wrapper classes for platform events

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.6.1"
+    def cioVersion = "local"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,7 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' } // Only required for using SNAPSHOT versions of the SDK
     }
 }
 
@@ -59,7 +60,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "local"
+    def cioVersion = "consoladated-platform-SNAPSHOT" // Replace with the actual version after native release
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/FlutterInAppPlatformDelegate.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/FlutterInAppPlatformDelegate.kt
@@ -1,0 +1,31 @@
+package io.customer.customer_io.messaginginapp
+
+import android.view.View
+import io.customer.messaginginapp.ui.bridge.WrapperPlatformDelegate
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Flutter platform delegate for in-app messaging.
+ * Now uses WrapperPlatformDelegate from native SDK to eliminate code duplication with React Native.
+ * Only contains Flutter-specific event dispatch logic - all animation and state management is shared.
+ *
+ * @param view The native Android view hosting the in-app message
+ * @param methodChannel The Flutter method channel for communication
+ */
+class FlutterInAppPlatformDelegate(
+    view: View,
+    private val methodChannel: MethodChannel
+) : WrapperPlatformDelegate(view) {
+
+    companion object {
+        private const val TAG = "FlutterInAppPlatformDelegate"
+    }
+
+    /**
+     * Flutter-specific event dispatch implementation.
+     * This is the ONLY platform-specific code - everything else is now shared!
+     */
+    override fun dispatchEvent(eventName: String, payload: Map<String, Any?>) {
+        methodChannel.invokeMethod(eventName, payload)
+    }
+}

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/FlutterInlineInAppMessageView.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/FlutterInlineInAppMessageView.kt
@@ -1,0 +1,43 @@
+package io.customer.customer_io.messaginginapp
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.annotation.AttrRes
+import androidx.annotation.StyleRes
+import io.customer.messaginginapp.ui.core.WrapperInlineView
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Flutter implementation of inline in-app message view.
+ * Now uses WrapperInlineView from native SDK to eliminate code duplication with React Native.
+ * Only contains Flutter-specific functionality - all lifecycle and state management is shared.
+ */
+class FlutterInlineInAppMessageView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    @AttrRes defStyleAttr: Int = 0,
+    @StyleRes defStyleRes: Int = 0,
+    private val methodChannel: MethodChannel
+) : WrapperInlineView<FlutterInAppPlatformDelegate>(
+    context, attrs, defStyleAttr, defStyleRes
+) {
+    override val platformDelegate = FlutterInAppPlatformDelegate(view = this, methodChannel = methodChannel)
+
+    init {
+        // Initialize the wrapper view after platformDelegate is set
+        initializeView()
+    }
+
+    /**
+     * Flutter-specific method to trigger size animations from Dart code.
+     */
+    fun triggerSizeAnimation(widthInDp: Double?, heightInDp: Double?, duration: Long = 200L) {
+        platformDelegate.animateViewSize(
+            widthInDp = widthInDp,
+            heightInDp = heightInDp,
+            duration = duration,
+            onStart = null,
+            onEnd = null
+        )
+    }
+}


### PR DESCRIPTION
Refactor Flutter inline in-app messaging to use shared wrapper classes from the native Customer.io SDK, eliminating code duplication between React Native and Flutter platforms.

  **Key Changes:**
  - Replace custom `BaseInlineInAppMessageView` usage with `WrapperInlineView<FlutterInAppPlatformDelegate>`
  - Replace custom `AndroidInAppPlatformDelegate` usage with `WrapperPlatformDelegate`
  - Consolidate Flutter-specific logic to only event dispatch implementation
  - All animation, state management, and lifecycle logic now shared across platforms

  **Files Changed:**
  - `android/build.gradle` - Currently 
  - `FlutterInlineInAppMessageView.kt` - Now extends `WrapperInlineView` with shared lifecycle management
  - `FlutterInAppPlatformDelegate.kt` - Now extends `WrapperPlatformDelegate` with only Flutter-specific event dispatch

  ## Benefits

  - **Reduced Code Duplication**: Shared implementation between React Native and Flutter
  - **Improved Maintainability**: Single source of truth for animation and state logic
  - **Consistent Behavior**: Identical behavior across all wrapper platforms
  - **Simplified Codebase**: Platform-specific code reduced to essential event dispatch only

