### PR TITLE
chore: add iOS allowBackgroundDelivery config for geofence

### DIFF
--- a/customerio-flutter.api
+++ b/customerio-flutter.api
@@ -59,7 +59,8 @@ public final class CustomerIOConfig {
 		InAppConfig? inAppConfig,
 		PushConfig? pushConfig,
 		LocationConfig? locationConfig,
-		GeofenceConfig? geofenceConfig
+		GeofenceConfig? geofenceConfig,
+		CustomerIOConfigIos? iosConfig
 	): CustomerIOConfig;
 	public fun toMap(): Map<String, dynamic>;
 	public val apiHost: String?;
@@ -70,6 +71,7 @@ public final class CustomerIOConfig {
 	public val flushInterval: int?;
 	public val geofenceConfig: GeofenceConfig?;
 	public val inAppConfig: InAppConfig?;
+	public val iosConfig: CustomerIOConfigIos?;
 	public val locationConfig: LocationConfig?;
 	public val logLevel: CioLogLevel?;
 	public val migrationSiteId: String?;
@@ -79,6 +81,12 @@ public final class CustomerIOConfig {
 	public val source: String;
 	public val trackApplicationLifecycleEvents: bool?;
 	public val version: String;
+}
+
+public final class CustomerIOConfigIos {
+	public fun new(bool? allowBackgroundDelivery): CustomerIOConfigIos;
+	public fun toMap(): Map<String, dynamic>;
+	public val allowBackgroundDelivery: bool?;
 }
 
 public final class CustomerIOLocationPlatform {

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -202,6 +202,15 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
             #endif
             #endif
 
+            // Customer value wins; otherwise on when the geofence module is added, off otherwise.
+            #if canImport(CioLocationGeofence)
+            let geofenceAdded = params["geofence"] as? [String: AnyHashable] != nil
+            #else
+            let geofenceAdded = false
+            #endif
+            let allowBackgroundDelivery = (params["ios"] as? [String: AnyHashable])?["allowBackgroundDelivery"] as? Bool
+            _ = sdkConfigBuilder.allowBackgroundDelivery(allowBackgroundDelivery ?? geofenceAdded)
+
             CustomerIO.initialize(withConfig: sdkConfigBuilder.build())
 
             // Initialize in-app messaging with provided config

--- a/lib/config/customer_io_config.dart
+++ b/lib/config/customer_io_config.dart
@@ -2,6 +2,7 @@ import '../customer_io_enums.dart';
 import '../customer_io_plugin_version.dart' as plugin_info show version;
 import 'geofence_config.dart';
 import 'in_app_config.dart';
+import 'ios_config.dart';
 import 'location_config.dart';
 import 'push_config.dart';
 
@@ -24,6 +25,7 @@ class CustomerIOConfig {
   final PushConfig pushConfig;
   final LocationConfig? locationConfig;
   final GeofenceConfig? geofenceConfig;
+  final CustomerIOConfigIos? iosConfig;
 
   CustomerIOConfig({
     required this.cdpApiKey,
@@ -41,6 +43,7 @@ class CustomerIOConfig {
     PushConfig? pushConfig,
     this.locationConfig,
     this.geofenceConfig,
+    this.iosConfig,
   }) : pushConfig = pushConfig ?? PushConfig();
 
   Map<String, dynamic> toMap() {
@@ -60,6 +63,7 @@ class CustomerIOConfig {
       'push': pushConfig.toMap(),
       'location': locationConfig?.toMap(),
       'geofence': geofenceConfig?.toMap(),
+      'ios': iosConfig?.toMap(),
       'version': version,
       'source': source
     };

--- a/lib/config/ios_config.dart
+++ b/lib/config/ios_config.dart
@@ -1,0 +1,14 @@
+/// iOS-only SDK configuration; has no effect on Android.
+class CustomerIOConfigIos {
+  /// Whether geofence transitions are delivered in real time on a background cold-wake.
+  /// When unset, defaults on if the geofence module is added, off otherwise.
+  final bool? allowBackgroundDelivery;
+
+  CustomerIOConfigIos({this.allowBackgroundDelivery});
+
+  Map<String, dynamic> toMap() {
+    return {
+      'allowBackgroundDelivery': allowBackgroundDelivery,
+    };
+  }
+}

--- a/lib/customer_io_config.dart
+++ b/lib/customer_io_config.dart
@@ -1,5 +1,6 @@
 export 'config/customer_io_config.dart';
 export 'config/geofence_config.dart';
 export 'config/in_app_config.dart';
+export 'config/ios_config.dart';
 export 'config/location_config.dart';
 export 'config/push_config.dart';

--- a/test/customer_io_config_test.dart
+++ b/test/customer_io_config_test.dart
@@ -111,6 +111,7 @@ void main() {
         'push': pushConfig.toMap(),
         'location': null,
         'geofence': null,
+        'ios': null,
         'version': config.version,
         'source': config.source,
       };


### PR DESCRIPTION
## Summary
Adds an **iOS-only** `allowBackgroundDelivery` option for geofence, exposed as `CustomerIOConfig.iosConfig` (a `CustomerIOConfigIos` platform namespace, mirroring `PushConfig.android`) and wired to the native `SDKConfigBuilder.allowBackgroundDelivery`.

Resolution on iOS — a customer value always wins; when unset it defaults **on if the geofence module is added, off otherwise**:

| Customer sets | Geofence module added | Result |
|---|---|---|
| `true` / `false` | either | that value |
| unset | yes | on |
| unset | no | off |

**Android:** no native equivalent — the `ios` config key is ignored (background delivery runs automatically via WorkManager + manifest receivers).

Self-contained: can be closed/reverted without affecting the other PRs in the stack.

## Ticket
[MBL-1783 — Flutter: add geofencing support](https://linear.app/customerio/issue/MBL-1783/flutter-add-geofencing-support)

## PR stack
1. Build enablement + config → `feature/geofence-on-device` (#354)
2. Register geofence module with native SDKs → #354 (#355)
3. **(this PR)** iOS allowBackgroundDelivery config → stacks on #355
4. Enable geofence in sample apps → _coming next_

> ⚠️ Stacked on #355 — review/merge that first; this PR targets its branch (`mbl-1783-geofence-module`).

## Testing
`flutter analyze` + unit tests pass (config serialization test updated). Verified by building the iOS sample against the local geofence native — Swift compiles and `CioLocationGeofence` links.

> Depends on the native iOS `allowBackgroundDelivery` (currently on `geofence-testing`) landing in the released SDK version the plugin targets before this can merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped iOS init/config plumbing with sensible defaults; no auth or data-model changes, and Android is unaffected.
> 
> **Overview**
> Adds an **iOS-only** `CustomerIOConfig.iosConfig` (`CustomerIOConfigIos`) with optional `allowBackgroundDelivery`, serialized under the `ios` key in `CustomerIOConfig.toMap()` (mirroring Android nested under `push`).
> 
> On iOS init, the plugin maps that flag to `SDKConfigBuilder.allowBackgroundDelivery`: an explicit customer value wins; if unset, it defaults **on** when the geofence module is registered and **off** otherwise. Android ignores the `ios` config.
> 
> Public API surface and the config serialization test are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ada4832cd97f92ae80e7b88f2245b1a7607e960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->