### PR TITLE
Add web support to Customer IO 3.X.X

### DIFF
--- a/customerio-flutter.api
+++ b/customerio-flutter.api
@@ -44,6 +44,7 @@ public final class CustomerIO {
 public final class CustomerIOConfig {
 	public fun new(
 		required String cdpApiKey,
+		String? jsKey,
 		String? migrationSiteId,
 		Region? region,
 		CioLogLevel? logLevel,
@@ -63,6 +64,7 @@ public final class CustomerIOConfig {
 	public val cdnHost: String?;
 	public val cdpApiKey: String;
 	public val flushAt: int?;
+	public val jsKey: String?;
 	public val flushInterval: int?;
 	public val inAppConfig: InAppConfig?;
 	public val logLevel: CioLogLevel?;
@@ -233,5 +235,4 @@ public final class ScreenView {
 	static public val inApp: ScreenView;
 	static public val values: List<ScreenView>;
 }
-
 

--- a/lib/config/customer_io_config.dart
+++ b/lib/config/customer_io_config.dart
@@ -8,6 +8,7 @@ class CustomerIOConfig {
   final String version = plugin_info.version;
 
   final String cdpApiKey;
+  final String? jsKey;
   final String? migrationSiteId;
   final Region? region;
   final CioLogLevel? logLevel;
@@ -23,6 +24,7 @@ class CustomerIOConfig {
 
   CustomerIOConfig({
     required this.cdpApiKey,
+    this.jsKey,
     this.migrationSiteId,
     this.region,
     this.logLevel,
@@ -38,7 +40,7 @@ class CustomerIOConfig {
   }) : pushConfig = pushConfig ?? PushConfig();
 
   Map<String, dynamic> toMap() {
-    return {
+    final map = {
       'cdpApiKey': cdpApiKey,
       'migrationSiteId': migrationSiteId,
       'region': region?.name,
@@ -55,5 +57,11 @@ class CustomerIOConfig {
       'version': version,
       'source': source
     };
+
+    if (jsKey != null) {
+      map['jsKey'] = jsKey;
+    }
+
+    return map;
   }
 }

--- a/lib/customer_io_web.dart
+++ b/lib/customer_io_web.dart
@@ -1,0 +1,211 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'package:js/js.dart';
+
+import 'package:customer_io/customer_io_config.dart';
+import 'package:customer_io/customer_io_enums.dart';
+import 'package:customer_io/data_pipelines/customer_io_platform_interface.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+@JS('window')
+external JSObject get _window;
+
+@JS('Function')
+external Object _jsFunctionConstructor(String code);
+
+class CustomerIOWebPlugin extends CustomerIOPlatform {
+  String? _currentUserId;
+  late final CustomerIOConfig _config;
+
+  static void registerWith(Registrar registrar) {
+    CustomerIOPlatform.instance = CustomerIOWebPlugin();
+  }
+
+  void _injectAnalyticsSnippet(String key) {
+    try {
+      final has = _window.has('cioanalytics');
+      if (has) return;
+    } catch (_) {}
+
+    final snippet = '''
+      !(function () {
+        var i = "cioanalytics",
+          analytics = (window[i] = window[i] || []);
+        if (!analytics.initialize)
+          if (analytics.invoked)
+            window.console &&
+              console.error &&
+              console.error("Snippet included twice.");
+          else {
+            analytics.invoked = !0;
+            analytics.methods = [
+              "trackSubmit",
+              "trackClick",
+              "trackLink",
+              "trackForm",
+              "pageview",
+              "identify",
+              "reset",
+              "group",
+              "track",
+              "ready",
+              "alias",
+              "debug",
+              "page",
+              "once",
+              "off",
+              "on",
+              "addSourceMiddleware",
+              "addIntegrationMiddleware",
+              "setAnonymousId",
+              "addDestinationMiddleware",
+            ];
+            analytics.factory = function (e) {
+              return function () {
+                var t = Array.prototype.slice.call(arguments);
+                t.unshift(e);
+                analytics.push(t);
+                return analytics;
+              };
+            };
+            for (var e = 0; e < analytics.methods.length; e++) {
+              var key = analytics.methods[e];
+              analytics[key] = analytics.factory(key);
+            }
+            analytics.load = function (key, e) {
+              var t = document.createElement("script");
+              t.type = "text/javascript";
+              t.async = !0;
+              t.setAttribute("data-global-customerio-analytics-key", i);
+              t.src =
+                "https://cdp.customer.io/v1/analytics-js/snippet/" +
+                key +
+                "/analytics.min.js";
+              var n = document.getElementsByTagName("script")[0];
+              n.parentNode.insertBefore(t, n);
+              analytics._writeKey = key;
+              analytics._loadOptions = e;
+            };
+            analytics.SNIPPET_VERSION = "4.15.3";
+            analytics.load("$key");
+          }
+      })();
+    ''';
+
+    try {
+      final fn = _jsFunctionConstructor(snippet) as Function;
+      fn();
+    } catch (_) {
+      print('CustomerIO web: Failed to inject analytics snippet.');
+    }
+  }
+
+  JSObject get _cio {
+    if (!_window.has('cioanalytics')) {
+      _window['cioanalytics'] = <JSAny?>[].toJS;
+    }
+    return _window['cioanalytics'] as JSObject;
+  }
+
+  JSAny? _toJS(dynamic value) {
+    if (value == null) return null;
+    if (value is String) return value.toJS;
+    if (value is num) return value.toJS;
+    if (value is bool) return value.toJS;
+    if (value is List) {
+      return value.map(_toJS).toList().toJS;
+    }
+    if (value is Map<String, dynamic>) {
+      final jsObject = JSObject();
+      value.forEach((key, val) {
+        jsObject[key] = _toJS(val);
+      });
+      return jsObject;
+    }
+    return value.toString().toJS;
+  }
+
+  void _callCio(String method, [List<dynamic>? args]) {
+    final List<JSAny?> payload = [method.toJS];
+    if (args != null && args.isNotEmpty) {
+      payload.addAll(args.map(_toJS));
+    }
+
+    _cio.callMethod('push'.toJS, payload.toJS);
+  }
+
+  @override
+  Future<void> initialize({required CustomerIOConfig config}) async {
+    _config = config;
+    final key = _config.jsKey ?? '';
+    if (key.isEmpty) {
+      print(
+          'CustomerIO web: JSKey is empty. Do NOT use cdpApiKey in client-side code.');
+    }
+    _injectAnalyticsSnippet(key);
+  }
+
+  @override
+  void identify(
+      {required String userId, Map<String, dynamic> traits = const {}}) {
+    _currentUserId = userId;
+
+    if (traits.isEmpty) {
+      _callCio('identify', [userId]);
+    } else {
+      _callCio('identify', [userId, traits]);
+    }
+  }
+
+  @override
+  void clearIdentify() {
+    _currentUserId = null;
+    _callCio('reset', const []);
+  }
+
+  @override
+  void track(
+      {required String name, Map<String, dynamic> properties = const {}}) {
+    if (properties.isEmpty) {
+      _callCio('track', [name]);
+    } else {
+      _callCio('track', [name, properties]);
+    }
+  }
+
+  @override
+  void screen(
+      {required String title, Map<String, dynamic> properties = const {}}) {
+    if (properties.isEmpty) {
+      _callCio('page', [title]);
+    } else {
+      _callCio('page', [title, properties]);
+    }
+  }
+
+  @override
+  void trackMetric(
+      {required String deliveryID,
+      required String deviceToken,
+      required MetricEvent event}) {}
+
+  @override
+  void deleteDeviceToken() {}
+
+  @override
+  void registerDeviceToken({required String deviceToken}) {}
+
+  @override
+  void setDeviceAttributes({required Map<String, dynamic> attributes}) {
+    if (_currentUserId != null) {
+      identify(userId: _currentUserId!, traits: attributes);
+    }
+  }
+
+  @override
+  void setProfileAttributes({required Map<String, dynamic> attributes}) {
+    if (_currentUserId != null) {
+      identify(userId: _currentUserId!, traits: attributes);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,9 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
+  flutter_web_plugins:
+    sdk: flutter
+  js: ^0.6.5
 
 dev_dependencies:
   flutter_test:
@@ -44,3 +47,6 @@ flutter:
       ios:
         pluginClass: CustomerIOPlugin
         native_sdk_version: 3.14.0
+      web:
+        pluginClass: CustomerIOWebPlugin
+        fileName: customer_io_web.dart

--- a/test/customer_io_config_test.dart
+++ b/test/customer_io_config_test.dart
@@ -11,6 +11,7 @@ void main() {
       final config = CustomerIOConfig(cdpApiKey: 'testApiKey');
 
       expect(config.cdpApiKey, 'testApiKey');
+      expect(config.jsKey, isNull);
       expect(config.migrationSiteId, isNull);
       expect(config.region, isNull);
       expect(config.logLevel, isNull);
@@ -43,6 +44,7 @@ void main() {
 
       final config = CustomerIOConfig(
         cdpApiKey: 'testApiKey',
+        jsKey: 'webKey',
         migrationSiteId: 'testMigrationSiteId',
         region: Region.us,
         logLevel: CioLogLevel.debug,
@@ -57,6 +59,7 @@ void main() {
       );
 
       expect(config.cdpApiKey, 'testApiKey');
+      expect(config.jsKey, 'webKey');
       expect(config.migrationSiteId, 'testMigrationSiteId');
       expect(config.region, Region.us);
       expect(config.logLevel, CioLogLevel.debug);
@@ -81,6 +84,7 @@ void main() {
 
       final config = CustomerIOConfig(
         cdpApiKey: 'testApiKey',
+        jsKey: 'webKey',
         migrationSiteId: 'testMigrationSiteId',
         region: Region.eu,
         logLevel: CioLogLevel.info,
@@ -98,6 +102,7 @@ void main() {
       final expectedMap = {
         'cdpApiKey': 'testApiKey',
         'migrationSiteId': 'testMigrationSiteId',
+        'jsKey': 'webKey',
         'region': 'eu',
         'logLevel': 'info',
         'autoTrackDeviceAttributes': false,
@@ -121,6 +126,13 @@ void main() {
 
       expect(config.pushConfig.pushConfigAndroid.pushClickBehavior,
           PushClickBehaviorAndroid.activityPreventRestart);
+    });
+
+    test('toMap() omits jsKey when not provided', () {
+      final config = CustomerIOConfig(cdpApiKey: 'testApiKey');
+
+      final map = config.toMap();
+      expect(map.containsKey('jsKey'), isFalse);
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a web implementation using the analytics JS snippet and introduces optional jsKey in CustomerIOConfig, with plugin registration, dependencies, and tests.
> 
> - **Web Platform**:
>   - **New `CustomerIOWebPlugin`** (`lib/customer_io_web.dart`): injects analytics JS snippet, implements `initialize` (uses `config.jsKey`), `identify`, `reset`, `track`, `page`, and attribute setters; stubs metric/device token methods.
>   - **Plugin registration**: adds web entry in `pubspec.yaml` (`plugin.platforms.web`) and dependencies `flutter_web_plugins`, `js`.
> - **Config**:
>   - Add optional `jsKey` to `CustomerIOConfig` (API + implementation) with conditional inclusion in `toMap()`.
> - **Tests**:
>   - Update/add tests to validate `jsKey` default/null behavior and presence in `toMap()` when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c38a14f2a3c8c0513659ea690d1ab5accba2cd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->