### PR TITLE
chore: enable geofence in sample apps

### DIFF
--- a/apps/flutter_sample_cocoapods/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter_sample_cocoapods/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Required for geofence transition delivery while the app is backgrounded (API 29+) -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <!-- Lets geofence monitoring resume after device reboot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name="${applicationName}"

--- a/apps/flutter_sample_cocoapods/android/gradle.properties
+++ b/apps/flutter_sample_cocoapods/android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
 customerio_location_enabled=true
+customerio_geofence_enabled=true

--- a/apps/flutter_sample_cocoapods/ios/Podfile
+++ b/apps/flutter_sample_cocoapods/ios/Podfile
@@ -45,6 +45,7 @@ target 'Runner' do
   # Uncomment only 1 of the lines below to install a version of the iOS SDK
   pod 'customer_io/fcm', :path => '.symlinks/plugins/customer_io/ios' # install podspec bundled with the plugin
   pod 'customer_io/location', :path => '.symlinks/plugins/customer_io/ios' # install location subspec for testing
+  pod 'customer_io/geofence', :path => '.symlinks/plugins/customer_io/ios' # install geofence subspec for testing (pulls in location)
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: "fcm")
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: "fcm")
 

--- a/apps/flutter_sample_cocoapods/ios/Runner/AppDelegate.swift
+++ b/apps/flutter_sample_cocoapods/ios/Runner/AppDelegate.swift
@@ -5,6 +5,9 @@ import CioMessagingPushFCM
 import FirebaseMessaging
 import FirebaseCore
 import CioFirebaseWrapper
+#if canImport(CioLocationGeofence)
+import CioLocationGeofence
+#endif
 
 @main
 class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
@@ -17,6 +20,12 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
+
+        #if canImport(CioLocationGeofence)
+        // iOS can cold-wake the app for a geofence transition before the Dart runtime
+        // starts, so bootstrap here rather than relying on CustomerIO.initialize.
+        GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)
+        #endif
 
         let controller = window?.rootViewController as! FlutterViewController
         permissionHandler.register(with: controller.binaryMessenger)

--- a/apps/flutter_sample_cocoapods/ios/Runner/Info.plist
+++ b/apps/flutter_sample_cocoapods/ios/Runner/Info.plist
@@ -102,5 +102,7 @@
 	<string>Required to send push notifications</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app uses your location to test Customer.io location tracking features.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app uses your location in the background to test Customer.io geofence features.</string>
 </dict>
 </plist>

--- a/apps/flutter_sample_spm/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter_sample_spm/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Required for geofence transition delivery while the app is backgrounded (API 29+) -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <!-- Lets geofence monitoring resume after device reboot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name="${applicationName}"

--- a/apps/flutter_sample_spm/android/gradle.properties
+++ b/apps/flutter_sample_spm/android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
 customerio_location_enabled=true
+customerio_geofence_enabled=true

--- a/apps/flutter_sample_spm/ios/Runner/AppDelegate.swift
+++ b/apps/flutter_sample_spm/ios/Runner/AppDelegate.swift
@@ -5,6 +5,9 @@ import CioMessagingPushFCM
 import FirebaseMessaging
 import FirebaseCore
 import CioFirebaseWrapper
+#if canImport(CioLocationGeofence)
+import CioLocationGeofence
+#endif
 
 @main
 class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
@@ -17,7 +20,13 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
-        
+
+        #if canImport(CioLocationGeofence)
+        // iOS can cold-wake the app for a geofence transition before the Dart runtime
+        // starts, so bootstrap here rather than relying on CustomerIO.initialize.
+        GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)
+        #endif
+
         let controller = window?.rootViewController as! FlutterViewController
         permissionHandler.register(with: controller.binaryMessenger)
 

