### PR TITLE
chore: Implement tabbed inline view to enable testing inline bug

### DIFF
--- a/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
+++ b/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
@@ -5,46 +5,93 @@ import 'package:flutter/material.dart';
 
 import '../components/container.dart';
 
-class InlineMessagesScreen extends StatelessWidget {
+class InlineMessagesScreen extends StatefulWidget {
   const InlineMessagesScreen({super.key});
+
+  @override
+  State<InlineMessagesScreen> createState() => _InlineMessagesScreenState();
+}
+
+class _InlineMessagesScreenState extends State<InlineMessagesScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return AppContainer(
       appBar: AppBar(
         title: const Text('Inline Message Test'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Single View'),
+            Tab(text: 'Multiple Views'),
+          ],
+        ),
       ),
-      body: Column(
+      body: TabBarView(
+        controller: _tabController,
         children: [
-          // Sticky Header Inline Message
+          _buildSingleViewTab(),
+          _buildMultipleViewsTab(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSingleViewTab() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        children: [
           InlineInAppMessageView(
-            elementId: 'sticky-header',
+            elementId: 'single-inline',
             onActionClick: _showInlineActionClick,
           ),
-          Expanded(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                children: [
-                  _buildImageAndTextBlock(),
-                  _buildFullWidthCard(),
-                  _buildThreeColumnRow(),
-                  const SizedBox(height: 16),
-                  InlineInAppMessageView(
-                    elementId: 'inline',
-                    onActionClick: _showInlineActionClick,
-                  ),
-                  _buildImageAndTextBlock(),
-                  _buildFullWidthCard(),
-                  _buildThreeColumnRow(),
-                  const SizedBox(height: 16),
-                  InlineInAppMessageView(
-                    elementId: 'below-fold',
-                    onActionClick: _showInlineActionClick,
-                  ),
-                ],
-              ),
-            ),
+          const SizedBox(height: 16),
+          _buildImageAndTextBlock(),
+          _buildFullWidthCard(),
+          _buildThreeColumnRow(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMultipleViewsTab() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        children: [
+          InlineInAppMessageView(
+            elementId: 'multi-top',
+            onActionClick: _showInlineActionClick,
+          ),
+          const SizedBox(height: 16),
+          _buildImageAndTextBlock(),
+          _buildFullWidthCard(),
+          const SizedBox(height: 16),
+          InlineInAppMessageView(
+            elementId: 'multi-middle',
+            onActionClick: _showInlineActionClick,
+          ),
+          const SizedBox(height: 16),
+          _buildThreeColumnRow(),
+          const SizedBox(height: 16),
+          InlineInAppMessageView(
+            elementId: 'multi-bottom',
+            onActionClick: _showInlineActionClick,
           ),
         ],
       ),

--- a/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
+++ b/apps/amiapp_flutter/lib/src/screens/inline_messages.dart
@@ -56,6 +56,38 @@ class _InlineMessagesScreenState extends State<InlineMessagesScreen>
       padding: const EdgeInsets.all(16),
       child: Column(
         children: [
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            margin: const EdgeInsets.only(bottom: 16),
+            decoration: BoxDecoration(
+              color: Colors.blue[50],
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: Colors.blue[200]!),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Element IDs in this tab:',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.blue[800],
+                    fontSize: 14,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '• single-inline',
+                  style: TextStyle(
+                    color: Colors.blue[700],
+                    fontSize: 13,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+              ],
+            ),
+          ),
           InlineInAppMessageView(
             elementId: 'single-inline',
             onActionClick: _showInlineActionClick,
@@ -74,6 +106,38 @@ class _InlineMessagesScreenState extends State<InlineMessagesScreen>
       padding: const EdgeInsets.all(16),
       child: Column(
         children: [
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            margin: const EdgeInsets.only(bottom: 16),
+            decoration: BoxDecoration(
+              color: Colors.green[50],
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: Colors.green[200]!),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Element IDs in this tab:',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.green[800],
+                    fontSize: 14,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '• multi-top\n• multi-middle\n• multi-bottom',
+                  style: TextStyle(
+                    color: Colors.green[700],
+                    fontSize: 13,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+              ],
+            ),
+          ),
           InlineInAppMessageView(
             elementId: 'multi-top',
             onActionClick: _showInlineActionClick,

--- a/apps/amiapp_flutter/pubspec.lock
+++ b/apps/amiapp_flutter/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.6.0"
+    version: "2.6.1"
   dbus:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR adds tabs to inline screen to showcase bug inline being dismissed when switching tabs without being dismissed


https://github.com/user-attachments/assets/3a314604-a22b-4a1a-8920-7688b2952049


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a tabbed UI to `InlineMessagesScreen` (single vs multiple inline message views) and upgrades `customer_io` to 2.6.1.
> 
> - **UI (`apps/amiapp_flutter/lib/src/screens/inline_messages.dart`)**:
>   - Convert `InlineMessagesScreen` to `StatefulWidget` with `TabController` and `TabBar`/`TabBarView` (tabs: `Single View`, `Multiple Views`).
>   - `Single View` tab: one `InlineInAppMessageView` with `elementId` `single-inline`, plus content sections.
>   - `Multiple Views` tab: three `InlineInAppMessageView` instances (`multi-top`, `multi-middle`, `multi-bottom`).
>   - Remove previous layout and element IDs (`sticky-header`, `inline`, `below-fold`).
> - **Dependencies**:
>   - Update `customer_io` from `2.6.0` to `2.6.1` in `apps/amiapp_flutter/pubspec.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43c2223adacb819995d043d9c4fb7a32ea48f3ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->