### PR TITLE
chore: update native SDKs to Android 4.18.1 and iOS 4.5.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.18.0"
+    def cioVersion = "4.18.1"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -95,7 +95,7 @@ let package = Package(
         .library(name: "customer-io", targets: ["customer_io"])
     ],
     dependencies: [
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.5.0"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.5.1"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.5.0
+        native_sdk_version: 4.5.1
         firebase_wrapper_version: 1.0.0


### PR DESCRIPTION
Bumps the pinned native SDK versions to the latest releases: Android `4.18.0` → `4.18.1` and iOS `4.5.0` → `4.5.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bumps only; no Dart/Kotlin/Swift API or logic changes in this diff.
> 
> **Overview**
> Bumps the pinned Customer.io native SDK versions across the Flutter plugin: **Android** `cioVersion` in `android/build.gradle` from `4.18.0` to **`4.18.1`** (datapipelines, push FCM, in-app, and optional location), and **iOS** SPM dependency in `ios/customer_io/Package.swift` from `4.5.0` to **`4.5.1`**. **`pubspec.yaml`** `native_sdk_version` is updated to **`4.5.1`** so plugin metadata matches the iOS pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b29b36e1caa5f014bff0a4ff5930967014a3da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->