--- a/apps/flutter_sample_spm/ios/Runner/Info.plist
+++ b/apps/flutter_sample_spm/ios/Runner/Info.plist
@@ -102,5 +102,7 @@
 	<string>Required to send push notifications</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app uses your location to test Customer.io location tracking features.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app uses your location in the background to test Customer.io geofence features.</string>
 </dict>
 </plist>

--- a/apps/flutter_sample_spm/ios/Runner/PermissionChannelHandler.swift
+++ b/apps/flutter_sample_spm/ios/Runner/PermissionChannelHandler.swift
@@ -4,6 +4,7 @@ import UIKit
 
 class PermissionChannelHandler: NSObject, CLLocationManagerDelegate {
     private let locationManager = CLLocationManager()
+    // Pending result for the foreground (When In Use) request, resolved by the delegate.
     private var locationPermissionResult: FlutterResult?
 
     func register(with messenger: FlutterBinaryMessenger) {
@@ -23,6 +24,10 @@ class PermissionChannelHandler: NSObject, CLLocationManagerDelegate {
             getNotificationPermissionStatus(result: result)
         case "requestLocationPermission":
             requestLocationPermission(result: result)
+        case "requestBackgroundLocationPermission":
+            requestBackgroundLocationPermission(result: result)
+        case "getLocationAuthorizationStatus":
+            getLocationAuthorizationStatus(result: result)
         case "openAppSettings":
             if let url = URL(string: UIApplication.openSettingsURLString) {
                 UIApplication.shared.open(url)
@@ -30,6 +35,22 @@ class PermissionChannelHandler: NSObject, CLLocationManagerDelegate {
             result(nil)
         default:
             result(FlutterMethodNotImplemented)
+        }
+    }
+
+    // Drives the state-aware "Background Location" button, mirroring the native sample apps.
+    private func getLocationAuthorizationStatus(result: @escaping FlutterResult) {
+        switch locationManager.authorizationStatus {
+        case .authorizedAlways:
+            result("backgroundGranted")
+        case .authorizedWhenInUse:
+            result("foregroundOnly")
+        case .denied, .restricted:
+            result("denied")
+        case .notDetermined:
+            result("notDetermined")
+        @unknown default:
+            result("denied")
         }
     }
 
@@ -58,6 +79,17 @@ class PermissionChannelHandler: NSObject, CLLocationManagerDelegate {
         }
     }
 
+    // Only one permission request can be in flight at a time (single result slot).
+    // Reject a second concurrent request instead of clobbering the first's callback.
+    private func claimPendingResult(_ result: @escaping FlutterResult) -> Bool {
+        if locationPermissionResult != nil {
+            result("denied")
+            return false
+        }
+        locationPermissionResult = result
+        return true
+    }
+
     private func requestLocationPermission(result: @escaping FlutterResult) {
         let status = locationManager.authorizationStatus
         switch status {
@@ -66,13 +98,36 @@ class PermissionChannelHandler: NSObject, CLLocationManagerDelegate {
         case .denied, .restricted:
             result("permanentlyDenied")
         case .notDetermined:
-            locationPermissionResult = result
+            guard claimPendingResult(result) else { return }
             locationManager.requestWhenInUseAuthorization()
         @unknown default:
             result("denied")
         }
     }
 
+    // "Always" authorization is required for geofence region monitoring to wake the app
+    // in the background. iOS escalates from When In Use to Always with a separate prompt.
+    private func requestBackgroundLocationPermission(result: @escaping FlutterResult) {
+        let status = locationManager.authorizationStatus
+        switch status {
+        case .authorizedAlways:
+            result("granted")
+        case .denied, .restricted:
+            result("permanentlyDenied")
+        case .notDetermined, .authorizedWhenInUse:
+            // The Always upgrade is delivered asynchronously, and Core Location may never
+            // call the delegate (e.g. the user keeps "While Using", or the prompt was
+            // already shown once). So don't await it — kick off the request and report
+            // "pending"; the UI reflects the real outcome on resume via the status query.
+            locationManager.requestAlwaysAuthorization()
+            result("pending")
+        @unknown default:
+            result("denied")
+        }
+    }
+
+    // Resolves the foreground (When In Use) request. The background request is fire-and-forget,
+    // so When In Use here is always a foreground grant.
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         guard let result = locationPermissionResult else { return }
         locationPermissionResult = nil

--- a/apps/flutter_sample_spm/lib/src/customer_io.dart
+++ b/apps/flutter_sample_spm/lib/src/customer_io.dart
@@ -74,6 +74,7 @@ class CustomerIOSDK extends ChangeNotifier {
           screenViewUse: _sdkConfig?.screenViewUse,
           inAppConfig: inAppConfig,
           locationConfig: LocationConfig(),
+          geofenceConfig: GeofenceConfig(),
         ),
       );
     } catch (ex) {

--- a/apps/flutter_sample_spm/lib/src/screens/location.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/location.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:customer_io/customer_io.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show MethodChannel;
@@ -15,10 +17,48 @@ class LocationScreen extends StatefulWidget {
   State<LocationScreen> createState() => _LocationScreenState();
 }
 
-class _LocationScreenState extends State<LocationScreen> {
+class _LocationScreenState extends State<LocationScreen>
+    with WidgetsBindingObserver {
   final _latitudeController = TextEditingController();
   final _longitudeController = TextEditingController();
   String _statusText = 'No location set yet';
+
+  // Drives the state-aware Background Location button (mirrors the native samples).
+  // One of notDetermined, foregroundOnly, backgroundGranted, denied; null until queried.
+  String? _locationStatus;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _refreshLocationStatus();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Re-query after returning from Settings so the button reflects any change.
+    if (state == AppLifecycleState.resumed) {
+      _refreshLocationStatus();
+    }
+  }
+
+  static const _grantedStatuses = {'foregroundOnly', 'backgroundGranted'};
+
+  Future<void> _refreshLocationStatus() async {
+    final status = await _permissionChannel
+        .invokeMethod<String>('getLocationAuthorizationStatus');
+    if (!mounted) return;
+    final previous = _locationStatus;
+    setState(() => _locationStatus = status);
+    // On any new grant — including one made in Settings and picked up on resume —
+    // fetch so geofences register. The SDK's auto-fetch hook runs once per process,
+    // so a runtime grant needs an explicit request (matches the native sample apps).
+    if (previous != null &&
+        status != previous &&
+        _grantedStatuses.contains(status)) {
+      CustomerIO.location.requestLocationUpdate();
+    }
+  }
 
   static const _presetNames = [
     'New York', 'London', 'Tokyo', 'Sydney', 'Sao Paulo', '0, 0'
@@ -73,16 +113,137 @@ class _LocationScreenState extends State<LocationScreen> {
       return;
     }
 
+    if (!mounted) return;
     if (status == 'granted') {
       CustomerIO.location.requestLocationUpdate();
       setState(() {
         _statusText = 'Requested SDK location update...';
       });
-      if (!mounted) return;
       context.showSnackBar('SDK location update requested');
     } else {
-      if (!mounted) return;
       context.showSnackBar('Location permission denied');
+    }
+  }
+
+  String get _backgroundButtonLabel {
+    switch (_locationStatus) {
+      case 'foregroundOnly':
+        return Platform.isIOS ? "Upgrade to 'Always'" : 'Allow all the time';
+      case 'backgroundGranted':
+        return Platform.isIOS ? 'Always — granted' : 'Background — granted';
+      case 'denied':
+        return 'Open Settings';
+      default:
+        return 'Grant location access';
+    }
+  }
+
+  bool get _backgroundButtonEnabled => _locationStatus != 'backgroundGranted';
+
+  Future<void> _handleBackgroundLocationTap() async {
+    switch (_locationStatus) {
+      case 'foregroundOnly':
+        _showBackgroundRationale();
+        break;
+      case 'backgroundGranted':
+        break;
+      case 'denied':
+        _permissionChannel.invokeMethod('openAppSettings');
+        break;
+      default:
+        // notDetermined, or status not yet loaded: request foreground first.
+        final status = await _permissionChannel
+            .invokeMethod<String>('requestLocationPermission');
+        if (!mounted) return;
+        await _refreshLocationStatus();
+        if (!mounted) return;
+        if (status == 'granted') {
+          // Foreground granted; escalate to background with a rationale.
+          _showBackgroundRationale();
+        } else if (status == 'permanentlyDenied') {
+          _showOpenSettingsDialog();
+        } else {
+          context.showSnackBar('Location permission denied');
+        }
+    }
+  }
+
+  void _showBackgroundRationale() {
+    context.showMessageDialog(
+      'Allow background location?',
+      'Geofence transitions only fire while the app is backgrounded if you grant '
+          '"Always"/"Allow all the time". If no prompt appears, use Open Settings.',
+      actions: [
+        TextButton(
+          child: const Text('Cancel'),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        TextButton(
+          child: const Text('Open Settings'),
+          onPressed: () {
+            Navigator.of(context).pop();
+            _permissionChannel.invokeMethod('openAppSettings');
+          },
+        ),
+        TextButton(
+          child: const Text('Continue'),
+          onPressed: () {
+            Navigator.of(context).pop();
+            _requestBackgroundLocation();
+          },
+        ),
+      ],
+    );
+  }
+
+  void _showOpenSettingsDialog() {
+    context.showMessageDialog(
+      'Location Permission Required',
+      'Location permission is denied. Please enable it from app settings.',
+      actions: [
+        TextButton(
+          child: const Text('Open Settings'),
+          onPressed: () {
+            Navigator.of(context).pop();
+            _permissionChannel.invokeMethod('openAppSettings');
+          },
+        ),
+        TextButton(
+          child: const Text('OK'),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _requestBackgroundLocation() async {
+    final status = await _permissionChannel
+        .invokeMethod<String>('requestBackgroundLocationPermission');
+
+    if (!mounted) return;
+    await _refreshLocationStatus();
+    if (!mounted) return;
+
+    switch (status) {
+      case 'granted':
+        // _refreshLocationStatus above kicks off the fetch on the grant transition.
+        context.showSnackBar(
+            'Background location granted — fetching location to start geofence');
+        break;
+      case 'pending':
+        // iOS: the "Always" prompt resolves asynchronously; the button and geofence
+        // fetch update on resume. Point the user to Settings if no prompt appears.
+        context.showSnackBar(
+            'Requesting background location — enable "Always" in Settings if no prompt appears');
+        break;
+      case 'fineLocationRequired':
+        context.showSnackBar('Grant location access first');
+        break;
+      case 'permanentlyDenied':
+        _showOpenSettingsDialog();
+        break;
+      default:
+        context.showSnackBar('Background location denied');
     }
   }
 
@@ -108,6 +269,7 @@ class _LocationScreenState extends State<LocationScreen> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _latitudeController.dispose();
     _longitudeController.dispose();
     super.dispose();
@@ -134,22 +296,22 @@ class _LocationScreenState extends State<LocationScreen> {
               ),
               const SizedBox(height: 24),
 
-              // Section 1: Quick Presets
+              // Section 1: Background Location (geofence permission)
               _SectionCard(
-                title: 'Quick Presets',
+                title: 'Background Location',
                 description:
-                    'Tap a city to call setLastKnownLocation with its coordinates.',
-                child: Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: List.generate(
-                    _presetNames.length,
-                    (i) => OutlinedButton(
-                      onPressed: () => _setLocation(
-                          _presetCoords[i][0], _presetCoords[i][1], _presetNames[i]),
-                      child: Text(_presetNames[i]),
-                    ),
+                    'Geofence runs automatically once enabled, but needs background '
+                    '("Always"/"Allow all the time") location to deliver transitions '
+                    'while the app is closed. This grants foreground access first, then '
+                    'escalates to background.',
+                child: FilledButton(
+                  style: FilledButton.styleFrom(
+                    minimumSize: sizes.buttonDefault(),
                   ),
+                  onPressed: _backgroundButtonEnabled
+                      ? _handleBackgroundLocationTap
+                      : null,
+                  child: Text(_backgroundButtonLabel),
                 ),
               ),
               const SizedBox(height: 16),
@@ -169,7 +331,27 @@ class _LocationScreenState extends State<LocationScreen> {
               ),
               const SizedBox(height: 16),
 
-              // Section 3: Manual Entry
+              // Section 3: Quick Presets
+              _SectionCard(
+                title: 'Quick Presets',
+                description:
+                    'Tap a city to call setLastKnownLocation with its coordinates.',
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: List.generate(
+                    _presetNames.length,
+                    (i) => OutlinedButton(
+                      onPressed: () => _setLocation(
+                          _presetCoords[i][0], _presetCoords[i][1], _presetNames[i]),
+                      child: Text(_presetNames[i]),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+
+              // Section 4: Manual Entry
               _SectionCard(
                 title: 'Manual Entry',
                 description: 'Enter custom latitude and longitude values.',

--- a/apps/shared/android/io/customer/testbed/flutter/PermissionChannelHandler.kt
+++ b/apps/shared/android/io/customer/testbed/flutter/PermissionChannelHandler.kt
@@ -19,6 +19,7 @@ class PermissionChannelHandler(
     companion object {
         private const val REQUEST_NOTIFICATION = 1001
         private const val REQUEST_LOCATION = 1002
+        private const val REQUEST_BACKGROUND_LOCATION = 1003
     }
 
     private var pendingResult: MethodChannel.Result? = null
@@ -32,6 +33,8 @@ class PermissionChannelHandler(
             "requestNotificationPermission" -> requestNotificationPermission(result)
             "getNotificationPermissionStatus" -> getNotificationPermissionStatus(result)
             "requestLocationPermission" -> requestLocationPermission(result)
+            "requestBackgroundLocationPermission" -> requestBackgroundLocationPermission(result)
+            "getLocationAuthorizationStatus" -> getLocationAuthorizationStatus(result)
             "openAppSettings" -> {
                 val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
                     data = Uri.fromParts("package", activity.packageName, null)
@@ -41,6 +44,22 @@ class PermissionChannelHandler(
             }
             else -> result.notImplemented()
         }
+    }
+
+    // Drives the state-aware "Background Location" button, mirroring the native sample apps.
+    private fun getLocationAuthorizationStatus(result: MethodChannel.Result) {
+        val fineGranted = ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+        if (!fineGranted) {
+            val permanentlyDenied = !ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION) &&
+                hasRequestedPermissionBefore(Manifest.permission.ACCESS_FINE_LOCATION)
+            result.success(if (permanentlyDenied) "denied" else "notDetermined")
+            return
+        }
+        val backgroundGranted = Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+            ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+        result.success(if (backgroundGranted) "backgroundGranted" else "foregroundOnly")
     }
 
     private fun getNotificationPermissionStatus(result: MethodChannel.Result) {
@@ -67,7 +86,7 @@ class PermissionChannelHandler(
             result.success("granted")
             return
         }
-        pendingResult = result
+        if (!claimPendingResult(result)) return
         ActivityCompat.requestPermissions(
             activity,
             arrayOf(Manifest.permission.POST_NOTIFICATIONS),
@@ -86,7 +105,7 @@ class PermissionChannelHandler(
             result.success("permanentlyDenied")
             return
         }
-        pendingResult = result
+        if (!claimPendingResult(result)) return
         markPermissionRequested(Manifest.permission.ACCESS_FINE_LOCATION)
         ActivityCompat.requestPermissions(
             activity,
@@ -95,8 +114,43 @@ class PermissionChannelHandler(
         )
     }
 
+    // Background location is a separate, escalated grant required for geofence transition
+    // delivery while the app is backgrounded. It only exists as its own permission on
+    // API 29+, and on API 30+ the OS requires fine location to be granted first.
+    private fun requestBackgroundLocationPermission(result: MethodChannel.Result) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            result.success("granted")
+            return
+        }
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
+            != PackageManager.PERMISSION_GRANTED) {
+            result.success("fineLocationRequired")
+            return
+        }
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+            == PackageManager.PERMISSION_GRANTED) {
+            result.success("granted")
+            return
+        }
+        if (!ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+            && hasRequestedPermissionBefore(Manifest.permission.ACCESS_BACKGROUND_LOCATION)) {
+            result.success("permanentlyDenied")
+            return
+        }
+        if (!claimPendingResult(result)) return
+        markPermissionRequested(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        ActivityCompat.requestPermissions(
+            activity,
+            arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION),
+            REQUEST_BACKGROUND_LOCATION
+        )
+    }
+
     fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray): Boolean {
-        if (requestCode != REQUEST_NOTIFICATION && requestCode != REQUEST_LOCATION) return false
+        if (requestCode != REQUEST_NOTIFICATION &&
+            requestCode != REQUEST_LOCATION &&
+            requestCode != REQUEST_BACKGROUND_LOCATION
+        ) return false
 
         val result = pendingResult ?: return false
         pendingResult = null
@@ -111,6 +165,17 @@ class PermissionChannelHandler(
                 result.success("denied")
             }
         }
+        return true
+    }
+
+    // Only one permission request can be in flight at a time (single result slot).
+    // Reject a second concurrent request instead of clobbering the first's callback.
+    private fun claimPendingResult(result: MethodChannel.Result): Boolean {
+        if (pendingResult != null) {
+            result.success("denied")
+            return false
+        }
+        pendingResult = result
         return true
     }
 


### PR DESCRIPTION
Enables the geofence module in both sample apps and demonstrates the background-location permission flow.

## What's included
- Geofence build flags + config in both samples (`customerio_geofence_enabled=true`, `GeofenceConfig`).
- Background-location permissions (manifest entries, `Info.plist` usage strings + `location` background mode) and the iOS cold-wake `GeofenceModule.bootstrapForBackgroundDelivery` call.
- A single **state-aware Background Location button** on the Location screen that walks foreground → background and calls `requestLocationUpdate()` after the grant, mirroring the native iOS/Android sample apps. Adds a `getLocationAuthorizationStatus` channel method (iOS + Android) to drive the button label and a lifecycle refresh on resume.

## Stack
- #354 — geofence module build enablement + Dart config
- #355 — native geofence module registration
- #356 — iOS `allowBackgroundDelivery` config
- **this PR** — sample apps (based on #356)

## Ticket
https://linear.app/customerio/issue/MBL-1783/flutter-add-geofencing-support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to internal sample/testbed apps and permission demo plumbing, not the published Flutter SDK or customer integration defaults.
> 
> **Overview**
> Turns on **geofence** in the CocoaPods and SPM Flutter sample apps so internal testing can exercise background geofence delivery end-to-end.
> 
> Both samples set `customerio_geofence_enabled=true`, add Android background-location and boot-completed permissions, wire the iOS **geofence** CocoaPod (CocoaPods app), call `GeofenceModule.bootstrapForBackgroundDelivery` on cold start, and add the **Always** location usage string. SPM initialization now passes `GeofenceConfig()` alongside location.
> 
> The **Location** screen (SPM sample) gains a state-aware **Background Location** flow: native channel methods `getLocationAuthorizationStatus` and `requestBackgroundLocationPermission` on shared Android and SPM iOS handlers (with concurrent-request guarding), lifecycle refresh on resume, and `CustomerIO.location.requestLocationUpdate()` when authorization newly allows foreground or background so geofences can register after runtime grants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5557449eb0718331031e64f3a097e66c2113135e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->