### PR TITLE
feat: update native SDKs to iOS 4.5.0 and Android 4.18.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.17.1"
+    def cioVersion = "4.18.0"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -95,7 +95,7 @@ let package = Package(
         .library(name: "customer-io", targets: ["customer_io"])
     ],
     dependencies: [
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.4.3"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.5.0"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.4.3
+        native_sdk_version: 4.5.0
         firebase_wrapper_version: 1.0.0


### PR DESCRIPTION
## What

Bumps the pinned native Customer.io SDK versions used by the Flutter wrapper to the latest releases.

| Native SDK | Before | After |
| --- | --- | --- |
| iOS (`native_sdk_version` / `Package.swift`) | 4.4.3 | **4.5.0** |
| Android (`cioVersion`) | 4.17.1 | **4.18.0** |

iOS FCM wrapper (`firebase_wrapper_version`) stays at `1.0.0` — already the latest release.

## Why

[customerio-ios 4.5.0](https://github.com/customerio/customerio-ios/releases/tag/4.5.0) and [customerio-android 4.18.0](https://github.com/customerio/customerio-android/releases/tag/4.18.0) are the latest native releases.

## Files changed
- `pubspec.yaml` — `native_sdk_version` (consumed by the podspecs)
- `ios/customer_io/Package.swift` — pinned `customerio-ios` exact version
- `android/build.gradle` — `cioVersion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only dependency bumps with no application logic changes; residual risk is limited to upstream native SDK release notes and behavior.
> 
> **Overview**
> Bumps the **pinned native Customer.io SDK versions** the Flutter plugin pulls in on each platform, with no Dart or bridge code changes.
> 
> **Android** `cioVersion` in `android/build.gradle` moves from **4.17.1** to **4.18.0**, updating all `io.customer.android:*` artifacts (datapipelines, push FCM, in-app, and optional location).
> 
> **iOS** `native_sdk_version` in `pubspec.yaml` moves from **4.4.3** to **4.5.0** (used by CocoaPods podspecs), and `ios/customer_io/Package.swift` pins the same **4.5.0** exact release for Swift Package Manager builds. `firebase_wrapper_version` stays at **1.0.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba4caf023ca8cb4cdd53a60becb69e6c72c950a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->