### PR TITLE
fix: prevent displaying inline when no content available

### DIFF
--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/FlutterInlineInAppMessageView.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/FlutterInlineInAppMessageView.kt
@@ -2,7 +2,6 @@ package io.customer.customer_io.messaginginapp
 
 import android.content.Context
 import android.util.AttributeSet
-import android.util.Log
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
 import io.customer.messaginginapp.type.InAppMessage

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/InlineInAppMessagePlatformView.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/InlineInAppMessagePlatformView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.view.View
-import android.view.ViewGroup
 import io.customer.customer_io.bridge.native
 import io.customer.sdk.core.util.Logger
 import io.customer.sdk.core.di.SDKComponent
@@ -77,6 +76,7 @@ class InlineInAppMessagePlatformView(
         when (call.method) {
             "setElementId" -> call.native(result, { it as? String }, ::setElementId)
             "getElementId" -> call.native(result, { Unit }, { getElementId() })
+            "cleanup" -> call.native(result, { Unit }, {  })
             else -> result.notImplemented()
         }
     }

--- a/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
+++ b/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
@@ -29,6 +29,7 @@ class InlineMessagesScreen extends StatelessWidget {
                   _buildImageAndTextBlock(),
                   _buildFullWidthCard(),
                   _buildThreeColumnRow(),
+                  const SizedBox(height: 16),
                   InlineInAppMessageView(
                     elementId: 'inline',
                     onActionClick: _showInlineActionClick,
@@ -36,6 +37,7 @@ class InlineMessagesScreen extends StatelessWidget {
                   _buildImageAndTextBlock(),
                   _buildFullWidthCard(),
                   _buildThreeColumnRow(),
+                  const SizedBox(height: 16),
                   InlineInAppMessageView(
                     elementId: 'below-fold',
                     onActionClick: _showInlineActionClick,

--- a/apps/amiapp_flutter/pubspec.lock
+++ b/apps/amiapp_flutter/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.4.2"
   dbus:
     dependency: transitive
     description:


### PR DESCRIPTION
closes: [MBL-1312](https://linear.app/customerio/issue/MBL-1312/allow-custom-sizing-for-empthy-inlineinappmessageview-widgets)

### Summary

The PR addresses the issue where inline message views would still occupy space in the layout even when no content was available, which could cause unwanted visual artifacts and layout problems. The[ `Offstage` widget](https://api.flutter.dev/flutter/widgets/Offstage-class.html) ensures the view is completely removed from the render tree when empty.

### Changes

- Modified `InlineInAppMessageView` to use `Offstage` widget to completely hide the view when no message content is available (`height ≤ 1.0`)
- Added spacing between inline message views for better visual separation in example app
- Added empty implementation for missing `cleanup` method to platform view method channel in Android. Following warning should not appear now:

```
Unexpected error invoking cleanup: MissingPluginException(No implementation found for method cleanup on channel customer_io_inline_view_3)
```

### Testing

- Verify inline message views are completely hidden when no content is available
- Test that views properly show/hide with animated transitions when content becomes available/unavailable
- Confirm no layout shifts or rendering issues occur during state transitions