### PR TITLE
chore: register geofence module with native SDKs

### DIFF
--- a/android/src/main/kotlin/io/customer/customer_io/CustomerIOPlugin.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/CustomerIOPlugin.kt
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull
 import io.customer.customer_io.bridge.NativeModuleBridge
 import io.customer.customer_io.bridge.nativeMapArgs
 import io.customer.customer_io.bridge.nativeNoArgs
+import io.customer.customer_io.geofence.CustomerIOGeofence
 import io.customer.customer_io.location.CustomerIOLocation
 import io.customer.customer_io.messaginginapp.CustomerIOInAppMessaging
 import io.customer.customer_io.messagingpush.CustomerIOPushMessaging
@@ -54,9 +55,14 @@ class CustomerIOPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         modules = buildList {
             add(CustomerIOPushMessaging(flutterPluginBinding))
             add(CustomerIOInAppMessaging(flutterPluginBinding))
-            // Location module is optional - enabled via customerio_location_enabled gradle property
+            // Location module is optional - enabled via customerio_location_enabled gradle
+            // property. CIO_LOCATION_ENABLED also covers geofence (geofence implies location).
             if (BuildConfig.CIO_LOCATION_ENABLED) {
                 add(CustomerIOLocation(flutterPluginBinding))
+            }
+            // Geofence module is optional - enabled via customerio_geofence_enabled gradle property
+            if (BuildConfig.CIO_GEOFENCE_ENABLED) {
+                add(CustomerIOGeofence(flutterPluginBinding))
             }
         }
 
@@ -231,13 +237,30 @@ class CustomerIOPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     )
                 }
             }
-            // Configure location module based on config provided by customer app
-            args.getAs<Map<String, Any>>(key = "location")?.let { locationConfig ->
+            // Configure location module. Geofence implies location, so register location
+            // (with the app's config if given, otherwise defaults) whenever location or
+            // geofence is configured, since geofence relies on its location fixes. The build
+            // flags guard each block so the optional bridge classes (which reference native
+            // artifacts that are only linked when enabled) are never touched otherwise.
+            val locationConfig = args.getAs<Map<String, Any>>(key = "location")
+            val geofenceConfig = args.getAs<Map<String, Any>>(key = "geofence")
+            if (BuildConfig.CIO_LOCATION_ENABLED && (locationConfig != null || geofenceConfig != null)) {
                 modules.filterIsInstance<CustomerIOLocation>().forEach {
                     it.configureModule(
                         builder = this,
-                        config = locationConfig,
+                        config = locationConfig ?: emptyMap(),
                     )
+                }
+            }
+            // Configure geofence module (runs automatically once registered)
+            if (BuildConfig.CIO_GEOFENCE_ENABLED) {
+                geofenceConfig?.let { config ->
+                    modules.filterIsInstance<CustomerIOGeofence>().forEach {
+                        it.configureModule(
+                            builder = this,
+                            config = config,
+                        )
+                    }
                 }
             }
         }.build()

--- a/android/src/main/kotlin/io/customer/customer_io/CustomerIOPlugin.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/CustomerIOPlugin.kt
@@ -244,7 +244,9 @@ class CustomerIOPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             // artifacts that are only linked when enabled) are never touched otherwise.
             val locationConfig = args.getAs<Map<String, Any>>(key = "location")
             val geofenceConfig = args.getAs<Map<String, Any>>(key = "geofence")
