### PR TITLE
feat: support for xcode 26

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,4 +43,4 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 3.11.0
+        native_sdk_version: 3.13.1


### PR DESCRIPTION
part of: [MBL-1383](https://linear.app/customerio/issue/MBL-1383/build-issues-on-xcode-26-beta)

### Summary

Upgraded native iOS SDK from `3.11.0` to `3.13.1` which includes following updates:

- Sticky session queue support
- Public API alignment
- Xcode 16 beta fixes
- Fixed deep link issues with FCM when using `CioAppDelegateWrapper`