### PR TITLE
chore: Prevent accidental public API changes

### DIFF
--- a/.github/workflows/check-api-changes.yml
+++ b/.github/workflows/check-api-changes.yml
@@ -1,4 +1,4 @@
-name: Extract API
+name: Check API Changes
 
 on: [pull_request]
 
@@ -8,14 +8,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  extract_api:
+  check_api_changes:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-flutter
     
-    - name: Install dart_apitool
-      run: dart pub global activate dart_apitool
-    
-    - name: Extract API
-      run: bash ./scripts/extract_api.sh
+    - name: Check for API changes
+      run: ./scripts/check_api_changes.sh

--- a/customerio-flutter.api
+++ b/customerio-flutter.api
@@ -1,62 +1,31 @@
-public final class InAppMessage {
-	public fun new(
-		required String messageId,
-		String? deliveryId
-	): InAppMessage;
-	public val messageId: String;
-	public val deliveryId: String?;
-}
-
-public final class InAppEventListener {
-	public fun new(): InAppEventListener;
-	public fun messageShown(InAppMessage message);
-	public fun messageDismissed(InAppMessage message);
-	public fun errorWithMessage(InAppMessage message);
-	public fun messageActionTaken(
-		InAppMessage message,
-		String actionValue,
-		String actionName
-	);
-}
-
-public final class InAppEvent {
-	public fun new(
-		required EventType eventType,
-		required InAppMessage message,
-		String? actionValue,
-		String? actionName
-	): InAppEvent;
-	public fun fromMap(
-		EventType type,
-		Map<String?, dynamic> map
-	): InAppEvent;
-	public val message: InAppMessage;
-	public val actionValue: String?;
-	public val actionName: String?;
-	public val eventType: EventType;
-}
-
-public final class EventType {
-	static public val messageShown: EventType;
-	static public val messageDismissed: EventType;
-	static public val errorWithMessage: EventType;
-	static public val messageActionTaken: EventType;
-	static public val values: List<EventType>;
+public final class CioLogLevel {
+	static public val debug: CioLogLevel;
+	static public val error: CioLogLevel;
+	static public val info: CioLogLevel;
+	static public val none: CioLogLevel;
+	static public val values: List<CioLogLevel>;
 }
 
 public final class CustomerIO {
+	public fun clearIdentify();
 	static public fun createInstance(
 		CustomerIOPlatform? platform,
 		CustomerIOMessagingPushPlatform? pushMessaging,
 		CustomerIOMessagingInAppPlatform? inAppMessaging
 	): CustomerIO;
-	static public fun reset();
-	static public fun initialize(required CustomerIOConfig config): Future<void> async;
 	public fun identify(
 		required String userId,
 		Map<String, dynamic> traits
 	);
-	public fun clearIdentify();
+	static public fun initialize(required CustomerIOConfig config): Future<void> async;
+	public fun registerDeviceToken(required String deviceToken);
+	static public fun reset();
+	public fun screen(
+		required String title,
+		Map<String, dynamic> properties
+	);
+	public fun setDeviceAttributes(required Map<String, dynamic> attributes);
+	public fun setProfileAttributes(required Map<String, dynamic> attributes);
 	public fun track(
 		required String name,
 		Map<String, dynamic> properties
@@ -66,61 +35,9 @@ public final class CustomerIO {
 		required String deviceToken,
 		required MetricEvent event
 	);
-	public fun registerDeviceToken(required String deviceToken);
-	public fun screen(
-		required String title,
-		Map<String, dynamic> properties
-	);
-	public fun setDeviceAttributes(required Map<String, dynamic> attributes);
-	public fun setProfileAttributes(required Map<String, dynamic> attributes);
+	static public val inAppMessaging: CustomerIOMessagingInAppPlatform;
 	static public val instance: CustomerIO;
 	static public val pushMessaging: CustomerIOMessagingPushPlatform;
-	static public val inAppMessaging: CustomerIOMessagingInAppPlatform;
-}
-
-public final class CustomerIOMessagingPushPlatform {
-	public fun new(): CustomerIOMessagingPushPlatform;
-	public fun getRegisteredDeviceToken(): Future<String?> async;
-	public fun onMessageReceived(
-		Map<String, dynamic> message,
-		bool handleNotificationTrigger
-	): Future<bool> async;
-	public fun onBackgroundMessageReceived(Map<String, dynamic> message): Future<bool> async;
-	static public var instance: CustomerIOMessagingPushPlatform;
-}
-
-public final class CustomerIOMessagingInAppPlatform {
-	public fun new(): CustomerIOMessagingInAppPlatform;
-	public fun dismissMessage();
-	public fun subscribeToEventsListener(void Function(InAppEvent) onEvent): StreamSubscription<dynamic>;
-	static public var instance: CustomerIOMessagingInAppPlatform;
-}
-
-public final class CustomerIOPlatform {
-	public fun new(): CustomerIOPlatform;
-	public fun initialize(required CustomerIOConfig config): Future<void> async;
-	public fun identify(
-		required String userId,
-		Map<String, dynamic> traits
-	);
-	public fun clearIdentify();
-	public fun track(
-		required String name,
-		Map<String, dynamic> properties
-	);
-	public fun trackMetric(
-		required String deliveryID,
-		required String deviceToken,
-		required MetricEvent event
-	);
-	public fun registerDeviceToken(required String deviceToken);
-	public fun screen(
-		required String title,
-		Map<String, dynamic> properties
-	);
-	public fun setDeviceAttributes(required Map<String, dynamic> attributes);
-	public fun setProfileAttributes(required Map<String, dynamic> attributes);
-	static public var instance: CustomerIOPlatform;
 }
 
 public final class CustomerIOConfig {
@@ -140,47 +57,155 @@ public final class CustomerIOConfig {
 		PushConfig? pushConfig
 	): CustomerIOConfig;
 	public fun toMap(): Map<String, dynamic>;
-	public val source: String;
-	public val version: String;
-	public val cdpApiKey: String;
-	public val migrationSiteId: String?;
-	public val region: Region?;
-	public val logLevel: CioLogLevel?;
-	public val trackApplicationLifecycleEvents: bool?;
-	public val autoTrackDeviceAttributes: bool?;
 	public val apiHost: String?;
+	public val autoTrackDeviceAttributes: bool?;
 	public val cdnHost: String?;
+	public val cdpApiKey: String;
 	public val flushAt: int?;
 	public val flushInterval: int?;
-	public val screenViewUse: ScreenView?;
 	public val inAppConfig: InAppConfig?;
+	public val logLevel: CioLogLevel?;
+	public val migrationSiteId: String?;
 	public val pushConfig: PushConfig;
+	public val region: Region?;
+	public val screenViewUse: ScreenView?;
+	public val source: String;
+	public val trackApplicationLifecycleEvents: bool?;
+	public val version: String;
 }
 
-public final class Region {
-	static public val us: Region;
-	static public val eu: Region;
-	static public val values: List<Region>;
+public final class CustomerIOMessagingInAppPlatform {
+	public fun new(): CustomerIOMessagingInAppPlatform;
+	public fun dismissMessage();
+	public fun subscribeToEventsListener(void Function(InAppEvent) onEvent): StreamSubscription<dynamic>;
+	static public var instance: CustomerIOMessagingInAppPlatform;
 }
 
-public final class CioLogLevel {
-	static public val none: CioLogLevel;
-	static public val error: CioLogLevel;
-	static public val info: CioLogLevel;
-	static public val debug: CioLogLevel;
-	static public val values: List<CioLogLevel>;
+public final class CustomerIOMessagingPushPlatform {
+	public fun new(): CustomerIOMessagingPushPlatform;
+	public fun getRegisteredDeviceToken(): Future<String?> async;
+	public fun onBackgroundMessageReceived(Map<String, dynamic> message): Future<bool> async;
+	public fun onMessageReceived(
+		Map<String, dynamic> message,
+		bool handleNotificationTrigger
+	): Future<bool> async;
+	static public var instance: CustomerIOMessagingPushPlatform;
 }
 
-public final class ScreenView {
-	static public val all: ScreenView;
-	static public val inApp: ScreenView;
-	static public val values: List<ScreenView>;
+public final class CustomerIOPlatform {
+	public fun new(): CustomerIOPlatform;
+	public fun clearIdentify();
+	public fun identify(
+		required String userId,
+		Map<String, dynamic> traits
+	);
+	public fun initialize(required CustomerIOConfig config): Future<void> async;
+	public fun registerDeviceToken(required String deviceToken);
+	public fun screen(
+		required String title,
+		Map<String, dynamic> properties
+	);
+	public fun setDeviceAttributes(required Map<String, dynamic> attributes);
+	public fun setProfileAttributes(required Map<String, dynamic> attributes);
+	public fun track(
+		required String name,
+		Map<String, dynamic> properties
+	);
+	public fun trackMetric(
+		required String deliveryID,
+		required String deviceToken,
+		required MetricEvent event
+	);
+	static public var instance: CustomerIOPlatform;
+}
+
+public final class EventType {
+	static public val errorWithMessage: EventType;
+	static public val messageActionTaken: EventType;
+	static public val messageDismissed: EventType;
+	static public val messageShown: EventType;
+	static public val values: List<EventType>;
 }
 
 public final class InAppConfig {
 	public fun new(required String siteId): InAppConfig;
 	public fun toMap(): Map<String, dynamic>;
 	public val siteId: String;
+}
+
+public final class InAppEvent {
+	public fun fromMap(
+		EventType type,
+		Map<String?, dynamic> map
+	): InAppEvent;
+	public fun new(
+		required EventType eventType,
+		required InAppMessage message,
+		String? actionValue,
+		String? actionName
+	): InAppEvent;
+	public val actionName: String?;
+	public val actionValue: String?;
+	public val eventType: EventType;
+	public val message: InAppMessage;
+}
+
+public final class InAppEventListener {
+	public fun new(): InAppEventListener;
+	public fun errorWithMessage(InAppMessage message);
+	public fun messageActionTaken(
+		InAppMessage message,
+		String actionValue,
+		String actionName
+	);
+	public fun messageDismissed(InAppMessage message);
+	public fun messageShown(InAppMessage message);
+}
+
+public final class InAppMessage {
+	public fun new(
+		required String messageId,
+		String? deliveryId
+	): InAppMessage;
+	public val deliveryId: String?;
+	public val messageId: String;
+}
+
+public final class InAppMessage {
+	public fun new(
+		required String messageId,
+		String? deliveryId,
+		String? elementId
+	): InAppMessage;
+	public val deliveryId: String?;
+	public val elementId: String?;
+	public val hashCode: int;
+	public val messageId: String;
+}
+
+public final class InlineInAppMessageView {
+	public fun new(
+		Key? key,
+		required String elementId,
+		void Function(InAppMessage, String, String)? onActionClick
+	): InlineInAppMessageView;
+	public val elementId: String;
+	public val onActionClick: void Function(InAppMessage, String, String)?;
+}
+
+public final class MetricEvent {
+	static public val converted: MetricEvent;
+	static public val delivered: MetricEvent;
+	static public val opened: MetricEvent;
+	static public val values: List<MetricEvent>;
+}
+
+public final class PushClickBehaviorAndroid {
+	static public val activityNoFlags: PushClickBehaviorAndroid;
+	static public val activityPreventRestart: PushClickBehaviorAndroid;
+	public val rawValue: String;
+	static public val resetTaskStack: PushClickBehaviorAndroid;
+	static public val values: List<PushClickBehaviorAndroid>;
 }
 
 public final class PushConfig {
@@ -195,41 +220,16 @@ public final class PushConfigAndroid {
 	public var pushClickBehavior: PushClickBehaviorAndroid;
 }
 
-public final class PushClickBehaviorAndroid {
-	static public val resetTaskStack: PushClickBehaviorAndroid;
-	static public val activityPreventRestart: PushClickBehaviorAndroid;
-	static public val activityNoFlags: PushClickBehaviorAndroid;
-	static public val values: List<PushClickBehaviorAndroid>;
-	public val rawValue: String;
+public final class Region {
+	static public val eu: Region;
+	static public val us: Region;
+	static public val values: List<Region>;
 }
 
-public final class MetricEvent {
-	static public val delivered: MetricEvent;
-	static public val opened: MetricEvent;
-	static public val converted: MetricEvent;
-	static public val values: List<MetricEvent>;
-}
-
-public final class InAppMessage {
-	public fun new(
-		required String messageId,
-		String? deliveryId,
-		String? elementId
-	): InAppMessage;
-	public val messageId: String;
-	public val deliveryId: String?;
-	public val elementId: String?;
-	public val hashCode: int;
-}
-
-public final class InlineInAppMessageView {
-	public fun new(
-		Key? key,
-		required String elementId,
-		void Function(InAppMessage, String, String)? onActionClick
-	): InlineInAppMessageView;
-	public val elementId: String;
-	public val onActionClick: void Function(InAppMessage, String, String)?;
+public final class ScreenView {
+	static public val all: ScreenView;
+	static public val inApp: ScreenView;
+	static public val values: List<ScreenView>;
 }
 
 

--- a/lib/customer_io.dart
+++ b/lib/customer_io.dart
@@ -159,10 +159,4 @@ class CustomerIO {
     return _platform.setProfileAttributes(
         attributes: attributes.excludeNullValues());
   }
-
-  /// Test method for API change detection
-  /// This method should be detected by the API change detection script
-  String testApiChangeDetection({required String message}) {
-    return 'Test: $message';
-  }
 }

--- a/lib/customer_io.dart
+++ b/lib/customer_io.dart
@@ -159,4 +159,10 @@ class CustomerIO {
     return _platform.setProfileAttributes(
         attributes: attributes.excludeNullValues());
   }
+
+  /// Test method for API change detection
+  /// This method should be detected by the API change detection script
+  String testApiChangeDetection({required String message}) {
+    return 'Test: $message';
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dev_dependencies:
   flutter_lints: ^3.0.2
   build_runner: ^2.2.0
   mockito: ^5.0.15
+  dart_apitool: ^0.22.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/scripts/check_api_changes.sh
+++ b/scripts/check_api_changes.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Customer.io Flutter SDK API Change Detection Tool
+# Usage: ./check_api_changes.sh
+
+set -e
+
+# Define file paths
+CURRENT_API_FILE="customerio-flutter.api"
+BACKUP_API_FILE="customerio-flutter.api.backup"
+
+# Exit codes
+EXIT_NO_CHANGES=0
+EXIT_CHANGES_DETECTED=1
+EXIT_ERROR=2
+
+# Function to cleanup temporary files
+cleanup() {
+    rm -f "$BACKUP_API_FILE"
+}
+
+# Set up cleanup on exit
+trap cleanup EXIT
+
+# Check if current API file exists
+if [ ! -f "$CURRENT_API_FILE" ]; then
+    echo "❌ Error: Current API file '$CURRENT_API_FILE' not found"
+    echo "   Run './scripts/extract_api.sh' first to generate the initial API file"
+    exit $EXIT_ERROR
+fi
+
+# Backup current API file
+cp "$CURRENT_API_FILE" "$BACKUP_API_FILE"
+
+# Generate new API file using existing extraction script
+./scripts/extract_api.sh > /dev/null 2>&1
+
+# Compare API files (backup vs newly generated current file)
+if cmp -s "$BACKUP_API_FILE" "$CURRENT_API_FILE"; then
+    echo "✅ No API changes detected"
+    exit $EXIT_NO_CHANGES
+else
+    echo "🚨 API changes detected!"
+    echo ""
+    echo "📊 Detailed differences:"
+    echo "===================="
+    
+    # Show detailed diff
+    diff --unified=3 "$BACKUP_API_FILE" "$CURRENT_API_FILE" || true
+    
+    echo ""
+    echo "===================="
+    echo "❗ Please review the changes carefully before merging."
+    echo ""
+    echo "💡 If these changes are intentional, update the baseline API file:"
+    echo "   ./scripts/extract_api.sh"
+    echo ""
+    echo "   This will regenerate customerio-flutter.api with the current API surface."
+    
+    exit $EXIT_CHANGES_DETECTED
+fi 

--- a/scripts/extract_api.sh
+++ b/scripts/extract_api.sh
@@ -5,13 +5,25 @@
 
 echo "🔍 Extracting Customer.io Flutter SDK API..."
 
+# Remove existing API file to ensure fresh generation
+echo "🗑️ Removing existing API file..."
+rm -f customerio-flutter.api
+
 # Extract full API using dart_apitool
 echo "📝 Running dart_apitool extraction..."
-dart-apitool extract --input . --output api_current.json --force-use-flutter
+flutter pub run dart_apitool:main extract --input . --output api_current.json --force-use-flutter
 
 # Generate filtered API format
 echo "🎯 Generating API format..."
 dart run scripts/filter_api.dart api_current.json > customerio-flutter.api
+
+# Verify the API file was created
+if [ ! -f customerio-flutter.api ]; then
+    echo "❌ Error: Failed to generate customerio-flutter.api"
+    rm -f api_current.json
+    exit 1
+fi
+
 echo "✅ API saved to customerio-flutter.api"
 
 # Clean up temporary files

--- a/scripts/filter_api.dart
+++ b/scripts/filter_api.dart
@@ -146,7 +146,15 @@ String generateSummary(Map<String, dynamic> filtered) {
   final buffer = StringBuffer();
   final classes = filtered['classes'] as List<dynamic>;
 
-  for (final cls in classes) {
+  // Sort classes alphabetically by name for deterministic output
+  final sortedClasses = List<dynamic>.from(classes);
+  sortedClasses.sort((a, b) {
+    final nameA = (a as Map<String, dynamic>)['name'] as String;
+    final nameB = (b as Map<String, dynamic>)['name'] as String;
+    return nameA.compareTo(nameB);
+  });
+
+  for (final cls in sortedClasses) {
     final clsMap = cls as Map<String, dynamic>;
     final methods = clsMap['methods'] as List<dynamic>;
     final properties = clsMap['properties'] as List<dynamic>;
@@ -158,6 +166,9 @@ String generateSummary(Map<String, dynamic> filtered) {
     // Handle constructors - keep original constructor names and types
     final constructors =
         methods.where((m) => m['type'] == 'constructor').toList();
+    // Sort constructors alphabetically
+    constructors
+        .sort((a, b) => (a['name'] as String).compareTo(b['name'] as String));
     for (final constructor in constructors) {
       final constructorName = constructor['name'];
       final returnType = constructor['returnType'];
@@ -172,6 +183,9 @@ String generateSummary(Map<String, dynamic> filtered) {
     // Handle regular methods - keep original method names and types
     final nonConstructors =
         methods.where((m) => m['type'] != 'constructor').toList();
+    // Sort methods alphabetically
+    nonConstructors
+        .sort((a, b) => (a['name'] as String).compareTo(b['name'] as String));
     for (final method in nonConstructors) {
       final methodName = method['name'];
       final returnType = method['returnType']; // Keep original type
@@ -185,7 +199,11 @@ String generateSummary(Map<String, dynamic> filtered) {
     }
 
     // Handle properties - keep original property names and types
-    for (final property in properties) {
+    // Sort properties alphabetically
+    final sortedProperties = List<dynamic>.from(properties);
+    sortedProperties
+        .sort((a, b) => (a['name'] as String).compareTo(b['name'] as String));
+    for (final property in sortedProperties) {
       final propName = property['name'];
       final propType = property['type']; // Keep original type
       final isStatic = property['isStatic'] == true;


### PR DESCRIPTION
Closes: [MBL-1294](https://linear.app/customerio/issue/MBL-1294/flutter-automate-public-api-breaking-changes)

This PR introduces automated API change detection to prevent accidental breaking changes to the public API surface.

### Key Changes
✅ New CI Workflow
- Replaces manual API extraction with automated change detection
- Fails CI if public API changes are detected without updating baseline
- Uses local dev dependencies for reproducible builds

✅ Enhanced Scripts
- `check_api_changes.sh`: New script that compares current API against baseline
- `extract_api.sh`: Updated with error handling and local dependency usage
- `filter_api.dart`: Added alphabetical sorting for deterministic output across environments

✅ Dependency Management
- Moved dart_apitool from global to dev dependency in pubspec.yaml
- Eliminates need for manual global package installation
- Version-locked for consistent results

### Benefits
- Prevents breaking changes: CI fails if API surface changes unexpectedly
- Reproducible builds: Local dependencies ensure consistent results across environments
- Clear workflow: Developers know exactly when and how to update API baseline
- Better maintainability: Single source of truth for API extraction logic

### Usage
When making intentional API changes, update the baseline:
```bash
bash ./scripts/extract_api.sh
```