### PR TITLE
chore: pin geofence native SDK versions and sample test wiring

### DIFF
--- a/.github/workflows/reusable-build-sample-apps.yml
+++ b/.github/workflows/reusable-build-sample-apps.yml
@@ -70,6 +70,7 @@ jobs:
           PUBLIC_BUILDS_GROUP: public
           # Input variables
           CURRENT_BRANCH: ${{ github.ref }}
+          PR_HEAD_BRANCH: ${{ github.head_ref }}
           USE_LATEST_SDK_VERSION: ${{ inputs.use_latest_sdk_version }}
           IS_PRIMARY_APP: ${{ inputs.is_primary_app }}
         run: |
@@ -79,6 +80,10 @@ jobs:
           # Only primary app gets additional distribution groups
           if [[ "$IS_PRIMARY_APP" == "true" ]]; then
             [[ "$CURRENT_BRANCH" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+            # TEMP (geofence pre-release): also publish this PR's builds to the feature-branch
+            # channel so peers can test geofence before native Android 4.20.0 / iOS 4.7.0 ship.
+            # Reverted with the rest of the geofence test wiring once native goes live.
+            [[ "$PR_HEAD_BRANCH" == "mbl-1783-geofence-release" ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
             [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$NEXT_BUILDS_GROUP")
             [[ "$USE_LATEST_SDK_VERSION" == "true" ]] && distribution_groups+=("$PUBLIC_BUILDS_GROUP")
           fi
@@ -257,6 +262,7 @@ jobs:
           PUBLIC_BUILDS_GROUP: public
           # Input variables
           CURRENT_BRANCH: ${{ github.ref }}
+          PR_HEAD_BRANCH: ${{ github.head_ref }}
           USE_LATEST_SDK_VERSION: ${{ inputs.use_latest_sdk_version }}
           IS_PRIMARY_APP: ${{ inputs.is_primary_app }}
         run: |
@@ -266,6 +272,10 @@ jobs:
           # Only primary app gets additional distribution groups
           if [[ "$IS_PRIMARY_APP" == "true" ]]; then
             [[ "$CURRENT_BRANCH" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+            # TEMP (geofence pre-release): also publish this PR's builds to the feature-branch
+            # channel so peers can test geofence before native Android 4.20.0 / iOS 4.7.0 ship.
+            # Reverted with the rest of the geofence test wiring once native goes live.
+            [[ "$PR_HEAD_BRANCH" == "mbl-1783-geofence-release" ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
             [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$NEXT_BUILDS_GROUP")
             [[ "$USE_LATEST_SDK_VERSION" == "true" ]] && distribution_groups+=("$PUBLIC_BUILDS_GROUP")
           fi

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 def cioLocationEnabled = rootProject.findProperty("customerio_location_enabled")?.toBoolean() ?: false
+def cioGeofenceEnabled = rootProject.findProperty("customerio_geofence_enabled")?.toBoolean() ?: false
+// Geofence depends on the location module, so location is linked/enabled whenever either is on.
+def cioLocationLinked = cioLocationEnabled || cioGeofenceEnabled
 
 android {
     namespace 'io.customer.customer_io'
@@ -50,7 +53,8 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        buildConfigField "boolean", "CIO_LOCATION_ENABLED", "$cioLocationEnabled"
+        buildConfigField "boolean", "CIO_LOCATION_ENABLED", "$cioLocationLinked"
+        buildConfigField "boolean", "CIO_GEOFENCE_ENABLED", "$cioGeofenceEnabled"
         consumerProguardFiles 'consumer-rules.pro'
     }
 
@@ -72,11 +76,19 @@ dependencies {
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"
     // Location module is optional - customers enable it by adding
-    // customerio_location_enabled=true in their gradle.properties
-    if (cioLocationEnabled) {
+    // customerio_location_enabled=true in their gradle.properties.
+    // Geofence implies Location: enabling geofence pulls in location too.
+    if (cioLocationLinked) {
         implementation "io.customer.android:location:$cioVersion"
     } else {
         compileOnly "io.customer.android:location:$cioVersion"
+    }
+    // Geofence module is optional - customers enable it by adding
+    // customerio_geofence_enabled=true in their gradle.properties
+    if (cioGeofenceEnabled) {
+        implementation "io.customer.android:geofence:$cioVersion"
+    } else {
+        compileOnly "io.customer.android:geofence:$cioVersion"
     }
     
     testImplementation 'junit:junit:4.13.2'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,8 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
+        // TESTING SCAFFOLD: resolve the unreleased geofence snapshot. Revert with this commit.
+        maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
     }
 }
 
@@ -71,7 +73,12 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.20.0"
+    // TESTING SCAFFOLD: build against an unreleased native SDK branch snapshot. To retarget to
+    // the next feature, change cioBranch below. Revert with this commit. Note: Android only
+    // publishes snapshots for open PR branches, so `main` has no snapshot — the Android sample
+    // builds stay red until a native release ships (expected). iOS tracks the branch directly.
+    def cioBranch = "main"
+    def cioVersion = "${cioBranch.replaceAll('/', '-')}-SNAPSHOT"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,7 +71,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.18.2"
+    def cioVersion = "4.20.0"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/src/main/kotlin/io/customer/customer_io/CustomerIOPlugin.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/CustomerIOPlugin.kt
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull
 import io.customer.customer_io.bridge.NativeModuleBridge
 import io.customer.customer_io.bridge.nativeMapArgs
 import io.customer.customer_io.bridge.nativeNoArgs
+import io.customer.customer_io.geofence.CustomerIOGeofence
 import io.customer.customer_io.location.CustomerIOLocation
 import io.customer.customer_io.messaginginapp.CustomerIOInAppMessaging
 import io.customer.customer_io.messagingpush.CustomerIOPushMessaging
@@ -54,9 +55,14 @@ class CustomerIOPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         modules = buildList {
             add(CustomerIOPushMessaging(flutterPluginBinding))
             add(CustomerIOInAppMessaging(flutterPluginBinding))
-            // Location module is optional - enabled via customerio_location_enabled gradle property
+            // Location module is optional - enabled via customerio_location_enabled gradle
+            // property. CIO_LOCATION_ENABLED also covers geofence (geofence implies location).
             if (BuildConfig.CIO_LOCATION_ENABLED) {
                 add(CustomerIOLocation(flutterPluginBinding))
+            }
+            // Geofence module is optional - enabled via customerio_geofence_enabled gradle property
+            if (BuildConfig.CIO_GEOFENCE_ENABLED) {
+                add(CustomerIOGeofence(flutterPluginBinding))
             }
         }
 
@@ -231,13 +237,32 @@ class CustomerIOPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     )
                 }
             }
-            // Configure location module based on config provided by customer app
-            args.getAs<Map<String, Any>>(key = "location")?.let { locationConfig ->
+            // Configure location module. Geofence implies location, so register location
+            // (with the app's config if given, otherwise defaults) whenever location or
+            // geofence is configured, since geofence relies on its location fixes. The build
+            // flags guard each block so the optional bridge classes (which reference native
+            // artifacts that are only linked when enabled) are never touched otherwise.
+            val locationConfig = args.getAs<Map<String, Any>>(key = "location")
+            val geofenceConfig = args.getAs<Map<String, Any>>(key = "geofence")
+            if (BuildConfig.CIO_LOCATION_ENABLED &&
+                (locationConfig != null || (BuildConfig.CIO_GEOFENCE_ENABLED && geofenceConfig != null))
+            ) {
                 modules.filterIsInstance<CustomerIOLocation>().forEach {
                     it.configureModule(
                         builder = this,
-                        config = locationConfig,
+                        config = locationConfig ?: emptyMap(),
                     )
+                }
+            }
+            // Configure geofence module (runs automatically once registered)
+            if (BuildConfig.CIO_GEOFENCE_ENABLED) {
+                geofenceConfig?.let { config ->
+                    modules.filterIsInstance<CustomerIOGeofence>().forEach {
+                        it.configureModule(
+                            builder = this,
+                            config = config,
+                        )
+                    }
                 }
             }
         }.build()

--- a/android/src/main/kotlin/io/customer/customer_io/geofence/CustomerIOGeofence.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/geofence/CustomerIOGeofence.kt
@@ -1,0 +1,29 @@
+package io.customer.customer_io.geofence
+
+import io.customer.customer_io.bridge.NativeModuleBridge
+import io.customer.geofence.GeofenceModuleConfig
+import io.customer.geofence.ModuleGeofence
+import io.customer.sdk.CustomerIOBuilder
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Flutter bridge for the geofence module. Geofence has no Flutter-facing methods —
+ * it runs automatically once registered — so this only wires the native module into
+ * the SDK builder. The reference to [ModuleGeofence] is isolated here so it is loaded
+ * only when the geofence dependency is bundled.
+ *
+ * Geofence depends on the location module; registration of location is handled by the
+ * plugin when geofence is configured.
+ */
+internal class CustomerIOGeofence(
+    pluginBinding: FlutterPlugin.FlutterPluginBinding,
+) : NativeModuleBridge {
+    override val moduleName: String = "Geofence"
+    override val flutterCommunicationChannel: MethodChannel =
+        MethodChannel(pluginBinding.binaryMessenger, "customer_io_geofence")
+
+    override fun configureModule(builder: CustomerIOBuilder, config: Map<String, Any>) {
+        builder.addCustomerIOModule(ModuleGeofence(GeofenceModuleConfig.Builder().build()))
+    }
+}

--- a/android/src/main/kotlin/io/customer/customer_io/geofence/CustomerIOGeofence.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/geofence/CustomerIOGeofence.kt
@@ -1,20 +1,26 @@
 package io.customer.customer_io.geofence
 
 import io.customer.customer_io.bridge.NativeModuleBridge
+import io.customer.customer_io.bridge.nativeNoArgs
+import io.customer.customer_io.utils.getAs
+import io.customer.geofence.GeofenceLocationMode
 import io.customer.geofence.GeofenceModuleConfig
 import io.customer.geofence.ModuleGeofence
 import io.customer.sdk.CustomerIOBuilder
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
 /**
- * Flutter bridge for the geofence module. Geofence has no Flutter-facing methods —
- * it runs automatically once registered — so this only wires the native module into
- * the SDK builder. The reference to [ModuleGeofence] is isolated here so it is loaded
- * only when the geofence dependency is bundled.
+ * Flutter bridge for the geofence module. Wires the native module into the SDK
+ * builder and exposes its Flutter-facing methods. The references to
+ * [ModuleGeofence] are isolated here so they are loaded only when the geofence
+ * dependency is bundled.
  *
- * Geofence depends on the location module; registration of location is handled by the
- * plugin when geofence is configured.
+ * Geofence depends on the location module; registration of location is handled by
+ * the plugin when geofence is configured.
  */
 internal class CustomerIOGeofence(
     pluginBinding: FlutterPlugin.FlutterPluginBinding,
@@ -22,8 +28,39 @@ internal class CustomerIOGeofence(
     override val moduleName: String = "Geofence"
     override val flutterCommunicationChannel: MethodChannel =
         MethodChannel(pluginBinding.binaryMessenger, "customer_io_geofence")
+    private val logger: Logger = SDKComponent.logger
+
+    private fun getModuleGeofence() = runCatching {
+        ModuleGeofence.instance()
+    }.onFailure {
+        logger.error("Geofence module is not initialized. Ensure geofence config is provided during SDK initialization.")
+    }.getOrNull()
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "refreshFromCurrentLocation" -> call.nativeNoArgs(result, ::refreshFromCurrentLocation)
+            else -> super.onMethodCall(call, result)
+        }
+    }
+
+    private fun refreshFromCurrentLocation() {
+        getModuleGeofence()?.refreshFromCurrentLocation()
+    }
 
     override fun configureModule(builder: CustomerIOBuilder, config: Map<String, Any>) {
-        builder.addCustomerIOModule(ModuleGeofence(GeofenceModuleConfig.Builder().build()))
+        val locationModeValue = config.getAs<String>("locationMode")
+        // Uppercase before matching so casing can't diverge from iOS (which uppercases too);
+        // enumValueOf is case-sensitive. Unknown values fall back to the SDK default.
+        val locationMode = locationModeValue?.let { value ->
+            runCatching { enumValueOf<GeofenceLocationMode>(value.uppercase()) }.getOrNull()
+        } ?: GeofenceLocationMode.AUTOMATIC
+
+        builder.addCustomerIOModule(
+            ModuleGeofence(
+                GeofenceModuleConfig.Builder()
+                    .setLocationMode(locationMode)
+                    .build()
+            )
+        )
     }
 }

--- a/apps/flutter_sample_cocoapods/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter_sample_cocoapods/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Required for geofence transition delivery while the app is backgrounded (API 29+) -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <!-- Lets geofence monitoring resume after device reboot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name="${applicationName}"

--- a/apps/flutter_sample_cocoapods/android/gradle.properties
+++ b/apps/flutter_sample_cocoapods/android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
 customerio_location_enabled=true
+customerio_geofence_enabled=true

--- a/apps/flutter_sample_cocoapods/ios/Podfile
+++ b/apps/flutter_sample_cocoapods/ios/Podfile
@@ -45,6 +45,7 @@ target 'Runner' do
   # Uncomment only 1 of the lines below to install a version of the iOS SDK
   pod 'customer_io/fcm', :path => '.symlinks/plugins/customer_io/ios' # install podspec bundled with the plugin
   pod 'customer_io/location', :path => '.symlinks/plugins/customer_io/ios' # install location subspec for testing
+  pod 'customer_io/geofence', :path => '.symlinks/plugins/customer_io/ios' # install geofence subspec for testing (pulls in location)
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: "fcm")
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: "fcm")
 

--- a/apps/flutter_sample_cocoapods/ios/Podfile
+++ b/apps/flutter_sample_cocoapods/ios/Podfile
@@ -47,7 +47,12 @@ target 'Runner' do
   pod 'customer_io/location', :path => '.symlinks/plugins/customer_io/ios' # install location subspec for testing
   pod 'customer_io/geofence', :path => '.symlinks/plugins/customer_io/ios' # install geofence subspec for testing (pulls in location)
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: "fcm")
-  # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: "fcm")
+  # TESTING SCAFFOLD: build against an unreleased native SDK branch. To retarget to the next
+  # feature, change cio_test_branch below (single source for both refs). Revert with this commit.
+  cio_test_branch = 'main'
+  install_non_production_ios_sdk_git_branch(branch_name: cio_test_branch, is_app_extension: false, push_service: "fcm")
+  # Umbrella geofence subspec isn't on the released trunk spec yet, so pull it from the branch too.
+  pod 'CustomerIO/LocationGeofence', :git => 'https://github.com/customerio/customerio-ios.git', :branch => cio_test_branch
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end

--- a/apps/flutter_sample_cocoapods/ios/Runner/AppDelegate.swift
+++ b/apps/flutter_sample_cocoapods/ios/Runner/AppDelegate.swift
@@ -5,6 +5,9 @@ import CioMessagingPushFCM
 import FirebaseMessaging
 import FirebaseCore
 import CioFirebaseWrapper
+#if canImport(CioLocationGeofence)
+import CioLocationGeofence
+#endif
 
 @main
 class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
@@ -17,6 +20,12 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
+
+        #if canImport(CioLocationGeofence)
+        // iOS can cold-wake the app for a geofence transition before the Dart runtime
+        // starts, so bootstrap here rather than relying on CustomerIO.initialize.
+        GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)
+        #endif
 
         let controller = window?.rootViewController as! FlutterViewController
         permissionHandler.register(with: controller.binaryMessenger)

--- a/apps/flutter_sample_cocoapods/ios/Runner/Info.plist
+++ b/apps/flutter_sample_cocoapods/ios/Runner/Info.plist
@@ -102,5 +102,7 @@
 	<string>Required to send push notifications</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app uses your location to test Customer.io location tracking features.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app uses your location in the background to test Customer.io geofence features.</string>
 </dict>
 </plist>

--- a/apps/flutter_sample_spm/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter_sample_spm/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Required for geofence transition delivery while the app is backgrounded (API 29+) -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <!-- Lets geofence monitoring resume after device reboot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name="${applicationName}"

--- a/apps/flutter_sample_spm/android/gradle.properties
+++ b/apps/flutter_sample_spm/android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
 customerio_location_enabled=true
+customerio_geofence_enabled=true

--- a/apps/flutter_sample_spm/ios/Runner/AppDelegate.swift
+++ b/apps/flutter_sample_spm/ios/Runner/AppDelegate.swift
@@ -5,6 +5,9 @@ import CioMessagingPushFCM
 import FirebaseMessaging
 import FirebaseCore
 import CioFirebaseWrapper
+#if canImport(CioLocationGeofence)
+import CioLocationGeofence
+#endif
 
 @main
 class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
@@ -17,7 +20,13 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
-        
+
+        #if canImport(CioLocationGeofence)
+        // iOS can cold-wake the app for a geofence transition before the Dart runtime
+        // starts, so bootstrap here rather than relying on CustomerIO.initialize.
+        GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)
+        #endif
+
         let controller = window?.rootViewController as! FlutterViewController
         permissionHandler.register(with: controller.binaryMessenger)
 

--- a/apps/flutter_sample_spm/ios/Runner/Info.plist
+++ b/apps/flutter_sample_spm/ios/Runner/Info.plist
@@ -102,5 +102,7 @@
 	<string>Required to send push notifications</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app uses your location to test Customer.io location tracking features.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app uses your location in the background to test Customer.io geofence features.</string>
 </dict>
 </plist>

--- a/apps/flutter_sample_spm/ios/Runner/PermissionChannelHandler.swift
+++ b/apps/flutter_sample_spm/ios/Runner/PermissionChannelHandler.swift
@@ -4,6 +4,7 @@ import UIKit
 
 class PermissionChannelHandler: NSObject, CLLocationManagerDelegate {
     private let locationManager = CLLocationManager()
+    // Pending result for the foreground (When In Use) request, resolved by the delegate.
     private var locationPermissionResult: FlutterResult?
 
     func register(with messenger: FlutterBinaryMessenger) {
@@ -23,6 +24,10 @@ class PermissionChannelHandler: NSObject, CLLocationManagerDelegate {
             getNotificationPermissionStatus(result: result)
         case "requestLocationPermission":
             requestLocationPermission(result: result)
+        case "requestBackgroundLocationPermission":
+            requestBackgroundLocationPermission(result: result)
+        case "getLocationAuthorizationStatus":
+            getLocationAuthorizationStatus(result: result)
         case "openAppSettings":
             if let url = URL(string: UIApplication.openSettingsURLString) {
                 UIApplication.shared.open(url)
@@ -30,6 +35,22 @@ class PermissionChannelHandler: NSObject, CLLocationManagerDelegate {
             result(nil)
         default:
             result(FlutterMethodNotImplemented)
+        }
+    }
+
+    // Drives the state-aware "Background Location" button, mirroring the native sample apps.
+    private func getLocationAuthorizationStatus(result: @escaping FlutterResult) {
+        switch locationManager.authorizationStatus {
+        case .authorizedAlways:
+            result("backgroundGranted")
+        case .authorizedWhenInUse:
+            result("foregroundOnly")
+        case .denied, .restricted:
+            result("denied")
+        case .notDetermined:
+            result("notDetermined")
+        @unknown default:
+            result("denied")
         }
     }
 
@@ -58,6 +79,17 @@ class PermissionChannelHandler: NSObject, CLLocationManagerDelegate {
         }
     }
 
+    // Only one permission request can be in flight at a time (single result slot).
+    // Reject a second concurrent request instead of clobbering the first's callback.
+    private func claimPendingResult(_ result: @escaping FlutterResult) -> Bool {
+        if locationPermissionResult != nil {
+            result("denied")
+            return false
+        }
+        locationPermissionResult = result
+        return true
+    }
+
     private func requestLocationPermission(result: @escaping FlutterResult) {
         let status = locationManager.authorizationStatus
         switch status {
@@ -66,13 +98,36 @@ class PermissionChannelHandler: NSObject, CLLocationManagerDelegate {
         case .denied, .restricted:
             result("permanentlyDenied")
         case .notDetermined:
-            locationPermissionResult = result
+            guard claimPendingResult(result) else { return }
             locationManager.requestWhenInUseAuthorization()
         @unknown default:
             result("denied")
         }
     }
 
+    // "Always" authorization is required for geofence region monitoring to wake the app
+    // in the background. iOS escalates from When In Use to Always with a separate prompt.
+    private func requestBackgroundLocationPermission(result: @escaping FlutterResult) {
+        let status = locationManager.authorizationStatus
+        switch status {
+        case .authorizedAlways:
+            result("granted")
+        case .denied, .restricted:
+            result("permanentlyDenied")
+        case .notDetermined, .authorizedWhenInUse:
+            // The Always upgrade is delivered asynchronously, and Core Location may never
+            // call the delegate (e.g. the user keeps "While Using", or the prompt was
+            // already shown once). So don't await it — kick off the request and report
+            // "pending"; the UI reflects the real outcome on resume via the status query.
+            locationManager.requestAlwaysAuthorization()
+            result("pending")
+        @unknown default:
+            result("denied")
+        }
+    }
+
+    // Resolves the foreground (When In Use) request. The background request is fire-and-forget,
+    // so When In Use here is always a foreground grant.
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         guard let result = locationPermissionResult else { return }
         locationPermissionResult = nil

--- a/apps/flutter_sample_spm/lib/src/customer_io.dart
+++ b/apps/flutter_sample_spm/lib/src/customer_io.dart
@@ -74,6 +74,7 @@ class CustomerIOSDK extends ChangeNotifier {
           screenViewUse: _sdkConfig?.screenViewUse,
           inAppConfig: inAppConfig,
           locationConfig: LocationConfig(),
+          geofenceConfig: GeofenceConfig(),
         ),
       );
     } catch (ex) {

--- a/apps/flutter_sample_spm/lib/src/customer_io.dart
+++ b/apps/flutter_sample_spm/lib/src/customer_io.dart
@@ -73,7 +73,9 @@ class CustomerIOSDK extends ChangeNotifier {
           flushInterval: _sdkConfig?.flushInterval?.toInt(),
           screenViewUse: _sdkConfig?.screenViewUse,
           inAppConfig: inAppConfig,
-          locationConfig: LocationConfig(),
+          locationConfig: LocationConfig(
+              trackingMode: _sdkConfig?.locationTrackingMode ??
+                  LocationTrackingMode.onAppStart),
           geofenceConfig: GeofenceConfig(),
         ),
       );

--- a/apps/flutter_sample_spm/lib/src/customer_io.dart
+++ b/apps/flutter_sample_spm/lib/src/customer_io.dart
@@ -75,7 +75,7 @@ class CustomerIOSDK extends ChangeNotifier {
           inAppConfig: inAppConfig,
           locationConfig: LocationConfig(
               trackingMode: _sdkConfig?.locationTrackingMode ??
-                  LocationTrackingMode.onAppStart),
+                  LocationTrackingMode.manual),
           geofenceConfig: GeofenceConfig(),
         ),
       );

