### PR TITLE
chore: common permission handler for sample apps

### DIFF
--- a/apps/flutter_sample_cocoapods/android/app/build.gradle
+++ b/apps/flutter_sample_cocoapods/android/app/build.gradle
@@ -24,6 +24,7 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
+        main.java.srcDirs += '../../../shared/android'
     }
 
     // `copyFlutterAssetsRelease` task is responsible for copying the app's assets from the

--- a/apps/flutter_sample_cocoapods/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter_sample_cocoapods/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:name="${applicationName}"

--- a/apps/flutter_sample_cocoapods/android/app/src/main/kotlin/io/customer/testbed/flutter/cocoapods/MainActivity.kt
+++ b/apps/flutter_sample_cocoapods/android/app/src/main/kotlin/io/customer/testbed/flutter/cocoapods/MainActivity.kt
@@ -1,5 +1,24 @@
 package io.customer.testbed.flutter.cocoapods
 
+import io.customer.testbed.flutter.PermissionChannelHandler
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private lateinit var permissionHandler: PermissionChannelHandler
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        val channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "io.customer.testbed/permissions")
+        permissionHandler = PermissionChannelHandler(this)
+        permissionHandler.register(channel)
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        if (!permissionHandler.onRequestPermissionsResult(requestCode, permissions, grantResults)) {
+            super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        }
+    }
+}

--- a/apps/flutter_sample_cocoapods/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/flutter_sample_cocoapods/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		302D7E38295BEE78005CBB29 /* NotificationServiceExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 302D7E31295BEE78005CBB29 /* NotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		B7F5CCB42F87000000000001 /* PermissionChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -69,6 +70,7 @@
 		6615E32455EADFC1FBDD78CC /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		B7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionChannelHandler.swift; sourceTree = "<group>"; };
 		78A3A48B351662F042A03F84 /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7A6258D5F4955F2DA8E8B7E3 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				B7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -432,6 +435,7 @@
 			files = (
 				3006373429A1011F00D63963 /* Env.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				B7F5CCB42F87000000000001 /* PermissionChannelHandler.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/flutter_sample_cocoapods/ios/Runner/AppDelegate.swift
+++ b/apps/flutter_sample_cocoapods/ios/Runner/AppDelegate.swift
@@ -10,11 +10,16 @@ import CioFirebaseWrapper
 class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
 
 @objc class AppDelegate: FlutterAppDelegate {
+    private let permissionHandler = PermissionChannelHandler()
+
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
+
+        let controller = window?.rootViewController as! FlutterViewController
+        permissionHandler.register(with: controller.binaryMessenger)
         
         // Depending on the method you choose to install Firebase in your app,
         // you may need to add functions to this file, such as the following:

--- a/apps/flutter_sample_cocoapods/ios/Runner/PermissionChannelHandler.swift
+++ b/apps/flutter_sample_cocoapods/ios/Runner/PermissionChannelHandler.swift
@@ -1,0 +1,1 @@
+../../../flutter_sample_spm/ios/Runner/PermissionChannelHandler.swift

--- a/apps/flutter_sample_spm/android/app/build.gradle
+++ b/apps/flutter_sample_spm/android/app/build.gradle
@@ -24,6 +24,7 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
+        main.java.srcDirs += '../../../shared/android'
     }
 
     // `copyFlutterAssetsRelease` task is responsible for copying the app's assets from the

--- a/apps/flutter_sample_spm/android/app/src/main/kotlin/io/customer/testbed/flutter/spm/MainActivity.kt
+++ b/apps/flutter_sample_spm/android/app/src/main/kotlin/io/customer/testbed/flutter/spm/MainActivity.kt
@@ -1,5 +1,6 @@
 package io.customer.testbed.flutter.spm
 
+import io.customer.testbed.flutter.PermissionChannelHandler
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel

--- a/apps/shared/android/io/customer/testbed/flutter/PermissionChannelHandler.kt
+++ b/apps/shared/android/io/customer/testbed/flutter/PermissionChannelHandler.kt
@@ -1,4 +1,4 @@
-package io.customer.testbed.flutter.spm
+package io.customer.testbed.flutter
 
 import android.Manifest
 import android.app.Activity
@@ -11,6 +11,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+
 class PermissionChannelHandler(
     private val activity: Activity
 ) : MethodChannel.MethodCallHandler {


### PR DESCRIPTION
### Summary

Add native `PermissionChannelHandler` to the CocoaPods sample app and move the Android handler to a shared location. The CocoaPods app shares Dart source via symlink with the SPM app, which now uses a method channel for permissions instead of `permission_handler`. Without native handlers registered on both platforms, the CocoaPods app would crash with `MissingPluginException` on any permission interaction.

### Changes

#### Shared Android handler

- Move `PermissionChannelHandler.kt` from the SPM app to `apps/shared/android/` with package `io.customer.testbed.flutter`
- Add `'../../../shared/android'` to `sourceSets` in both apps' `build.gradle`
- Update both `MainActivity.kt` to import from the shared package

#### CocoaPods iOS handler

- Symlink `PermissionChannelHandler.swift` from the SPM app's `ios/Runner/`
- Register the handler in `AppDelegate.swift`
- Add file reference to `project.pbxproj`

#### Android permissions

- Add `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION` to CocoaPods app's `AndroidManifest.xml`

### Test plan

- ✅ Build and run CocoaPods sample app on iOS: verify push permission and location permission work
- ✅ Build and run CocoaPods sample app on Android: verify push permission and location permission work
- ✅ Verify SPM sample app still builds and works on both platforms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native iOS/Android permission handling and method-channel wiring, so misconfiguration could cause runtime `MissingPluginException` or incorrect permission results. Scope is limited to sample apps and build configuration changes.
> 
> **Overview**
> Adds a shared native permissions implementation so both Flutter sample apps can service `MethodChannel('io.customer.testbed/permissions')` calls without crashing.
> 
> On Android, `PermissionChannelHandler.kt` is moved into `apps/shared/android` (new package `io.customer.testbed.flutter`), both apps’ `build.gradle` include that source directory, and both `MainActivity` classes import/register the shared handler and forward `onRequestPermissionsResult`.
> 
> On iOS (CocoaPods sample), a `PermissionChannelHandler.swift` file is added via symlink and wired into the Xcode project, and `AppDelegate` now registers it with the `FlutterViewController` messenger. The CocoaPods Android manifest also adds coarse/fine location permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27f83034231907f2567908de4054a7ff696bdc7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->