### PR TITLE
fix: update native SDKs — iOS 4.5.3 (resolve duplicate event delivery bugs) and Android 4.18.2 (scope in-app polling to process lifecycle)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.18.1"
+    def cioVersion = "4.18.2"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -95,7 +95,7 @@ let package = Package(
         .library(name: "customer-io", targets: ["customer_io"])
     ],
     dependencies: [
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.5.1"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.5.3"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.5.1
+        native_sdk_version: 4.5.3
         firebase_wrapper_version: 1.0.0


### PR DESCRIPTION
Bump bundled native SDKs to iOS 4.5.2 and Android 4.18.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only dependency bumps with no application code changes; risk is limited to upstream SDK behavior in Customer.io releases.
> 
> **Overview**
> Updates the Flutter plugin’s **bundled native SDK versions** only—no Dart/Kotlin/Swift plugin logic changes.
> 
> **Android:** `cioVersion` in `android/build.gradle` moves from **4.18.1** to **4.18.2** for `datapipelines`, `messaging-push-fcm`, `messaging-in-app`, and the optional `location` module.
> 
> **iOS:** `ios/customer_io/Package.swift` pins `customerio-ios` from **4.5.1** to **4.5.3** (`exact`). **`pubspec.yaml`** `native_sdk_version` is updated to **4.5.3** so tooling stays aligned with the SPM pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a93a592beb98a8599382b06c0ab6371d3ce5447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->