### PR TITLE
fix: Bump Android compileSdk to 36 for AndroidX compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'io.customer.customer_io'
-    compileSdkVersion 34
+    compileSdkVersion 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/apps/amiapp_flutter/android/app/build.gradle
+++ b/apps/amiapp_flutter/android/app/build.gradle
@@ -76,6 +76,13 @@ dependencies {
     // Required for flutter_local_notifications, see more:
     // https://pub.dev/packages/flutter_local_notifications#gradle-setup
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
+
+    // AndroidX dependencies explicitly declared to catch compileSdk compatibility issues early.
+    // These are transitive dependencies of the CIO SDK; keeping them up-to-date ensures
+    // our SDK's compileSdk stays compatible with the latest AndroidX requirements.
+    implementation 'androidx.core:core-ktx:1.17.0'
+    implementation 'androidx.work:work-runtime-ktx:2.10.0'
+
     // Adding customer.io android sdk dependencies so we can use them in native code
     // These are not generally needed and should be avoided
     implementation "io.customer.android:datapipelines"

--- a/apps/amiapp_flutter/pubspec.lock
+++ b/apps/amiapp_flutter/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.1.0"
   dbus:
     dependency: transitive
     description:


### PR DESCRIPTION
## Problem
The Flutter plugin was compiled against Android SDK 34, but transitive AndroidX dependencies now require higher versions:
- androidx.core:core-ktx:1.17.0 → requires compileSdk 36
- androidx.work:work-runtime-ktx:2.10.x → requires compileSdk 35

This caused build failures for apps using the latest AndroidX libraries:
```
Execution failed for task ':customer_io:checkReleaseAarMetadata'.> Dependency 'androidx.core:core-ktx:1.17.0' requires libraries and applications that  depend on it to compile against version 36 or later of the Android APIs.  :customer_io is currently compiled against android-34.
```

## Fix
Bumped `compileSdkVersion` from 34 → 36 

## Prevention
Added explicit AndroidX dependencies (core-ktx, work-runtime-ktx) to the sample app so future compatibility issues surface in CI before reaching customers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raise Android compileSdk to 36 and explicitly declare AndroidX core/work deps; bump sample app plugin version to 3.1.0.
> 
> - **Android library**:
>   - Update `compileSdkVersion` to `36` in `android/build.gradle`.
> - **Sample Flutter app (`apps/amiapp_flutter`)**:
>   - Add explicit AndroidX dependencies: `androidx.core:core-ktx:1.17.0` and `androidx.work:work-runtime-ktx:2.10.0` in `android/app/build.gradle`.
> - **Dependencies**:
>   - Bump `customer_io` plugin in `pubspec.lock` from `3.0.1` to `3.1.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a75f160206d3289ce07b351858198a4cdeee5ff7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->