### PR TITLE
chore: add location tracking mode setting to sample apps

### DIFF
--- a/apps/flutter_sample_spm/lib/src/customer_io.dart
+++ b/apps/flutter_sample_spm/lib/src/customer_io.dart
@@ -73,7 +73,9 @@ class CustomerIOSDK extends ChangeNotifier {
           flushInterval: _sdkConfig?.flushInterval?.toInt(),
           screenViewUse: _sdkConfig?.screenViewUse,
           inAppConfig: inAppConfig,
-          locationConfig: LocationConfig(),
+          locationConfig: LocationConfig(
+              trackingMode: _sdkConfig?.locationTrackingMode ??
+                  LocationTrackingMode.onAppStart),
           geofenceConfig: GeofenceConfig(),
         ),
       );

--- a/apps/flutter_sample_spm/lib/src/data/config.dart
+++ b/apps/flutter_sample_spm/lib/src/data/config.dart
@@ -16,6 +16,7 @@ class CustomerIOSDKConfig {
   final int? flushAt;
   final int? flushInterval;
   final ScreenView? screenViewUse;
+  final LocationTrackingMode? locationTrackingMode;
   final InAppConfig? inAppConfig;
   final PushConfig pushConfig;
 
@@ -31,6 +32,7 @@ class CustomerIOSDKConfig {
     this.flushAt,
     this.flushInterval,
     this.screenViewUse,
+    this.locationTrackingMode,
     this.inAppConfig,
     PushConfig? pushConfig,
   }) : pushConfig = pushConfig ?? PushConfig();
