### PR TITLE
feat: inline message placeholder

### DIFF
--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/FlutterInlineInAppMessageView.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/FlutterInlineInAppMessageView.kt
@@ -2,7 +2,6 @@ package io.customer.customer_io.messaginginapp
 
 import android.content.Context
 import android.util.AttributeSet
-import android.util.Log
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
 import io.customer.messaginginapp.type.InAppMessage
@@ -52,5 +51,11 @@ class FlutterInlineInAppMessageView @JvmOverloads constructor(
         post {
             platformDelegate.dispatchEventPublic("onAction", payload)
         }
+    }
+
+    // Override onDetachedFromWindow as it is protected in base class and needs to be public
+    // to be from Flutter view lifecycle.
+    public override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
     }
 }

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/FlutterInlineInAppMessageView.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/FlutterInlineInAppMessageView.kt
@@ -52,10 +52,4 @@ class FlutterInlineInAppMessageView @JvmOverloads constructor(
             platformDelegate.dispatchEventPublic("onAction", payload)
         }
     }
-
-    // Override onDetachedFromWindow as it is protected in base class and needs to be public
-    // to be from Flutter view lifecycle.
-    public override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-    }
 }

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/InlineInAppMessagePlatformView.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/InlineInAppMessagePlatformView.kt
@@ -69,7 +69,6 @@ class InlineInAppMessagePlatformView(
     override fun getView(): View = inlineView
 
     override fun dispose() {
-        inlineView.onDetachedFromWindow()
         methodChannel.setMethodCallHandler(null)
     }
 
@@ -77,7 +76,7 @@ class InlineInAppMessagePlatformView(
         when (call.method) {
             "setElementId" -> call.native(result, { it as? String }, ::setElementId)
             "getElementId" -> call.native(result, { Unit }, { getElementId() })
-            "cleanup" -> call.native(result, { Unit }, { dispose() })
+            "cleanup" -> call.native(result, { Unit }, {  })
             else -> result.notImplemented()
         }
     }

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/InlineInAppMessagePlatformView.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/InlineInAppMessagePlatformView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.view.View
-import android.view.ViewGroup
 import io.customer.customer_io.bridge.native
 import io.customer.sdk.core.util.Logger
 import io.customer.sdk.core.di.SDKComponent
@@ -70,6 +69,7 @@ class InlineInAppMessagePlatformView(
     override fun getView(): View = inlineView
 
     override fun dispose() {
+        inlineView.onDetachedFromWindow()
         methodChannel.setMethodCallHandler(null)
     }
 
@@ -77,6 +77,7 @@ class InlineInAppMessagePlatformView(
         when (call.method) {
             "setElementId" -> call.native(result, { it as? String }, ::setElementId)
             "getElementId" -> call.native(result, { Unit }, { getElementId() })
+            "cleanup" -> call.native(result, { Unit }, { dispose() })
             else -> result.notImplemented()
         }
     }

--- a/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
+++ b/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
@@ -20,6 +20,7 @@ class InlineMessagesScreen extends StatelessWidget {
           InlineInAppMessageView(
             elementId: 'sticky-header',
             // Fixed height emptyStateView example
+            emptyStateViewMinHeight: 60,
             emptyStateView: Container(
               height: 60,
               decoration: BoxDecoration(

--- a/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
+++ b/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
@@ -19,6 +19,20 @@ class InlineMessagesScreen extends StatelessWidget {
           // Sticky Header Inline Message
           InlineInAppMessageView(
             elementId: 'sticky-header',
+            // Fixed height emptyStateView example
+            emptyStateView: Container(
+              height: 60,
+              decoration: BoxDecoration(
+                color: Colors.blue[100],
+                border: Border.all(color: Colors.blue[300]!),
+              ),
+              child: const Center(
+                child: Text(
+                  'Element ID: sticky-header',
+                  style: TextStyle(color: Colors.blue),
+                ),
+              ),
+            ),
             onActionClick: _showInlineActionClick,
           ),
           Expanded(
@@ -29,13 +43,30 @@ class InlineMessagesScreen extends StatelessWidget {
                   _buildImageAndTextBlock(),
                   _buildFullWidthCard(),
                   _buildThreeColumnRow(),
+                  const SizedBox(height: 16),
                   InlineInAppMessageView(
                     elementId: 'inline',
+                    // Dynamic height emptyStateView example
+                    emptyStateView: Container(
+                      decoration: BoxDecoration(
+                        color: Colors.green[100],
+                        borderRadius: BorderRadius.circular(8),
+                        border: Border.all(color: Colors.green[300]!),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      child: const Center(
+                        child: Text(
+                          'Element ID: inline',
+                          style: TextStyle(color: Colors.green),
+                        ),
+                      ),
+                    ),
                     onActionClick: _showInlineActionClick,
                   ),
                   _buildImageAndTextBlock(),
                   _buildFullWidthCard(),
                   _buildThreeColumnRow(),
+                  const SizedBox(height: 16),
                   InlineInAppMessageView(
                     elementId: 'below-fold',
                     onActionClick: _showInlineActionClick,

--- a/apps/amiapp_flutter/pubspec.lock
+++ b/apps/amiapp_flutter/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.4.2"
   dbus:
     dependency: transitive
     description:

--- a/lib/messaging_in_app/inline_in_app_message_view.dart
+++ b/lib/messaging_in_app/inline_in_app_message_view.dart
@@ -191,17 +191,27 @@ class _InlineInAppMessageViewState extends State<InlineInAppMessageView> {
           ),
         ),
         // Overlay empty state on top when no message content is available
-        // Uses AnimatedOpacity for smooth transitions between states
-        AnimatedOpacity(
-          opacity: shouldShowEmptyState ? 1.0 : 0.0,
-          duration: _InlineMessageConstants.animationDuration,
-          curve: Curves.easeOut,
-          child: IgnorePointer(
-            // Disable touch events on empty state when it's not visible
-            ignoring: !shouldShowEmptyState,
-            child: emptyStateView,
-          ),
-        ),
+        if (emptyStateView != null)
+          // Uses animated views for smooth transitions between states
+          AnimatedSize(
+            duration: _InlineMessageConstants.animationDuration,
+            curve: Curves.easeOut,
+            child: AnimatedSwitcher(
+              duration: _InlineMessageConstants.animationDuration,
+              switchInCurve: Curves.easeOut,
+              switchOutCurve: Curves.easeOut,
+              transitionBuilder: (Widget child, Animation<double> animation) {
+                return FadeTransition(
+                  opacity: animation,
+                  child: child,
+                );
+              },
+              child: shouldShowEmptyState ? KeyedSubtree(
+                key: ValueKey('emptyStateView-${widget.elementId}'),
+                child: emptyStateView!,
+              ) : const SizedBox.shrink(),
+            ),
+          )
       ],
     );
   }

--- a/lib/messaging_in_app/inline_in_app_message_view.dart
+++ b/lib/messaging_in_app/inline_in_app_message_view.dart
@@ -220,7 +220,7 @@ class _InlineInAppMessageViewState extends State<InlineInAppMessageView> {
                   // Show empty state widget when no message content available
                   ? KeyedSubtree(
                       key: ValueKey('emptyStateView-${widget.elementId}'),
-                      child: emptyStateView!,
+                      child: emptyStateView,
                     )
                   // Reserve minimum height space when content is present to prevent layout shifts
                   : emptyStateViewMinHeight != null


### PR DESCRIPTION
closes: [MBL-1312](https://linear.app/customerio/issue/MBL-1312/allow-custom-sizing-for-empthy-inlineinappmessageview-widgets)

### Changes

- Added `emptyStateView` parameter to `InlineInAppMessageView` for custom empty state widgets
- Platform view always renders in background for proper initialization, empty state overlays when no content available
- Uses `AnimatedOpacity` for seamless state changes between empty and content states
- Added sample empty state implementations with different styling approaches
- Fixed missing `cleanup` method call on Android and added empty implementation to fix the error

### Testing

- Run example app
- Navigate to Inline Messages screen
- Verify:
  - Inline messages without empty states should be unaffected
  - Inline messages with empty states should show the provided widget when no content is available
  - Empty states should smoothly fade out when messages appear and fade back in when messages disappear
  - Following warning should not appear after fixing the `cleanup` method call

```
Unexpected error invoking cleanup: MissingPluginException(No implementation found for method cleanup on channel customer_io_inline_view_3)
```

### Example Usage

```dart
InlineInAppMessageView(
  elementId: 'banner-message',
  emptyStateView: Container(
    padding: EdgeInsets.all(16),
    child: Text('No messages available'),
  ),
  onActionClick: (message, actionValue, actionName) {
    // Handle message actions
  },
)
```

### Notes

- Platform view remains initialized even when showing empty state, ensuring messages can appear immediately when available
- Empty state only shows when no message content is present (`height` ≤ `1.0`)
- Existing implementations without emptyStateView work unchanged

### Screenshots

<img width="1080" height="2400" alt="Screenshot_20250731_183434" src="https://github.com/user-attachments/assets/0fa8df7a-b930-4aeb-82da-055bba1d65fe" />