### PR TITLE
feat: Upgrade Kotlin and AGP versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'io.customer.customer_io'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '2.1.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.1'
+        classpath 'com.android.tools.build:gradle:8.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -60,7 +60,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.7.1"
+    def cioVersion = "4.10.1"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/apps/amiapp_flutter/android/app/build.gradle
+++ b/apps/amiapp_flutter/android/app/build.gradle
@@ -13,13 +13,13 @@ android {
     compileOptions {
         // Flag to enable support for the new language APIs
         coreLibraryDesugaringEnabled true
-        // Sets Java compatibility to Java 8
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        // Sets Java compatibility to Java 17
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {
@@ -73,7 +73,7 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.21"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.1.21"
     // Required for flutter_local_notifications, see more:
     // https://pub.dev/packages/flutter_local_notifications#gradle-setup
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'

--- a/apps/amiapp_flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/amiapp_flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip

--- a/apps/amiapp_flutter/android/settings.gradle
+++ b/apps/amiapp_flutter/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.1" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "com.android.application" version "8.6.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.21" apply false
     id "com.google.gms.google-services" version "4.3.15" apply false
 }
 

--- a/apps/amiapp_flutter/pubspec.lock
+++ b/apps/amiapp_flutter/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.6.0"
+    version: "2.6.1"
   dbus:
     dependency: transitive
     description:


### PR DESCRIPTION
To better align with our Android Native SDK

### This PR upgrades these versions
- Android Gradle Plugin (AGP): Updated from 8.3.1 → 8.6.1
    - Updated in /android/build.gradle

- Kotlin Version: Updated from 1.7.21 → 2.1.21
    - Updated in /android/build.gradle (ext.kotlin_version)
    - Updated in /apps/amiapp_flutter/android/app/build.gradle (kotlin-stdlib-jdk7 dependency)

- Gradle Wrapper: Updated from 8.4 → 8.7 (required for AGP 8.6.1 compatibility)
    - Updated in /android/gradle/wrapper/gradle-wrapper.properties
    - Updated in /apps/amiapp_flutter/android/gradle/wrapper/gradle-wrapper.properties

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades build tooling (Kotlin 2.1.21, AGP 8.6.1, Gradle 8.7), sets Java/Kotlin 17 in the Flutter Android app, and bumps Customer.io SDKs (Android 4.10.1, Flutter plugin 2.6.1).
> 
> - **Build Tooling**:
>   - Kotlin updated to `2.1.21` (`android/build.gradle`, Flutter app stdlib).
>   - Android Gradle Plugin to `8.6.1` (`android/build.gradle`, `apps/amiapp_flutter/android/settings.gradle`).
>   - Gradle Wrapper to `8.7` (`android/gradle/wrapper/gradle-wrapper.properties`, `apps/amiapp_flutter/android/gradle/wrapper/gradle-wrapper.properties`).
> - **Android Library (`android/build.gradle`)**:
>   - Customer.io Android SDK version bumped from `4.7.1` → `4.10.1` for `datapipelines`, `messaging-push-fcm`, `messaging-in-app`.
> - **Flutter Android App**:
>   - Java compatibility set to `17` and Kotlin `jvmTarget` to `17` (`apps/amiapp_flutter/android/app/build.gradle`).
>   - Kotlin stdlib updated to `2.1.21`; AGP/Kotlin plugin versions aligned in `settings.gradle`.
> - **Dart/Flutter Deps**:
>   - `pubspec.lock`: `customer_io` plugin bumped `2.6.0` → `2.6.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7ed6d528621a41ef57f6872421894a63416e258. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->