### PR TITLE
chore: add geofence module build enablement and config

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 def cioLocationEnabled = rootProject.findProperty("customerio_location_enabled")?.toBoolean() ?: false
+def cioGeofenceEnabled = rootProject.findProperty("customerio_geofence_enabled")?.toBoolean() ?: false
+// Geofence depends on the location module, so location is linked/enabled whenever either is on.
+def cioLocationLinked = cioLocationEnabled || cioGeofenceEnabled
 
 android {
     namespace 'io.customer.customer_io'
@@ -50,7 +53,8 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        buildConfigField "boolean", "CIO_LOCATION_ENABLED", "$cioLocationEnabled"
+        buildConfigField "boolean", "CIO_LOCATION_ENABLED", "$cioLocationLinked"
+        buildConfigField "boolean", "CIO_GEOFENCE_ENABLED", "$cioGeofenceEnabled"
         consumerProguardFiles 'consumer-rules.pro'
     }
 
@@ -72,11 +76,19 @@ dependencies {
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"
     // Location module is optional - customers enable it by adding
-    // customerio_location_enabled=true in their gradle.properties
-    if (cioLocationEnabled) {
+    // customerio_location_enabled=true in their gradle.properties.
+    // Geofence implies Location: enabling geofence pulls in location too.
+    if (cioLocationLinked) {
         implementation "io.customer.android:location:$cioVersion"
     } else {
         compileOnly "io.customer.android:location:$cioVersion"
+    }
+    // Geofence module is optional - customers enable it by adding
+    // customerio_geofence_enabled=true in their gradle.properties
+    if (cioGeofenceEnabled) {
+        implementation "io.customer.android:geofence:$cioVersion"
+    } else {
+        compileOnly "io.customer.android:geofence:$cioVersion"
     }
     
     testImplementation 'junit:junit:4.13.2'

--- a/customerio-flutter.api
+++ b/customerio-flutter.api
@@ -58,7 +58,8 @@ public final class CustomerIOConfig {
 		ScreenView? screenViewUse,
 		InAppConfig? inAppConfig,
 		PushConfig? pushConfig,
-		LocationConfig? locationConfig
+		LocationConfig? locationConfig,
+		GeofenceConfig? geofenceConfig
 	): CustomerIOConfig;
 	public fun toMap(): Map<String, dynamic>;
 	public val apiHost: String?;
@@ -67,6 +68,7 @@ public final class CustomerIOConfig {
 	public val cdpApiKey: String;
 	public val flushAt: int?;
 	public val flushInterval: int?;
+	public val geofenceConfig: GeofenceConfig?;
 	public val inAppConfig: InAppConfig?;
 	public val locationConfig: LocationConfig?;
 	public val logLevel: CioLogLevel?;
@@ -151,6 +153,11 @@ public final class EventType {
 	static public val messageDismissed: EventType;
 	static public val messageShown: EventType;
 	static public val values: List<EventType>;
+}
+
+public final class GeofenceConfig {
+	public fun new(): GeofenceConfig;
+	public fun toMap(): Map<String, dynamic>;
 }
 
 public final class InAppConfig {

--- a/ios/customer_io.podspec
+++ b/ios/customer_io.podspec
@@ -47,6 +47,12 @@ Pod::Spec.new do |s|
     ss.dependency "CustomerIO/Location", native_sdk_version
   end
 
+  # Geofence module is optional - customers must opt in by adding this subspec.
+  # It pulls in Location transitively (CustomerIO/LocationGeofence depends on it).
+  s.subspec 'geofence' do |ss|
+    ss.dependency "CustomerIO/LocationGeofence", native_sdk_version
+  end
+
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -3,16 +3,21 @@
 import PackageDescription
 import Foundation
 
-// MARK: - Location Module Configuration
+// MARK: - Location / Geofence Module Configuration
 //
-// The Location module is optional and excluded by default.
-// To enable it, use ONE of these approaches (checked in this order):
+// The Location and Geofence modules are optional and excluded by default.
+// To enable either, use ONE of these approaches (checked in this order):
 //
 // 1. Set in your Flutter app's android/gradle.properties (recommended, works for both platforms):
 //      customerio_location_enabled=true
+//      customerio_geofence_enabled=true
 //
 // 2. Set an environment variable (required for Flutter add-to-app modules or custom project structures):
 //      CIO_LOCATION=true flutter build ios
+//      CIO_GEOFENCE=true flutter build ios
+//
+// Geofence implies Location: enabling geofence also pulls in the Location
+// module, since geofence reacts to location fixes published by it.
 //
 
 /// Reads a value for the given key from a Java-style .properties file.
@@ -52,28 +57,33 @@ func readGradleProperty(_ key: String, from startDir: String) -> String? {
     return nil
 }
 
-/// Determines whether the Location module should be included.
-/// Checks gradle.properties first (file-based, persistent), then falls back to environment variable.
-/// Returns false if no configuration is found (Location is opt-in).
-let useLocation: Bool = {
+/// Resolves a boolean opt-in flag, checking gradle.properties first (file-based, persistent),
+/// then falling back to an environment variable. Returns false if no configuration is found.
+func isModuleEnabled(gradleKey: String, envKey: String) -> Bool {
     let env = ProcessInfo.processInfo.environment
-    let key = "customerio_location_enabled"
 
     // 1. Try gradle.properties via PWD (preserves symlink path in Flutter's SPM structure).
     if let pwd = env["PWD"],
-       let value = readGradleProperty(key, from: pwd) {
+       let value = readGradleProperty(gradleKey, from: pwd) {
         return value.lowercased() == "true"
     }
 
     // 2. Try gradle.properties via FileManager cwd (resolves symlinks; works for direct CLI usage).
     let cwd = FileManager.default.currentDirectoryPath
-    if let value = readGradleProperty(key, from: cwd) {
+    if let value = readGradleProperty(gradleKey, from: cwd) {
         return value.lowercased() == "true"
     }
 
     // 3. Fallback: environment variable (required for add-to-app modules and custom project layouts).
-    return env["CIO_LOCATION"]?.lowercased() == "true"
-}()
+    return env[envKey]?.lowercased() == "true"
+}
+
+/// Whether the Geofence module should be included (opt-in).
+let useGeofence = isModuleEnabled(gradleKey: "customerio_geofence_enabled", envKey: "CIO_GEOFENCE")
+
+/// Whether the Location module should be included. Opt-in, and also implied by
+/// geofence, which depends on it.
+let useLocation = isModuleEnabled(gradleKey: "customerio_location_enabled", envKey: "CIO_LOCATION") || useGeofence
 
 var targetDependencies: [Target.Dependency] = [
     .product(name: "DataPipelines", package: "customerio-ios"),
@@ -84,6 +94,10 @@ var targetDependencies: [Target.Dependency] = [
 
 if useLocation {
     targetDependencies.append(.product(name: "Location", package: "customerio-ios"))
+}
+
+if useGeofence {
+    targetDependencies.append(.product(name: "LocationGeofence", package: "customerio-ios"))
 }
 
 let package = Package(

--- a/lib/config/customer_io_config.dart
+++ b/lib/config/customer_io_config.dart
@@ -1,5 +1,6 @@
 import '../customer_io_enums.dart';
 import '../customer_io_plugin_version.dart' as plugin_info show version;
+import 'geofence_config.dart';
 import 'in_app_config.dart';
 import 'location_config.dart';
 import 'push_config.dart';
@@ -22,6 +23,7 @@ class CustomerIOConfig {
   final InAppConfig? inAppConfig;
   final PushConfig pushConfig;
   final LocationConfig? locationConfig;
+  final GeofenceConfig? geofenceConfig;
 
   CustomerIOConfig({
     required this.cdpApiKey,
@@ -38,6 +40,7 @@ class CustomerIOConfig {
     this.inAppConfig,
     PushConfig? pushConfig,
     this.locationConfig,
+    this.geofenceConfig,
   }) : pushConfig = pushConfig ?? PushConfig();
 
   Map<String, dynamic> toMap() {
@@ -56,6 +59,7 @@ class CustomerIOConfig {
       'inApp': inAppConfig?.toMap(),
       'push': pushConfig.toMap(),
       'location': locationConfig?.toMap(),
+      'geofence': geofenceConfig?.toMap(),
       'version': version,
       'source': source
     };

--- a/lib/config/geofence_config.dart
+++ b/lib/config/geofence_config.dart
@@ -1,0 +1,12 @@
+/// Configuration for the optional Geofence module.
+///
+/// Geofence runs automatically once enabled and has no options yet. Providing a
+/// [GeofenceConfig] opts the app into geofence monitoring; this also enables the
+/// Location module, which geofence depends on.
+class GeofenceConfig {
+  GeofenceConfig();
+
+  Map<String, dynamic> toMap() {
+    return {};
+  }
+}

--- a/lib/customer_io_config.dart
+++ b/lib/customer_io_config.dart
@@ -1,4 +1,5 @@
 export 'config/customer_io_config.dart';
+export 'config/geofence_config.dart';
 export 'config/in_app_config.dart';
 export 'config/location_config.dart';
 export 'config/push_config.dart';

--- a/test/customer_io_config_test.dart
+++ b/test/customer_io_config_test.dart
@@ -110,6 +110,7 @@ void main() {
         'inApp': inAppConfig.toMap(),
         'push': pushConfig.toMap(),
         'location': null,
+        'geofence': null,
         'version': config.version,
         'source': config.source,
       };


### PR DESCRIPTION
## Summary
Adds the opt-in build wiring and Dart config surface for a new **Geofence** module, modeled on the existing Location module. No geofence behavior yet — this PR only makes the module buildable and configurable; native registration follows in the next PR.

- **Android** — `customerio_geofence_enabled` gradle flag → `CIO_GEOFENCE_ENABLED`; pulls in `io.customer.android:geofence` (and `location`, since geofence depends on it).
- **iOS** — `geofence` podspec subspec (`CustomerIOLocationGeofence`) + SPM `LocationGeofence` product; `useLocation` is implied by `useGeofence`.
- **Dart** — empty `GeofenceConfig` + optional `geofenceConfig` on `CustomerIOConfig`.

**Geofence implies Location:** enabling geofence also enables the Location module, which geofence depends on for location fixes.

## Ticket
[MBL-1783 — Flutter: add geofencing support](https://linear.app/customerio/issue/MBL-1783/flutter-add-geofencing-support)

## PR stack
1. **(this PR)** Build enablement + config → `feature/geofence-on-device`
2. Register geofence module with native SDKs → stacks on this PR (#355)
3. Enable geofence in sample apps → _coming next_

## Testing
`flutter analyze` + unit tests pass. End-to-end native builds are validated in the stacked PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time optional dependencies and config surface only; no native geofence registration or behavior yet, though geofence opt-in will pull Location into customer builds.
> 
> **Overview**
> Introduces **opt-in Geofence module** build and configuration plumbing (no runtime geofence behavior in this PR), mirroring the existing Location pattern.
> 
> **Android:** `customerio_geofence_enabled` drives `CIO_GEOFENCE_ENABLED` and conditionally links `io.customer.android:geofence` vs `compileOnly`. **Location is linked whenever location or geofence is enabled** (`cioLocationLinked`), so `CIO_LOCATION_ENABLED` reflects that dependency.
> 
> **iOS:** New `geofence` CocoaPods subspec (`CustomerIO/LocationGeofence`) and SPM `LocationGeofence` when `customerio_geofence_enabled` or `CIO_GEOFENCE` is set. SPM refactors location/geofence toggles through shared `isModuleEnabled`; **enabling geofence also enables Location**.
> 
> **Dart/API:** Empty `GeofenceConfig`, optional `geofenceConfig` on `CustomerIOConfig` (serialized as `geofence` in `toMap()`), public export, and API snapshot updates. Tests expect `'geofence': null` in config maps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee58fe03ae936cacdcb05f816516decd8d1de3d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->