### PR TITLE
feat: Upgrade to latest Native Android SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,7 +60,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.10.1"
+    def cioVersion = "4.11.0"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/apps/amiapp_flutter/android/app/build.gradle
+++ b/apps/amiapp_flutter/android/app/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace 'io.customer.amiapp_flutter'
-    compileSdkVersion 34
+    compileSdkVersion 35
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/apps/amiapp_flutter/pubspec.lock
+++ b/apps/amiapp_flutter/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "2.6.1"
+    version: "2.7.0"
   dbus:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR brings the improvement to push delivery we had done for [Android](https://github.com/customerio/customerio-android/releases/tag/4.11.0) to the Flutter SDK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Customer.io Android SDK to 4.11.0, raise Flutter app compileSdk to 35, and update `customer_io` lock to 2.7.0.
> 
> - **Android SDK**:
>   - Bump `io.customer.android` dependencies to `4.11.0` via `cioVersion` in `android/build.gradle`.
> - **Flutter example app (Android)**:
>   - Increase `compileSdkVersion` to `35` in `apps/amiapp_flutter/android/app/build.gradle`.
> - **Flutter dependencies**:
>   - Update locked `customer_io` package to `2.7.0` in `apps/amiapp_flutter/pubspec.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b1612506a82b8419fc9d54deac3118ebe63b669. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->