### PR TITLE
chore: migrate deploy workflow to GitHub App for ruleset bypass

### DIFF
--- a/.github/workflows/tag-and-deploy.yml
+++ b/.github/workflows/tag-and-deploy.yml
@@ -17,17 +17,19 @@ jobs:
       new_release_published: ${{ steps.semantic-release.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic-release.outputs.new_release_version }}
     steps:
+      - name: 'Generate token'
+        id: generate_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.CIO_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CIO_APP_SECRET }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Install sd CLI
         uses: levibostian/setup-sd@cbdeed93d4fe03f9e36b73bb6d9e7c3c4805e1f9 # add-file-extension
-
-      - name: 'Generate token'
-        id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.CIO_APP_ID }}
-          private_key: ${{ secrets.CIO_APP_SECRET }}
 
       - name: Deploy git tag via semantic-release
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -45,7 +45,7 @@
           "lib/customer_io_plugin_version.dart",
           "android/src/main/res/values/customer_io_config.xml"
         ],
-        "message": "chore: prepare for ${nextRelease.version}\n\n${nextRelease.notes}"
+        "message": "chore: prepare for ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     [


### PR DESCRIPTION
## Overview

Prepares this repo to be locked down with a [GitHub Ruleset](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/managing-rulesets-for-a-repository) on `main` where the `cio-mobile-release` GitHub App is the only bypass actor for `git push` from the deploy workflow. Mirrors the cross-org migration off classic branch protection (see customerio-reactnative#587, customerio-android#681, customerio-ios#1044, customerio-expo-plugin#352).

## What this PR changes

1. **`actions/create-github-app-token@v3.1.1`** (SHA-pinned) replaces deprecated `tibdex/github-app-token@v2.1.0` (Node 20, archived). Uses the non-deprecated `client-id` input backed by a new `CIO_APP_CLIENT_ID` secret. Existing `CIO_APP_SECRET` (PEM) is reused as `private-key`.
2. **App token passed to `actions/checkout`** via `with.token`. This is the critical fix — without it, checkout's default `persist-credentials: true` writes `GITHUB_TOKEN` (= `github-actions[bot]`) into local git config, and the actual `git push` from `@semantic-release/git` goes out as the bot, not the App. With a ruleset active that's a guaranteed `GH013: Repository rule violations` rejection.
3. **Skip-ci directive added to the `@semantic-release/git` commit template** in `.releaserc.json`. App-installation-token pushes do **not** get GitHub's built-in `GITHUB_TOKEN` recursion guard, so without this marker the deploy workflow would self-trigger on its own release-prep commit on `main`.

## Manual steps still required (outside this PR)

1. Add repo secret `CIO_APP_CLIENT_ID` (the public `Iv23...` Client ID from the App settings page).
2. Verify `cio-mobile-release` is installed on this repo with permissions: Contents R/W, Metadata R, Pull requests R/W, Workflows R/W.
3. Create the ruleset on `main` (Settings → Rules → Rulesets → New branch ruleset). Bypass list: `cio-mobile-release` App, **Mode: Always** (not "For pull requests only"). Rules: Require PR + reviews, Require status checks, Block force pushes, Restrict deletions, Require linear history.
4. Leave the existing classic branch protection rule in place until step 5 verifies.
5. Trigger a release. Confirm push to `main` succeeds and the resulting release-prep commit shows pusher `cio-mobile-release[bot]`.
6. Remove the legacy classic branch protection rule.
7. (Optional) Delete the now-unused numeric `CIO_APP_ID` secret.

## Test plan

- [ ] Add `CIO_APP_CLIENT_ID` secret before merging
- [ ] Confirm App installation + permissions on this repo
- [ ] Merge this PR (with classic branch protection still active so existing flow stays protected)
- [ ] Watch the next release on `main`: push succeeds, pusher = `cio-mobile-release[bot]`, no recursive deploy run
- [ ] Configure the ruleset, then drop classic branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release/deploy GitHub Actions auth flow and semantic-release commit message, which can break automated tagging/publishing if the new App token or skip-ci behavior is misconfigured.
> 
> **Overview**
> Updates the `tag-and-deploy` workflow to authenticate as a GitHub App by generating an installation token via `actions/create-github-app-token` and using it for both `actions/checkout` and `GITHUB_TOKEN` during `semantic-release`, replacing the deprecated `tibdex/github-app-token` action.
> 
> Adjusts the `@semantic-release/git` release-prep commit message to include `[skip ci]` to prevent the workflow from re-triggering on its own version/changelog commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723f454db2d13b219a914e5e71aa58c0d464f9f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->