### PR TITLE
fix: update Customer.io native SDKs (iOS 4.4.3, Android 4.17.1)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.17.0"
+    def cioVersion = "4.17.1"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/apps/flutter_sample_spm/lib/src/app.dart
+++ b/apps/flutter_sample_spm/lib/src/app.dart
@@ -1,4 +1,5 @@
 import 'package:customer_io/customer_io.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -95,7 +95,7 @@ let package = Package(
         .library(name: "customer-io", targets: ["customer_io"])
     ],
     dependencies: [
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.4.1"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.4.3"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.4.1
+        native_sdk_version: 4.4.3
         firebase_wrapper_version: 1.0.0


### PR DESCRIPTION
## Summary
- Bump pinned native iOS SDK from `4.4.1` to `4.4.3` in `pubspec.yaml` (consumed by `ios/customer_io.podspec`).
- Bump pinned native Android SDK from `4.17.0` to `4.17.1` in `android/build.gradle`.

Latest releases as of 2026-05-20:
- customerio-ios: [`4.4.3`](https://github.com/customerio/customerio-ios/releases/tag/4.4.3) (2026-05-08)
- customerio-android: [`4.17.1`](https://github.com/customerio/customerio-android/releases/tag/4.17.1) (2026-05-18)

The Firebase wrapper version (`1.0.0`) is unchanged.

## Test plan
- [ ] CI: green (build + tests on both platforms)
- [ ] Sample apps resolve the new pods/AARs and launch cleanly
- [ ] Smoke-test core flows: identify, track event, in-app, push (FCM)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades pinned Customer.io iOS and Android native SDK dependencies, which can change runtime behavior for messaging/tracking even though the code changes are small.
> 
> **Overview**
> Updates the pinned Customer.io native SDK versions: **Android** from `4.17.0` to `4.17.1` in `android/build.gradle`, and **iOS** from `4.4.1` to `4.4.3` in both `ios/customer_io/Package.swift` (SPM) and `pubspec.yaml` (plugin metadata).
> 
> Also adds a missing Flutter `cupertino` import in the SPM sample app (`apps/flutter_sample_spm/lib/src/app.dart`) to support iOS-specific page transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6569d331a8ccd91070ef8aad8afa426b196b2a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->