--- a/apps/flutter_sample_spm/lib/src/data/config.dart
+++ b/apps/flutter_sample_spm/lib/src/data/config.dart
@@ -16,6 +16,7 @@ class CustomerIOSDKConfig {
   final int? flushAt;
   final int? flushInterval;
   final ScreenView? screenViewUse;
+  final LocationTrackingMode? locationTrackingMode;
   final InAppConfig? inAppConfig;
   final PushConfig pushConfig;
 
@@ -31,6 +32,7 @@ class CustomerIOSDKConfig {
     this.flushAt,
     this.flushInterval,
     this.screenViewUse,
+    this.locationTrackingMode,
     this.inAppConfig,
     PushConfig? pushConfig,
   }) : pushConfig = pushConfig ?? PushConfig();
@@ -51,6 +53,8 @@ class CustomerIOSDKConfig {
         prefs.getEnumValueFromPrefs(_PreferencesKey.region, Region.values);
     final screenViewUse = prefs.getEnumValueFromPrefs(
         _PreferencesKey.screenViewUse, ScreenView.values);
+    final locationTrackingMode = prefs.getEnumValueFromPrefs(
+        _PreferencesKey.locationTrackingMode, LocationTrackingMode.values);
 
     return CustomerIOSDKConfig(
       cdpApiKey: cdpApiKey,
@@ -67,6 +71,7 @@ class CustomerIOSDKConfig {
       flushAt: prefs.getInt(_PreferencesKey.flushAt),
       flushInterval: prefs.getInt(_PreferencesKey.flushInterval),
       screenViewUse: screenViewUse,
+      locationTrackingMode: locationTrackingMode,
       inAppConfig: InAppConfig(
           siteId: prefs.getString(_PreferencesKey.migrationSiteId) ?? ""),
     );
@@ -118,6 +123,9 @@ extension ConfigurationPreferencesExtensions on SharedPreferences {
     result = result &&
         await setOrRemoveString(
             _PreferencesKey.screenViewUse, config.screenViewUse?.name);
+    result = result &&
+        await setOrRemoveString(_PreferencesKey.locationTrackingMode,
+            config.locationTrackingMode?.name);
     return result;
   }
 
@@ -141,4 +149,5 @@ class _PreferencesKey {
   static const flushAt = 'FLUSH_AT';
   static const flushInterval = 'FLUSH_INTERVAL';
   static const screenViewUse = 'SCREEN_VIEW_USE';
+  static const locationTrackingMode = 'LOCATION_TRACKING_MODE';
 }

--- a/apps/flutter_sample_spm/lib/src/screens/location.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/location.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:customer_io/customer_io.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show MethodChannel;
@@ -15,10 +17,48 @@ class LocationScreen extends StatefulWidget {
   State<LocationScreen> createState() => _LocationScreenState();
 }
 
-class _LocationScreenState extends State<LocationScreen> {
+class _LocationScreenState extends State<LocationScreen>
+    with WidgetsBindingObserver {
   final _latitudeController = TextEditingController();
   final _longitudeController = TextEditingController();
   String _statusText = 'No location set yet';
+
+  // Drives the state-aware Background Location button (mirrors the native samples).
+  // One of notDetermined, foregroundOnly, backgroundGranted, denied; null until queried.
+  String? _locationStatus;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _refreshLocationStatus();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Re-query after returning from Settings so the button reflects any change.
+    if (state == AppLifecycleState.resumed) {
+      _refreshLocationStatus();
+    }
+  }
+
+  static const _grantedStatuses = {'foregroundOnly', 'backgroundGranted'};
+
+  Future<void> _refreshLocationStatus() async {
+    final status = await _permissionChannel
+        .invokeMethod<String>('getLocationAuthorizationStatus');
+    if (!mounted) return;
+    final previous = _locationStatus;
+    setState(() => _locationStatus = status);
+    // On any new grant — including one made in Settings and picked up on resume —
+    // fetch so geofences register. The SDK's auto-fetch hook runs once per process,
+    // so a runtime grant needs an explicit request (matches the native sample apps).
+    if (previous != null &&
+        status != previous &&
+        _grantedStatuses.contains(status)) {
+      CustomerIO.location.requestLocationUpdate();
+    }
+  }
 
   static const _presetNames = [
     'New York', 'London', 'Tokyo', 'Sydney', 'Sao Paulo', '0, 0'
@@ -73,16 +113,137 @@ class _LocationScreenState extends State<LocationScreen> {
       return;
     }
 
+    if (!mounted) return;
     if (status == 'granted') {
       CustomerIO.location.requestLocationUpdate();
       setState(() {
         _statusText = 'Requested SDK location update...';
       });
-      if (!mounted) return;
       context.showSnackBar('SDK location update requested');
     } else {
-      if (!mounted) return;
       context.showSnackBar('Location permission denied');
+    }
+  }
+
+  String get _backgroundButtonLabel {
+    switch (_locationStatus) {
+      case 'foregroundOnly':
+        return Platform.isIOS ? "Upgrade to 'Always'" : 'Allow all the time';
+      case 'backgroundGranted':
+        return Platform.isIOS ? 'Always — granted' : 'Background — granted';
+      case 'denied':
+        return 'Open Settings';
+      default:
+        return 'Grant location access';
+    }
+  }
+
+  bool get _backgroundButtonEnabled => _locationStatus != 'backgroundGranted';
+
+  Future<void> _handleBackgroundLocationTap() async {
+    switch (_locationStatus) {
+      case 'foregroundOnly':
+        _showBackgroundRationale();
+        break;
+      case 'backgroundGranted':
+        break;
+      case 'denied':
+        _permissionChannel.invokeMethod('openAppSettings');
+        break;
+      default:
+        // notDetermined, or status not yet loaded: request foreground first.
+        final status = await _permissionChannel
+            .invokeMethod<String>('requestLocationPermission');
+        if (!mounted) return;
+        await _refreshLocationStatus();
+        if (!mounted) return;
+        if (status == 'granted') {
+          // Foreground granted; escalate to background with a rationale.
+          _showBackgroundRationale();
+        } else if (status == 'permanentlyDenied') {
+          _showOpenSettingsDialog();
+        } else {
+          context.showSnackBar('Location permission denied');
+        }
+    }
+  }
+
+  void _showBackgroundRationale() {
+    context.showMessageDialog(
+      'Allow background location?',
+      'Geofence transitions only fire while the app is backgrounded if you grant '
+          '"Always"/"Allow all the time". If no prompt appears, use Open Settings.',
+      actions: [
+        TextButton(
+          child: const Text('Cancel'),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        TextButton(
+          child: const Text('Open Settings'),
+          onPressed: () {
+            Navigator.of(context).pop();
+            _permissionChannel.invokeMethod('openAppSettings');
+          },
+        ),
+        TextButton(
+          child: const Text('Continue'),
+          onPressed: () {
+            Navigator.of(context).pop();
+            _requestBackgroundLocation();
+          },
+        ),
+      ],
+    );
+  }
+
+  void _showOpenSettingsDialog() {
+    context.showMessageDialog(
+      'Location Permission Required',
+      'Location permission is denied. Please enable it from app settings.',
+      actions: [
+        TextButton(
+          child: const Text('Open Settings'),
+          onPressed: () {
+            Navigator.of(context).pop();
+            _permissionChannel.invokeMethod('openAppSettings');
+          },
+        ),
+        TextButton(
+          child: const Text('OK'),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _requestBackgroundLocation() async {
+    final status = await _permissionChannel
+        .invokeMethod<String>('requestBackgroundLocationPermission');
+
+    if (!mounted) return;
+    await _refreshLocationStatus();
+    if (!mounted) return;
+
+    switch (status) {
+      case 'granted':
+        // _refreshLocationStatus above kicks off the fetch on the grant transition.
+        context.showSnackBar(
+            'Background location granted — fetching location to start geofence');
+        break;
+      case 'pending':
+        // iOS: the "Always" prompt resolves asynchronously; the button and geofence
+        // fetch update on resume. Point the user to Settings if no prompt appears.
+        context.showSnackBar(
+            'Requesting background location — enable "Always" in Settings if no prompt appears');
+        break;
+      case 'fineLocationRequired':
+        context.showSnackBar('Grant location access first');
+        break;
+      case 'permanentlyDenied':
+        _showOpenSettingsDialog();
+        break;
+      default:
+        context.showSnackBar('Background location denied');
     }
   }
 
@@ -108,6 +269,7 @@ class _LocationScreenState extends State<LocationScreen> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _latitudeController.dispose();
     _longitudeController.dispose();
     super.dispose();
@@ -134,22 +296,22 @@ class _LocationScreenState extends State<LocationScreen> {
               ),
               const SizedBox(height: 24),
 
-              // Section 1: Quick Presets
+              // Section 1: Background Location (geofence permission)
               _SectionCard(
-                title: 'Quick Presets',
+                title: 'Background Location',
                 description:
-                    'Tap a city to call setLastKnownLocation with its coordinates.',
-                child: Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: List.generate(
-                    _presetNames.length,
-                    (i) => OutlinedButton(
-                      onPressed: () => _setLocation(
-                          _presetCoords[i][0], _presetCoords[i][1], _presetNames[i]),
-                      child: Text(_presetNames[i]),
-                    ),
+                    'Geofence runs automatically once enabled, but needs background '
+                    '("Always"/"Allow all the time") location to deliver transitions '
+                    'while the app is closed. This grants foreground access first, then '
+                    'escalates to background.',
+                child: FilledButton(
+                  style: FilledButton.styleFrom(
+                    minimumSize: sizes.buttonDefault(),
                   ),
+                  onPressed: _backgroundButtonEnabled
+                      ? _handleBackgroundLocationTap
+                      : null,
+                  child: Text(_backgroundButtonLabel),
                 ),
               ),
               const SizedBox(height: 16),
@@ -169,7 +331,27 @@ class _LocationScreenState extends State<LocationScreen> {
               ),
               const SizedBox(height: 16),
 
-              // Section 3: Manual Entry
+              // Section 3: Quick Presets
+              _SectionCard(
+                title: 'Quick Presets',
+                description:
+                    'Tap a city to call setLastKnownLocation with its coordinates.',
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: List.generate(
+                    _presetNames.length,
+                    (i) => OutlinedButton(
+                      onPressed: () => _setLocation(
+                          _presetCoords[i][0], _presetCoords[i][1], _presetNames[i]),
+                      child: Text(_presetNames[i]),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+
+              // Section 4: Manual Entry
               _SectionCard(
                 title: 'Manual Entry',
                 description: 'Enter custom latitude and longitude values.',

--- a/apps/flutter_sample_spm/lib/src/screens/location.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/location.dart
@@ -173,18 +173,11 @@ class _LocationScreenState extends State<LocationScreen>
     context.showMessageDialog(
       'Allow background location?',
       'Geofence transitions only fire while the app is backgrounded if you grant '
-          '"Always"/"Allow all the time". If no prompt appears, use Open Settings.',
+          '"Always"/"Allow all the time".',
       actions: [
         TextButton(
           child: const Text('Cancel'),
           onPressed: () => Navigator.of(context).pop(),
-        ),
-        TextButton(
-          child: const Text('Open Settings'),
-          onPressed: () {
-            Navigator.of(context).pop();
-            _permissionChannel.invokeMethod('openAppSettings');
-          },
         ),
         TextButton(
           child: const Text('Continue'),

--- a/apps/flutter_sample_spm/lib/src/screens/location.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/location.dart
@@ -51,12 +51,13 @@ class _LocationScreenState extends State<LocationScreen>
     final previous = _locationStatus;
     setState(() => _locationStatus = status);
     // On any new grant — including one made in Settings and picked up on resume —
-    // fetch so geofences register. The SDK's auto-fetch hook runs once per process,
-    // so a runtime grant needs an explicit request (matches the native sample apps).
+    // refresh geofences from the current location. This is silent (no location
+    // analytics event) and forces an immediate refresh once permission is granted
+    // at runtime (matches the native sample apps).
     if (previous != null &&
         status != previous &&
         _grantedStatuses.contains(status)) {
-      CustomerIO.location.requestLocationUpdate();
+      CustomerIO.geofence.refreshFromCurrentLocation();
     }
   }
 

--- a/apps/flutter_sample_spm/lib/src/screens/settings.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/settings.dart
@@ -46,6 +46,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late final TextEditingController _flushIntervalValueController;
 
   late ScreenView _screenViewUse;
+  late LocationTrackingMode _locationTrackingMode;
   late bool _featureTrackScreens;
   late bool _featureTrackDeviceAttributes;
   late bool _featureDebugMode;
@@ -68,6 +69,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _flushIntervalValueController =
         TextEditingController(text: cioConfig?.flushInterval?.toString());
     _screenViewUse = cioConfig?.screenViewUse ?? ScreenView.all;
+    _locationTrackingMode =
+        cioConfig?.locationTrackingMode ?? LocationTrackingMode.onAppStart;
     _featureTrackScreens = cioConfig?.screenTrackingEnabled ?? true;
     _featureTrackDeviceAttributes =
         cioConfig?.autoTrackDeviceAttributes ?? true;
@@ -89,6 +92,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         flushAt: _flushAtValueController.text.trim().toIntOrNull(),
         flushInterval: _flushIntervalValueController.text.trim().toIntOrNull(),
         screenViewUse: _screenViewUse,
+        locationTrackingMode: _locationTrackingMode,
         screenTrackingEnabled: _featureTrackScreens,
         autoTrackDeviceAttributes: _featureTrackDeviceAttributes,
         debugModeEnabled: _featureDebugMode,
@@ -123,6 +127,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _flushIntervalValueController.text =
           defaultConfig.flushInterval?.toString() ?? '';
       _screenViewUse = defaultConfig.screenViewUse ?? ScreenView.all;
+      _locationTrackingMode =
+          defaultConfig.locationTrackingMode ?? LocationTrackingMode.onAppStart;
       _featureTrackScreens = defaultConfig.screenTrackingEnabled;
       _featureTrackDeviceAttributes =
           defaultConfig.autoTrackDeviceAttributes ?? true;
@@ -300,6 +306,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             updateState: (ScreenView selected) {
                               setState(() {
                                 _screenViewUse = selected;
+                              });
+                            },
+                          ),
+                          const SizedBox(height: 16),
+                          ChoiceSettingsFormField<LocationTrackingMode>(
+                            labelText: 'Location Tracking Mode',
+                            semanticsLabel: 'Location tracking mode options',
+                            value: _locationTrackingMode,
+                            options: LocationTrackingMode.values,
+                            updateState: (LocationTrackingMode selected) {
+                              setState(() {
+                                _locationTrackingMode = selected;
                               });
                             },
                           ),

--- a/apps/flutter_sample_spm/lib/src/screens/settings.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/settings.dart
@@ -70,7 +70,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         TextEditingController(text: cioConfig?.flushInterval?.toString());
     _screenViewUse = cioConfig?.screenViewUse ?? ScreenView.all;
     _locationTrackingMode =
-        cioConfig?.locationTrackingMode ?? LocationTrackingMode.onAppStart;
+        cioConfig?.locationTrackingMode ?? LocationTrackingMode.manual;
     _featureTrackScreens = cioConfig?.screenTrackingEnabled ?? true;
     _featureTrackDeviceAttributes =
         cioConfig?.autoTrackDeviceAttributes ?? true;
@@ -128,7 +128,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           defaultConfig.flushInterval?.toString() ?? '';
       _screenViewUse = defaultConfig.screenViewUse ?? ScreenView.all;
       _locationTrackingMode =
-          defaultConfig.locationTrackingMode ?? LocationTrackingMode.onAppStart;
+          defaultConfig.locationTrackingMode ?? LocationTrackingMode.manual;
       _featureTrackScreens = defaultConfig.screenTrackingEnabled;
       _featureTrackDeviceAttributes =
           defaultConfig.autoTrackDeviceAttributes ?? true;

--- a/apps/shared/android/io/customer/testbed/flutter/PermissionChannelHandler.kt
+++ b/apps/shared/android/io/customer/testbed/flutter/PermissionChannelHandler.kt
@@ -19,6 +19,7 @@ class PermissionChannelHandler(
     companion object {
         private const val REQUEST_NOTIFICATION = 1001
         private const val REQUEST_LOCATION = 1002
+        private const val REQUEST_BACKGROUND_LOCATION = 1003
     }
 
     private var pendingResult: MethodChannel.Result? = null
@@ -32,6 +33,8 @@ class PermissionChannelHandler(
             "requestNotificationPermission" -> requestNotificationPermission(result)
             "getNotificationPermissionStatus" -> getNotificationPermissionStatus(result)
             "requestLocationPermission" -> requestLocationPermission(result)
+            "requestBackgroundLocationPermission" -> requestBackgroundLocationPermission(result)
+            "getLocationAuthorizationStatus" -> getLocationAuthorizationStatus(result)
             "openAppSettings" -> {
                 val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
                     data = Uri.fromParts("package", activity.packageName, null)
@@ -41,6 +44,22 @@ class PermissionChannelHandler(
             }
             else -> result.notImplemented()
         }
+    }
+
+    // Drives the state-aware "Background Location" button, mirroring the native sample apps.
+    private fun getLocationAuthorizationStatus(result: MethodChannel.Result) {
+        val fineGranted = ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+        if (!fineGranted) {
+            val permanentlyDenied = !ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION) &&
+                hasRequestedPermissionBefore(Manifest.permission.ACCESS_FINE_LOCATION)
+            result.success(if (permanentlyDenied) "denied" else "notDetermined")
+            return
+        }
+        val backgroundGranted = Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+            ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+        result.success(if (backgroundGranted) "backgroundGranted" else "foregroundOnly")
     }
 
     private fun getNotificationPermissionStatus(result: MethodChannel.Result) {
@@ -67,7 +86,7 @@ class PermissionChannelHandler(
             result.success("granted")
             return
         }
-        pendingResult = result
+        if (!claimPendingResult(result)) return
         ActivityCompat.requestPermissions(
             activity,
             arrayOf(Manifest.permission.POST_NOTIFICATIONS),
@@ -86,7 +105,7 @@ class PermissionChannelHandler(
             result.success("permanentlyDenied")
             return
         }
-        pendingResult = result
+        if (!claimPendingResult(result)) return
         markPermissionRequested(Manifest.permission.ACCESS_FINE_LOCATION)
         ActivityCompat.requestPermissions(
             activity,
@@ -95,8 +114,43 @@ class PermissionChannelHandler(
         )
     }
 
+    // Background location is a separate, escalated grant required for geofence transition
+    // delivery while the app is backgrounded. It only exists as its own permission on
+    // API 29+, and on API 30+ the OS requires fine location to be granted first.
+    private fun requestBackgroundLocationPermission(result: MethodChannel.Result) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            result.success("granted")
+            return
+        }
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
+            != PackageManager.PERMISSION_GRANTED) {
+            result.success("fineLocationRequired")
+            return
+        }
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+            == PackageManager.PERMISSION_GRANTED) {
+            result.success("granted")
+            return
+        }
+        if (!ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+            && hasRequestedPermissionBefore(Manifest.permission.ACCESS_BACKGROUND_LOCATION)) {
+            result.success("permanentlyDenied")
+            return
+        }
+        if (!claimPendingResult(result)) return
+        markPermissionRequested(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        ActivityCompat.requestPermissions(
+            activity,
+            arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION),
+            REQUEST_BACKGROUND_LOCATION
+        )
+    }
+
     fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray): Boolean {
-        if (requestCode != REQUEST_NOTIFICATION && requestCode != REQUEST_LOCATION) return false
+        if (requestCode != REQUEST_NOTIFICATION &&
+            requestCode != REQUEST_LOCATION &&
+            requestCode != REQUEST_BACKGROUND_LOCATION
+        ) return false
 
         val result = pendingResult ?: return false
         pendingResult = null
@@ -111,6 +165,17 @@ class PermissionChannelHandler(
                 result.success("denied")
             }
         }
+        return true
+    }
+
+    // Only one permission request can be in flight at a time (single result slot).
+    // Reject a second concurrent request instead of clobbering the first's callback.
+    private fun claimPendingResult(result: MethodChannel.Result): Boolean {
+        if (pendingResult != null) {
+            result.success("denied")
+            return false
+        }
+        pendingResult = result
         return true
     }
 

--- a/customerio-flutter.api
+++ b/customerio-flutter.api
@@ -59,7 +59,8 @@ public final class CustomerIOConfig {
 		InAppConfig? inAppConfig,
 		PushConfig? pushConfig,
 		LocationConfig? locationConfig,
-		GeofenceConfig? geofenceConfig
+		GeofenceConfig? geofenceConfig,
+		CustomerIOConfigIos? iosConfig
 	): CustomerIOConfig;
 	public fun toMap(): Map<String, dynamic>;
 	public val apiHost: String?;
@@ -70,6 +71,7 @@ public final class CustomerIOConfig {
 	public val flushInterval: int?;
 	public val geofenceConfig: GeofenceConfig?;
 	public val inAppConfig: InAppConfig?;
+	public val iosConfig: CustomerIOConfigIos?;
 	public val locationConfig: LocationConfig?;
 	public val logLevel: CioLogLevel?;
 	public val migrationSiteId: String?;
@@ -79,6 +81,12 @@ public final class CustomerIOConfig {
 	public val source: String;
 	public val trackApplicationLifecycleEvents: bool?;
 	public val version: String;
+}
+
+public final class CustomerIOConfigIos {
+	public fun new(bool? allowBackgroundDelivery): CustomerIOConfigIos;
+	public fun toMap(): Map<String, dynamic>;
+	public val allowBackgroundDelivery: bool?;
 }
 
 public final class CustomerIOLocationPlatform {

--- a/customerio-flutter.api
+++ b/customerio-flutter.api
@@ -58,7 +58,8 @@ public final class CustomerIOConfig {
 		ScreenView? screenViewUse,
 		InAppConfig? inAppConfig,
 		PushConfig? pushConfig,
-		LocationConfig? locationConfig
+		LocationConfig? locationConfig,
+		GeofenceConfig? geofenceConfig
 	): CustomerIOConfig;
 	public fun toMap(): Map<String, dynamic>;
 	public val apiHost: String?;
@@ -67,6 +68,7 @@ public final class CustomerIOConfig {
 	public val cdpApiKey: String;
 	public val flushAt: int?;
 	public val flushInterval: int?;
+	public val geofenceConfig: GeofenceConfig?;
 	public val inAppConfig: InAppConfig?;
 	public val locationConfig: LocationConfig?;
 	public val logLevel: CioLogLevel?;
@@ -151,6 +153,11 @@ public final class EventType {
 	static public val messageDismissed: EventType;
 	static public val messageShown: EventType;
 	static public val values: List<EventType>;
+}
+
+public final class GeofenceConfig {
+	public fun new(): GeofenceConfig;
+	public fun toMap(): Map<String, dynamic>;
 }
 
 public final class InAppConfig {

--- a/customerio-flutter.api
+++ b/customerio-flutter.api
@@ -12,7 +12,8 @@ public final class CustomerIO {
 		CustomerIOPlatform? platform,
 		CustomerIOMessagingPushPlatform? pushMessaging,
 		CustomerIOMessagingInAppPlatform? inAppMessaging,
-		CustomerIOLocationPlatform? location
+		CustomerIOLocationPlatform? location,
+		CustomerIOGeofencePlatform? geofence
 	): CustomerIO;
 	public fun deleteDeviceToken();
 	public fun identify(
@@ -37,6 +38,7 @@ public final class CustomerIO {
 		required String deviceToken,
 		required MetricEvent event
 	);
+	static public val geofence: CustomerIOGeofencePlatform;
 	static public val inAppMessaging: CustomerIOMessagingInAppPlatform;
 	static public val instance: CustomerIO;
 	static public val location: CustomerIOLocationPlatform;
@@ -87,6 +89,12 @@ public final class CustomerIOConfigIos {
 	public fun new(bool? allowBackgroundDelivery): CustomerIOConfigIos;
 	public fun toMap(): Map<String, dynamic>;
 	public val allowBackgroundDelivery: bool?;
+}
+
+public final class CustomerIOGeofencePlatform {
+	public fun new(): CustomerIOGeofencePlatform;
+	public fun refreshFromCurrentLocation();
+	static public var instance: CustomerIOGeofencePlatform;
 }
 
 public final class CustomerIOLocationPlatform {
@@ -164,8 +172,16 @@ public final class EventType {
 }
 
 public final class GeofenceConfig {
-	public fun new(): GeofenceConfig;
+	public fun new(GeofenceLocationMode locationMode): GeofenceConfig;
 	public fun toMap(): Map<String, dynamic>;
+	public val locationMode: GeofenceLocationMode;
+}
+
+public final class GeofenceLocationMode {
+	static public val automatic: GeofenceLocationMode;
+	static public val manual: GeofenceLocationMode;
+	public val rawValue: String;
+	static public val values: List<GeofenceLocationMode>;
 }
 
 public final class InAppConfig {

--- a/ios/customer_io.podspec
+++ b/ios/customer_io.podspec
@@ -47,6 +47,12 @@ Pod::Spec.new do |s|
     ss.dependency "CustomerIO/Location", native_sdk_version
   end
 
+  # Geofence module is optional - customers must opt in by adding this subspec.
+  # It pulls in Location transitively (CustomerIO/LocationGeofence depends on it).
+  s.subspec 'geofence' do |ss|
+    ss.dependency "CustomerIO/LocationGeofence", native_sdk_version
+  end
+
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -3,16 +3,21 @@
 import PackageDescription
 import Foundation
 
-// MARK: - Location Module Configuration
+// MARK: - Location / Geofence Module Configuration
 //
-// The Location module is optional and excluded by default.
-// To enable it, use ONE of these approaches (checked in this order):
+// The Location and Geofence modules are optional and excluded by default.
+// To enable either, use ONE of these approaches (checked in this order):
 //
 // 1. Set in your Flutter app's android/gradle.properties (recommended, works for both platforms):
 //      customerio_location_enabled=true
+//      customerio_geofence_enabled=true
 //
 // 2. Set an environment variable (required for Flutter add-to-app modules or custom project structures):
 //      CIO_LOCATION=true flutter build ios
+//      CIO_GEOFENCE=true flutter build ios
+//
+// Geofence implies Location: enabling geofence also pulls in the Location
+// module, since geofence reacts to location fixes published by it.
 //
 
 /// Reads a value for the given key from a Java-style .properties file.
@@ -52,28 +57,33 @@ func readGradleProperty(_ key: String, from startDir: String) -> String? {
     return nil
 }
 
-/// Determines whether the Location module should be included.
-/// Checks gradle.properties first (file-based, persistent), then falls back to environment variable.
-/// Returns false if no configuration is found (Location is opt-in).
-let useLocation: Bool = {
+/// Resolves a boolean opt-in flag, checking gradle.properties first (file-based, persistent),
+/// then falling back to an environment variable. Returns false if no configuration is found.
+func isModuleEnabled(gradleKey: String, envKey: String) -> Bool {
     let env = ProcessInfo.processInfo.environment
-    let key = "customerio_location_enabled"
 
     // 1. Try gradle.properties via PWD (preserves symlink path in Flutter's SPM structure).
     if let pwd = env["PWD"],
-       let value = readGradleProperty(key, from: pwd) {
+       let value = readGradleProperty(gradleKey, from: pwd) {
         return value.lowercased() == "true"
     }
 
     // 2. Try gradle.properties via FileManager cwd (resolves symlinks; works for direct CLI usage).
     let cwd = FileManager.default.currentDirectoryPath
-    if let value = readGradleProperty(key, from: cwd) {
+    if let value = readGradleProperty(gradleKey, from: cwd) {
         return value.lowercased() == "true"
     }
 
     // 3. Fallback: environment variable (required for add-to-app modules and custom project layouts).
-    return env["CIO_LOCATION"]?.lowercased() == "true"
-}()
+    return env[envKey]?.lowercased() == "true"
+}
+
+/// Whether the Geofence module should be included (opt-in).
+let useGeofence = isModuleEnabled(gradleKey: "customerio_geofence_enabled", envKey: "CIO_GEOFENCE")
+
+/// Whether the Location module should be included. Opt-in, and also implied by
+/// geofence, which depends on it.
+let useLocation = isModuleEnabled(gradleKey: "customerio_location_enabled", envKey: "CIO_LOCATION") || useGeofence
 
 var targetDependencies: [Target.Dependency] = [
     .product(name: "DataPipelines", package: "customerio-ios"),
@@ -84,6 +94,10 @@ var targetDependencies: [Target.Dependency] = [
 
 if useLocation {
     targetDependencies.append(.product(name: "Location", package: "customerio-ios"))
+}
+
+if useGeofence {
+    targetDependencies.append(.product(name: "LocationGeofence", package: "customerio-ios"))
 }
 
 let package = Package(

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -109,7 +109,9 @@ let package = Package(
         .library(name: "customer-io", targets: ["customer_io"])
     ],
     dependencies: [
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.7.0"),
+        // TESTING SCAFFOLD: build against an unreleased native SDK branch. To retarget to the
+        // next feature, change the branch name below. Revert with this commit.
+        .package(url: "https://github.com/customerio/customerio-ios.git", branch: "main"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -109,7 +109,7 @@ let package = Package(
         .library(name: "customer-io", targets: ["customer_io"])
     ],
     dependencies: [
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.5.3"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.7.0"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -202,6 +202,15 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
             #endif
             #endif
 
+            // Customer value wins; otherwise on when the geofence module is added, off otherwise.
+            #if canImport(CioLocationGeofence)
+            let geofenceAdded = params["geofence"] as? [String: AnyHashable] != nil
+            #else
+            let geofenceAdded = false
+            #endif
+            let allowBackgroundDelivery = (params["ios"] as? [String: AnyHashable])?["allowBackgroundDelivery"] as? Bool
+            _ = sdkConfigBuilder.allowBackgroundDelivery(allowBackgroundDelivery ?? geofenceAdded)
+
             CustomerIO.initialize(withConfig: sdkConfigBuilder.build())
 
             // Initialize in-app messaging with provided config

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -6,6 +6,9 @@ import UIKit
 #if canImport(CioLocation)
 import CioLocation
 #endif
+#if canImport(CioLocationGeofence)
+import CioLocationGeofence
+#endif
 
 public class CustomerIOPlugin: NSObject, FlutterPlugin {
     private var methodChannel: FlutterMethodChannel!
@@ -167,9 +170,18 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
             let sdkConfigBuilder = try SDKConfigBuilder.create(from: params)
 
             #if canImport(CioLocation)
-            // Add location module to config builder if location config is provided
-            if let locationConfig = params["location"] as? [String: AnyHashable] {
-                let trackingModeValue = locationConfig["trackingMode"] as? String
+            let locationConfig = params["location"] as? [String: AnyHashable]
+            #if canImport(CioLocationGeofence)
+            let geofenceConfigured = params["geofence"] as? [String: AnyHashable] != nil
+            #else
+            let geofenceConfigured = false
+            #endif
+
+            // Add location module when location or geofence is configured. Geofence implies
+            // location: it relies on the location module's fixes, so register location (with
+            // the app's config if given, otherwise defaults) whenever geofence is enabled.
+            if locationConfig != nil || geofenceConfigured {
+                let trackingModeValue = locationConfig?["trackingMode"] as? String
                 let mode: LocationTrackingMode
                 switch trackingModeValue?.uppercased() {
                 case "OFF":
@@ -181,6 +193,13 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
                 }
                 _ = sdkConfigBuilder.addModule(LocationModule(config: LocationConfig(mode: mode)))
             }
+
+            #if canImport(CioLocationGeofence)
+            // Geofence runs automatically once registered; relies on the location module above.
+            if geofenceConfigured {
+                _ = sdkConfigBuilder.addModule(GeofenceModule())
+            }
+            #endif
             #endif
 
             CustomerIO.initialize(withConfig: sdkConfigBuilder.build())

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -16,6 +16,9 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
     #if canImport(CioLocation)
     private var locationChannelHandler: CustomerIOLocation!
     #endif
+    #if canImport(CioLocationGeofence)
+    private var geofenceChannelHandler: CustomerIOGeofence!
+    #endif
     private var messagingPushChannelHandler: CustomerIOMessagingPush!
 
     private let logger: CioInternalCommon.Logger = DIGraphShared.shared.logger
@@ -29,6 +32,9 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
         instance.inAppMessagingChannelHandler = CustomerIOInAppMessaging(with: registrar)
         #if canImport(CioLocation)
         instance.locationChannelHandler = CustomerIOLocation(with: registrar)
+        #endif
+        #if canImport(CioLocationGeofence)
+        instance.geofenceChannelHandler = CustomerIOGeofence(with: registrar)
         #endif
         instance.messagingPushChannelHandler = CustomerIOMessagingPush(with: registrar)
     }
@@ -195,9 +201,16 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
             }
 
             #if canImport(CioLocationGeofence)
-            // Geofence runs automatically once registered; relies on the location module above.
-            if geofenceConfigured {
-                _ = sdkConfigBuilder.addModule(GeofenceModule())
+            // Geofence relies on the location module above.
+            if let geofenceConfig = params["geofence"] as? [String: AnyHashable] {
+                let locationMode: GeofenceLocationMode
+                switch (geofenceConfig["locationMode"] as? String)?.uppercased() {
+                case "MANUAL":
+                    locationMode = .manual
+                default:
+                    locationMode = .automatic
+                }
+                _ = sdkConfigBuilder.addModule(GeofenceModule(config: GeofenceModuleConfig(locationMode: locationMode)))
             }
             #endif
             #endif

--- a/ios/customer_io/Sources/customer_io/Geofence/CustomerIOGeofence.swift
+++ b/ios/customer_io/Sources/customer_io/Geofence/CustomerIOGeofence.swift
@@ -1,0 +1,45 @@
+#if canImport(CioLocationGeofence)
+import CioInternalCommon
+import CioLocationGeofence
+import Flutter
+import Foundation
+
+public class CustomerIOGeofence: NSObject, FlutterPlugin {
+    private var methodChannel: FlutterMethodChannel?
+    private let logger: Logger = DIGraphShared.shared.logger
+
+    public static func register(with _: FlutterPluginRegistrar) {}
+
+    init(with registrar: FlutterPluginRegistrar) {
+        super.init()
+
+        methodChannel = FlutterMethodChannel(name: "customer_io_geofence", binaryMessenger: registrar.messenger())
+
+        guard let methodChannel = methodChannel else {
+            print("customer_io_geofence methodChannel is nil")
+            return
+        }
+
+        registrar.addMethodCallDelegate(self, channel: methodChannel)
+    }
+
+    deinit {
+        methodChannel?.setMethodCallHandler(nil)
+        methodChannel = nil
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "refreshFromCurrentLocation":
+            call.nativeNoArgs(result: result, handler: refreshFromCurrentLocation)
+
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func refreshFromCurrentLocation() {
+        CustomerIO.geofence.refreshFromCurrentLocation()
+    }
+}
+#endif

--- a/lib/config/customer_io_config.dart
+++ b/lib/config/customer_io_config.dart
@@ -1,5 +1,6 @@
 import '../customer_io_enums.dart';
 import '../customer_io_plugin_version.dart' as plugin_info show version;
+import 'geofence_config.dart';
 import 'in_app_config.dart';
 import 'location_config.dart';
 import 'push_config.dart';
@@ -22,6 +23,7 @@ class CustomerIOConfig {
   final InAppConfig? inAppConfig;
   final PushConfig pushConfig;
   final LocationConfig? locationConfig;
+  final GeofenceConfig? geofenceConfig;
 
   CustomerIOConfig({
     required this.cdpApiKey,
@@ -38,6 +40,7 @@ class CustomerIOConfig {
     this.inAppConfig,
     PushConfig? pushConfig,
     this.locationConfig,
+    this.geofenceConfig,
   }) : pushConfig = pushConfig ?? PushConfig();
 
   Map<String, dynamic> toMap() {
@@ -56,6 +59,7 @@ class CustomerIOConfig {
       'inApp': inAppConfig?.toMap(),
       'push': pushConfig.toMap(),
       'location': locationConfig?.toMap(),
+      'geofence': geofenceConfig?.toMap(),
       'version': version,
       'source': source
     };

--- a/lib/config/customer_io_config.dart
+++ b/lib/config/customer_io_config.dart
@@ -2,6 +2,7 @@ import '../customer_io_enums.dart';
 import '../customer_io_plugin_version.dart' as plugin_info show version;
 import 'geofence_config.dart';
 import 'in_app_config.dart';
+import 'ios_config.dart';
 import 'location_config.dart';
 import 'push_config.dart';
 
@@ -24,6 +25,7 @@ class CustomerIOConfig {
   final PushConfig pushConfig;
   final LocationConfig? locationConfig;
   final GeofenceConfig? geofenceConfig;
+  final CustomerIOConfigIos? iosConfig;
 
   CustomerIOConfig({
     required this.cdpApiKey,
@@ -41,6 +43,7 @@ class CustomerIOConfig {
     PushConfig? pushConfig,
     this.locationConfig,
     this.geofenceConfig,
+    this.iosConfig,
   }) : pushConfig = pushConfig ?? PushConfig();
 
   Map<String, dynamic> toMap() {
@@ -60,6 +63,7 @@ class CustomerIOConfig {
       'push': pushConfig.toMap(),
       'location': locationConfig?.toMap(),
       'geofence': geofenceConfig?.toMap(),
+      'ios': iosConfig?.toMap(),
       'version': version,
       'source': source
     };

--- a/lib/config/geofence_config.dart
+++ b/lib/config/geofence_config.dart
@@ -1,0 +1,12 @@
+/// Configuration for the optional Geofence module.
+///
+/// Geofence runs automatically once enabled and has no options yet. Providing a
+/// [GeofenceConfig] opts the app into geofence monitoring; this also enables the
+/// Location module, which geofence depends on.
+class GeofenceConfig {
+  GeofenceConfig();
+
+  Map<String, dynamic> toMap() {
+    return {};
+  }
+}

--- a/lib/config/geofence_config.dart
+++ b/lib/config/geofence_config.dart
@@ -1,12 +1,19 @@
+import '../customer_io_enums.dart';
+
 /// Configuration for the optional Geofence module.
 ///
-/// Geofence runs automatically once enabled and has no options yet. Providing a
-/// [GeofenceConfig] opts the app into geofence monitoring; this also enables the
-/// Location module, which geofence depends on.
+/// Providing a [GeofenceConfig] opts the app into geofence monitoring; this also
+/// enables the Location module, which geofence depends on.
 class GeofenceConfig {
-  GeofenceConfig();
+  /// How the module acquires the device location it needs for geofencing.
+  /// Defaults to [GeofenceLocationMode.automatic].
+  final GeofenceLocationMode locationMode;
+
+  GeofenceConfig({this.locationMode = GeofenceLocationMode.automatic});
 
   Map<String, dynamic> toMap() {
-    return {};
+    return {
+      'locationMode': locationMode.rawValue,
+    };
   }
 }

--- a/lib/config/ios_config.dart
+++ b/lib/config/ios_config.dart
@@ -1,0 +1,14 @@
+/// iOS-only SDK configuration; has no effect on Android.
+class CustomerIOConfigIos {
+  /// Whether geofence transitions are delivered in real time on a background cold-wake.
+  /// When unset, defaults on if the geofence module is added, off otherwise.
+  final bool? allowBackgroundDelivery;
+
+  CustomerIOConfigIos({this.allowBackgroundDelivery});
+
+  Map<String, dynamic> toMap() {
+    return {
+      'allowBackgroundDelivery': allowBackgroundDelivery,
+    };
+  }
+}

--- a/lib/customer_io.dart
+++ b/lib/customer_io.dart
@@ -7,6 +7,7 @@ import 'customer_io_config.dart';
 import 'customer_io_enums.dart';
 import 'data_pipelines/customer_io_platform_interface.dart';
 import 'extensions/map_extensions.dart';
+import 'geofence/platform_interface.dart';
 import 'location/platform_interface.dart';
 import 'messaging_in_app/platform_interface.dart';
 import 'messaging_push/platform_interface.dart';
@@ -18,6 +19,7 @@ class CustomerIO {
   final CustomerIOMessagingPushPlatform _pushMessaging;
   final CustomerIOMessagingInAppPlatform _inAppMessaging;
   final CustomerIOLocationPlatform _location;
+  final CustomerIOGeofencePlatform _geofence;
 
   /// Private constructor to enforce singleton pattern
   CustomerIO._({
@@ -25,12 +27,14 @@ class CustomerIO {
     CustomerIOMessagingPushPlatform? pushMessaging,
     CustomerIOMessagingInAppPlatform? inAppMessaging,
     CustomerIOLocationPlatform? location,
+    CustomerIOGeofencePlatform? geofence,
   })  : _platform = platform ?? CustomerIOPlatform.instance,
         _pushMessaging =
             pushMessaging ?? CustomerIOMessagingPushPlatform.instance,
         _inAppMessaging =
             inAppMessaging ?? CustomerIOMessagingInAppPlatform.instance,
-        _location = location ?? CustomerIOLocationPlatform.instance;
+        _location = location ?? CustomerIOLocationPlatform.instance,
+        _geofence = geofence ?? CustomerIOGeofencePlatform.instance;
 
   /// Get the singleton instance of CustomerIO
   static CustomerIO get instance {
@@ -50,12 +54,14 @@ class CustomerIO {
     CustomerIOMessagingPushPlatform? pushMessaging,
     CustomerIOMessagingInAppPlatform? inAppMessaging,
     CustomerIOLocationPlatform? location,
+    CustomerIOGeofencePlatform? geofence,
   }) {
     _instance = CustomerIO._(
       platform: platform,
       pushMessaging: pushMessaging,
       inAppMessaging: inAppMessaging,
       location: location,
+      geofence: geofence,
     );
     return _instance!;
   }
@@ -80,6 +86,11 @@ class CustomerIO {
   /// Access location functionality
   static CustomerIOLocationPlatform get location {
     return _instance?._location ?? CustomerIOLocationPlatform.instance;
+  }
+
+  /// Access geofence functionality
+  static CustomerIOGeofencePlatform get geofence {
+    return _instance?._geofence ?? CustomerIOGeofencePlatform.instance;
   }
 
   /// To initialize the plugin

--- a/lib/customer_io_config.dart
+++ b/lib/customer_io_config.dart
@@ -1,5 +1,6 @@
 export 'config/customer_io_config.dart';
 export 'config/geofence_config.dart';
 export 'config/in_app_config.dart';
+export 'config/ios_config.dart';
 export 'config/location_config.dart';
 export 'config/push_config.dart';

--- a/lib/customer_io_config.dart
+++ b/lib/customer_io_config.dart
@@ -1,4 +1,5 @@
 export 'config/customer_io_config.dart';
+export 'config/geofence_config.dart';
 export 'config/in_app_config.dart';
 export 'config/location_config.dart';
 export 'config/push_config.dart';

--- a/lib/customer_io_enums.dart
+++ b/lib/customer_io_enums.dart
@@ -56,3 +56,18 @@ enum LocationTrackingMode {
 
   final String rawValue;
 }
+
+/// How the geofence module acquires the device location it needs for
+/// geofencing. Location acquired for geofencing is never sent to analytics.
+enum GeofenceLocationMode {
+  /// SDK acquires a fix itself when geofencing needs one and none is available
+  /// (default).
+  automatic(rawValue: 'AUTOMATIC'),
+
+  /// Host drives it via `CustomerIO.geofence.refreshFromCurrentLocation()`.
+  manual(rawValue: 'MANUAL');
+
+  const GeofenceLocationMode({required this.rawValue});
+
+  final String rawValue;
+}

--- a/lib/geofence/_native_constants.dart
+++ b/lib/geofence/_native_constants.dart
@@ -1,0 +1,4 @@
+/// Methods specific to Geofence module.
+class NativeMethods {
+  static const String refreshFromCurrentLocation = "refreshFromCurrentLocation";
+}

--- a/lib/geofence/method_channel.dart
+++ b/lib/geofence/method_channel.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import '_native_constants.dart';
+import 'platform_interface.dart';
+
+class CustomerIOGeofenceMethodChannel extends CustomerIOGeofencePlatform {
+  final MethodChannel methodChannel =
+      const MethodChannel('customer_io_geofence');
+
+  static bool _warnedNotEnabled = false;
+
+  /// Invokes a geofence method on the native side, handling all errors safely
+  /// for fire-and-forget calls. Logs a one-time warning if the geofence module
+  /// is not enabled.
+  Future<void> _invokeGeofenceMethod(String method,
+      [Map<String, dynamic> arguments = const {}]) async {
+    try {
+      await methodChannel.invokeMethod<void>(method, arguments);
+    } on MissingPluginException {
+      if (!_warnedNotEnabled && kDebugMode) {
+        _warnedNotEnabled = true;
+        debugPrint('Customer.io: Geofence module is not enabled. '
+            'To use geofence features, add the geofence subspec to your '
+            'Podfile (iOS) or set customerio_geofence_enabled=true in '
+            'gradle.properties (Android).');
+      }
+    } catch (ex) {
+      if (kDebugMode) {
+        debugPrint("Customer.io: Error invoking geofence method '$method': $ex");
+      }
+    }
+  }
+
+  @override
+  void refreshFromCurrentLocation() {
+    _invokeGeofenceMethod(NativeMethods.refreshFromCurrentLocation);
+  }
+}

--- a/lib/geofence/platform_interface.dart
+++ b/lib/geofence/platform_interface.dart
@@ -1,0 +1,28 @@
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import 'method_channel.dart';
+
+abstract class CustomerIOGeofencePlatform extends PlatformInterface {
+  CustomerIOGeofencePlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static CustomerIOGeofencePlatform _instance =
+      CustomerIOGeofenceMethodChannel();
+
+  static CustomerIOGeofencePlatform get instance => _instance;
+
+  static set instance(CustomerIOGeofencePlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  /// Requests a one-shot location fix and refreshes the nearby geofence set from
+  /// it, without emitting a location analytics event or caching the fix. Call
+  /// after the host app has been granted location permission; the SDK never
+  /// requests permission itself.
+  void refreshFromCurrentLocation() {
+    throw UnimplementedError(
+        'refreshFromCurrentLocation() has not been implemented.');
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.5.3
+        native_sdk_version: 4.7.0
         firebase_wrapper_version: 1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.7.0
+        native_sdk_version: 4.6.1
         firebase_wrapper_version: 1.0.0

--- a/test/customer_io_config_test.dart
+++ b/test/customer_io_config_test.dart
@@ -110,6 +110,7 @@ void main() {
         'inApp': inAppConfig.toMap(),
         'push': pushConfig.toMap(),
         'location': null,
+        'geofence': null,
         'version': config.version,
         'source': config.source,
       };

--- a/test/customer_io_config_test.dart
+++ b/test/customer_io_config_test.dart
@@ -111,6 +111,7 @@ void main() {
         'push': pushConfig.toMap(),
         'location': null,
         'geofence': null,
+        'ios': null,
         'version': config.version,
         'source': config.source,
       };


### PR DESCRIPTION
## Summary

Pins the native SDKs to the released versions that contain geofence support.

The native geofence work is now **released** on both platforms, so this PR is down to a single production change — the temporary test scaffolding that previously kept the sample apps building against pre-release native code has been **removed entirely**.

| Platform | Pin | File |
|---|---|---|
| Android | `cioVersion` → **`4.20.0`** | `android/build.gradle` |
| iOS (SPM) | `exact:` → **`4.7.0`** | `ios/customer_io/Package.swift` |
| iOS (CocoaPods) | `native_sdk_version` → **`4.7.0`** | `pubspec.yaml` |

## What changed since the last review

This PR was previously **two commits** (production pins + temporary scaffolding that pointed at native snapshots/branches). Now that the native SDKs are live, **the scaffold commit is dropped** and only the production pins remain. Removed with it:

- Android `-SNAPSHOT` version + Sonatype snapshots repo
- iOS SPM `branch:` pin and CocoaPods branch overrides / `CustomerIO/LocationGeofence` git pod
- The temporary `native_sdk_version` downgrade
- The `feature-branch` Firebase distribution tweak in `reusable-build-sample-apps.yml`

Net result: **3 files, 3 lines.**

## Verified locally

- **Android** — sample builds clean against released `4.20.0` (debug APK produced); `io.customer.android:geofence:4.20.0` resolves from Maven Central.
- **iOS SPM** — `4.7.0` git tag is live.
- **iOS CocoaPods** — ⏳ the `4.7.0` podspecs are **not on the CocoaPods trunk yet** (the iOS `Deploy SDK` run is still publishing them). Until that finishes, the CocoaPods sample can't resolve `CustomerIO/Location (= 4.7.0)`. This is a publish-timing gap, not a problem with these pins — the CocoaPods job goes green once trunk has `4.7.0` (re-run it if it fails first).

## Ticket
https://linear.app/customerio/issue/MBL-1783/flutter-add-geofencing-support
