### PR TITLE
fix: Upgrade Android compileSdk to 34

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'io.customer.customer_io'
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/apps/amiapp_flutter/android/app/build.gradle
+++ b/apps/amiapp_flutter/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
 
     defaultConfig {
         applicationId "io.customer.amiapp_flutter"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/apps/amiapp_flutter/pubspec.lock
+++ b/apps/amiapp_flutter/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.5.0"
+    version: "2.6.0"
   dbus:
     dependency: transitive
     description:


### PR DESCRIPTION
Upgrade Android compileSdk to 34 to avoid compilation errors for customers using latest versions of dependencies targeting Android 36