@@ -51,6 +53,8 @@ class CustomerIOSDKConfig {
         prefs.getEnumValueFromPrefs(_PreferencesKey.region, Region.values);
     final screenViewUse = prefs.getEnumValueFromPrefs(
         _PreferencesKey.screenViewUse, ScreenView.values);
+    final locationTrackingMode = prefs.getEnumValueFromPrefs(
+        _PreferencesKey.locationTrackingMode, LocationTrackingMode.values);
 
     return CustomerIOSDKConfig(
       cdpApiKey: cdpApiKey,
@@ -67,6 +71,7 @@ class CustomerIOSDKConfig {
       flushAt: prefs.getInt(_PreferencesKey.flushAt),
       flushInterval: prefs.getInt(_PreferencesKey.flushInterval),
       screenViewUse: screenViewUse,
+      locationTrackingMode: locationTrackingMode,
       inAppConfig: InAppConfig(
           siteId: prefs.getString(_PreferencesKey.migrationSiteId) ?? ""),
     );
@@ -118,6 +123,9 @@ extension ConfigurationPreferencesExtensions on SharedPreferences {
     result = result &&
         await setOrRemoveString(
             _PreferencesKey.screenViewUse, config.screenViewUse?.name);
+    result = result &&
+        await setOrRemoveString(_PreferencesKey.locationTrackingMode,
+            config.locationTrackingMode?.name);
     return result;
   }
 
@@ -141,4 +149,5 @@ class _PreferencesKey {
   static const flushAt = 'FLUSH_AT';
   static const flushInterval = 'FLUSH_INTERVAL';
   static const screenViewUse = 'SCREEN_VIEW_USE';
+  static const locationTrackingMode = 'LOCATION_TRACKING_MODE';
 }

--- a/apps/flutter_sample_spm/lib/src/screens/settings.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/settings.dart
@@ -46,6 +46,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   late final TextEditingController _flushIntervalValueController;
 
   late ScreenView _screenViewUse;
+  late LocationTrackingMode _locationTrackingMode;
   late bool _featureTrackScreens;
   late bool _featureTrackDeviceAttributes;
   late bool _featureDebugMode;
@@ -68,6 +69,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _flushIntervalValueController =
         TextEditingController(text: cioConfig?.flushInterval?.toString());
     _screenViewUse = cioConfig?.screenViewUse ?? ScreenView.all;
+    _locationTrackingMode =
+        cioConfig?.locationTrackingMode ?? LocationTrackingMode.onAppStart;
     _featureTrackScreens = cioConfig?.screenTrackingEnabled ?? true;
     _featureTrackDeviceAttributes =
         cioConfig?.autoTrackDeviceAttributes ?? true;
@@ -89,6 +92,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         flushAt: _flushAtValueController.text.trim().toIntOrNull(),
         flushInterval: _flushIntervalValueController.text.trim().toIntOrNull(),
         screenViewUse: _screenViewUse,
+        locationTrackingMode: _locationTrackingMode,
         screenTrackingEnabled: _featureTrackScreens,
         autoTrackDeviceAttributes: _featureTrackDeviceAttributes,
         debugModeEnabled: _featureDebugMode,
@@ -123,6 +127,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _flushIntervalValueController.text =
           defaultConfig.flushInterval?.toString() ?? '';
       _screenViewUse = defaultConfig.screenViewUse ?? ScreenView.all;
+      _locationTrackingMode =
+          defaultConfig.locationTrackingMode ?? LocationTrackingMode.onAppStart;
       _featureTrackScreens = defaultConfig.screenTrackingEnabled;
       _featureTrackDeviceAttributes =
           defaultConfig.autoTrackDeviceAttributes ?? true;
@@ -300,6 +306,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             updateState: (ScreenView selected) {
                               setState(() {
                                 _screenViewUse = selected;
+                              });
+                            },
+                          ),
+                          const SizedBox(height: 16),
+                          ChoiceSettingsFormField<LocationTrackingMode>(
+                            labelText: 'Location Tracking Mode',
+                            semanticsLabel: 'Location tracking mode options',
+                            value: _locationTrackingMode,
+                            options: LocationTrackingMode.values,
+                            updateState: (LocationTrackingMode selected) {
+                              setState(() {
+                                _locationTrackingMode = selected;
                               });
                             },
                           ),


### PR DESCRIPTION
## Summary

Surfaces the location tracking mode in the sample app Settings screen. Previously `LocationConfig()` was hardcoded (implicitly `manual`); now testers can switch between the three modes at runtime.

- **config.dart** — new `locationTrackingMode` field, persisted under `LOCATION_TRACKING_MODE` (load in `fromPrefs`, save in `saveSDKConfigState`).
- **settings.dart** — a `ChoiceSettingsFormField<LocationTrackingMode>` (**Off / Manual / OnAppStart**) below the ScreenView picker, wired into init / save / restore-defaults.
- **customer_io.dart** — SDK init now reads the persisted mode into `LocationConfig(trackingMode: …)`.

Sample-app default is **onAppStart**; the SDK's own default remains `manual`.

Applies to both sample apps (`flutter_sample_cocoapods` shares `lib/src` via symlink).

## Testing
- Built and ran on device (Android): picker renders, selection persists across restart, Restore Defaults resets to OnAppStart.
- `flutter analyze` clean; plugin unit tests pass (85).

## Notes
- Base is `feature/geofence-on-device` (geofence isn't on `main` yet).
- No plugin (`lib/`) or native changes — sample app only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app-only configuration and UI; affects how testers enable location tracking in demos, not production SDK behavior.
> 
> **Overview**
> The Flutter sample app can now **configure `LocationTrackingMode` at runtime** instead of always passing a default `LocationConfig()`.
> 
> **`CustomerIOSDKConfig`** gains a `locationTrackingMode` field, loaded and saved via SharedPreferences (`LOCATION_TRACKING_MODE`). **Settings** adds a `ChoiceSettingsFormField` for Off / Manual / OnAppStart (mirroring `ScreenView`), wired through init, save, and restore defaults. **SDK initialization** passes the stored mode into `LocationConfig(trackingMode: …)`, with sample-app fallback **`onAppStart`** when unset (distinct from the plugin’s default `manual`).
> 
> Changes are limited to the shared sample `lib/src` tree; no plugin or native code in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 456dc440aa128c88ff9596ffe3a859804df3200a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->