-            if (BuildConfig.CIO_LOCATION_ENABLED && (locationConfig != null || geofenceConfig != null)) {
+            if (BuildConfig.CIO_LOCATION_ENABLED &&
+                (locationConfig != null || (BuildConfig.CIO_GEOFENCE_ENABLED && geofenceConfig != null))
+            ) {
                 modules.filterIsInstance<CustomerIOLocation>().forEach {
                     it.configureModule(
                         builder = this,

--- a/android/src/main/kotlin/io/customer/customer_io/geofence/CustomerIOGeofence.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/geofence/CustomerIOGeofence.kt
@@ -1,0 +1,29 @@
+package io.customer.customer_io.geofence
+
+import io.customer.customer_io.bridge.NativeModuleBridge
+import io.customer.geofence.GeofenceModuleConfig
+import io.customer.geofence.ModuleGeofence
+import io.customer.sdk.CustomerIOBuilder
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Flutter bridge for the geofence module. Geofence has no Flutter-facing methods —
+ * it runs automatically once registered — so this only wires the native module into
+ * the SDK builder. The reference to [ModuleGeofence] is isolated here so it is loaded
+ * only when the geofence dependency is bundled.
+ *
+ * Geofence depends on the location module; registration of location is handled by the
+ * plugin when geofence is configured.
+ */
+internal class CustomerIOGeofence(
+    pluginBinding: FlutterPlugin.FlutterPluginBinding,
+) : NativeModuleBridge {
+    override val moduleName: String = "Geofence"
+    override val flutterCommunicationChannel: MethodChannel =
+        MethodChannel(pluginBinding.binaryMessenger, "customer_io_geofence")
+
+    override fun configureModule(builder: CustomerIOBuilder, config: Map<String, Any>) {
+        builder.addCustomerIOModule(ModuleGeofence(GeofenceModuleConfig.Builder().build()))
+    }
+}

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -6,6 +6,9 @@ import UIKit
 #if canImport(CioLocation)
 import CioLocation
 #endif
+#if canImport(CioLocationGeofence)
+import CioLocationGeofence
+#endif
 
 public class CustomerIOPlugin: NSObject, FlutterPlugin {
     private var methodChannel: FlutterMethodChannel!
@@ -167,9 +170,18 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
             let sdkConfigBuilder = try SDKConfigBuilder.create(from: params)
 
             #if canImport(CioLocation)
-            // Add location module to config builder if location config is provided
-            if let locationConfig = params["location"] as? [String: AnyHashable] {
-                let trackingModeValue = locationConfig["trackingMode"] as? String
+            let locationConfig = params["location"] as? [String: AnyHashable]
+            #if canImport(CioLocationGeofence)
+            let geofenceConfigured = params["geofence"] as? [String: AnyHashable] != nil
+            #else
+            let geofenceConfigured = false
+            #endif
+
+            // Add location module when location or geofence is configured. Geofence implies
+            // location: it relies on the location module's fixes, so register location (with
+            // the app's config if given, otherwise defaults) whenever geofence is enabled.
+            if locationConfig != nil || geofenceConfigured {
+                let trackingModeValue = locationConfig?["trackingMode"] as? String
                 let mode: LocationTrackingMode
                 switch trackingModeValue?.uppercased() {
                 case "OFF":
@@ -181,6 +193,13 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
                 }
                 _ = sdkConfigBuilder.addModule(LocationModule(config: LocationConfig(mode: mode)))
             }
+
+            #if canImport(CioLocationGeofence)
+            // Geofence runs automatically once registered; relies on the location module above.
+            if geofenceConfigured {
+                _ = sdkConfigBuilder.addModule(GeofenceModule())
+            }
+            #endif
             #endif
 
             CustomerIO.initialize(withConfig: sdkConfigBuilder.build())


### PR DESCRIPTION
## Summary
Wires the geofence module into the native SDK builders during `initialize()` on Android and iOS. Geofence runs **automatically** once registered (no Flutter-facing methods) and depends on the Location module, which is registered — with the app's config if provided, otherwise defaults (`manual`) — whenever geofence is enabled.

- **Android** — new `CustomerIOGeofence` bridge registers `ModuleGeofence`; the reference is isolated in its own class so a disabled/compileOnly dependency can't trigger `NoClassDefFoundError`. `initialize()` registers Location when either location or geofence is configured.
- **iOS** — `initialize()` adds `GeofenceModule()` plus `LocationModule` under the `canImport` guards.

## Ticket
[MBL-1783 — Flutter: add geofencing support](https://linear.app/customerio/issue/MBL-1783/flutter-add-geofencing-support)

## PR stack
1. Build enablement + config → `feature/geofence-on-device` (#354)
2. **(this PR)** Register geofence module with native SDKs → stacks on #354
3. Enable geofence in sample apps → _coming next_

> ⚠️ Stacked on #354 — review/merge that first; this PR targets its branch.

## Testing
`flutter analyze` + unit tests pass. Validated by building both sample apps against local geofence natives: Android APK links the `geofence` artifact; iOS `Runner.app` links `CioLocationGeofence.framework`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SDK initialization for location-dependent geofencing; behavior is gated by build flags and init config but affects background location-related native modules.
> 
> **Overview**
> **Registers the native geofence module** when Flutter `initialize()` includes a `geofence` config. Geofence has no Dart-facing APIs—it starts after `ModuleGeofence` / `GeofenceModule()` is added to the SDK builder.
> 
> On **Android**, a new `CustomerIOGeofence` bridge (behind `CIO_GEOFENCE_ENABLED`) attaches `ModuleGeofence` and is only loaded when the geofence artifact is linked. **`initialize()` now also wires Location** when either `location` or `geofence` is present (geofence-only apps get location with defaults/`emptyMap()`), instead of requiring an explicit `location` block.
> 
> On **iOS**, `initialize()` adds `GeofenceModule()` when `geofence` is set and applies the same rule: **Location is registered for geofence-only init** (default `manual` tracking when no `location` config), under `canImport(CioLocationGeofence)` guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab34fd23b070764c4c05591e2cfdc93879cb02c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->