### PR TITLE
chore: expose geofence location mode and refresh method

### DIFF
--- a/android/src/main/kotlin/io/customer/customer_io/geofence/CustomerIOGeofence.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/geofence/CustomerIOGeofence.kt
@@ -1,20 +1,26 @@
 package io.customer.customer_io.geofence
 
 import io.customer.customer_io.bridge.NativeModuleBridge
+import io.customer.customer_io.bridge.nativeNoArgs
+import io.customer.customer_io.utils.getAs
+import io.customer.geofence.GeofenceLocationMode
 import io.customer.geofence.GeofenceModuleConfig
 import io.customer.geofence.ModuleGeofence
 import io.customer.sdk.CustomerIOBuilder
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
 /**
- * Flutter bridge for the geofence module. Geofence has no Flutter-facing methods —
- * it runs automatically once registered — so this only wires the native module into
- * the SDK builder. The reference to [ModuleGeofence] is isolated here so it is loaded
- * only when the geofence dependency is bundled.
+ * Flutter bridge for the geofence module. Wires the native module into the SDK
+ * builder and exposes its Flutter-facing methods. The references to
+ * [ModuleGeofence] are isolated here so they are loaded only when the geofence
+ * dependency is bundled.
  *
- * Geofence depends on the location module; registration of location is handled by the
- * plugin when geofence is configured.
+ * Geofence depends on the location module; registration of location is handled by
+ * the plugin when geofence is configured.
  */
 internal class CustomerIOGeofence(
     pluginBinding: FlutterPlugin.FlutterPluginBinding,
@@ -22,8 +28,37 @@ internal class CustomerIOGeofence(
     override val moduleName: String = "Geofence"
     override val flutterCommunicationChannel: MethodChannel =
         MethodChannel(pluginBinding.binaryMessenger, "customer_io_geofence")
+    private val logger: Logger = SDKComponent.logger
+
+    private fun getModuleGeofence() = runCatching {
+        ModuleGeofence.instance()
+    }.onFailure {
+        logger.error("Geofence module is not initialized. Ensure geofence config is provided during SDK initialization.")
+    }.getOrNull()
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "refreshFromCurrentLocation" -> call.nativeNoArgs(result, ::refreshFromCurrentLocation)
+            else -> super.onMethodCall(call, result)
+        }
+    }
+
+    private fun refreshFromCurrentLocation() {
+        getModuleGeofence()?.refreshFromCurrentLocation()
+    }
 
     override fun configureModule(builder: CustomerIOBuilder, config: Map<String, Any>) {
-        builder.addCustomerIOModule(ModuleGeofence(GeofenceModuleConfig.Builder().build()))
+        val locationModeValue = config.getAs<String>("locationMode")
+        val locationMode = locationModeValue?.let { value ->
+            runCatching { enumValueOf<GeofenceLocationMode>(value) }.getOrNull()
+        } ?: GeofenceLocationMode.AUTOMATIC
+
+        builder.addCustomerIOModule(
+            ModuleGeofence(
+                GeofenceModuleConfig.Builder()
+                    .setLocationMode(locationMode)
+                    .build()
+            )
+        )
     }
 }

--- a/android/src/main/kotlin/io/customer/customer_io/geofence/CustomerIOGeofence.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/geofence/CustomerIOGeofence.kt
@@ -49,8 +49,10 @@ internal class CustomerIOGeofence(
 
     override fun configureModule(builder: CustomerIOBuilder, config: Map<String, Any>) {
         val locationModeValue = config.getAs<String>("locationMode")
+        // Uppercase before matching so casing can't diverge from iOS (which uppercases too);
+        // enumValueOf is case-sensitive. Unknown values fall back to the SDK default.
         val locationMode = locationModeValue?.let { value ->
-            runCatching { enumValueOf<GeofenceLocationMode>(value) }.getOrNull()
+            runCatching { enumValueOf<GeofenceLocationMode>(value.uppercase()) }.getOrNull()
         } ?: GeofenceLocationMode.AUTOMATIC
 
         builder.addCustomerIOModule(

--- a/apps/flutter_sample_spm/lib/src/screens/location.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/location.dart
@@ -51,12 +51,13 @@ class _LocationScreenState extends State<LocationScreen>
     final previous = _locationStatus;
     setState(() => _locationStatus = status);
     // On any new grant — including one made in Settings and picked up on resume —
-    // fetch so geofences register. The SDK's auto-fetch hook runs once per process,
-    // so a runtime grant needs an explicit request (matches the native sample apps).
+    // refresh geofences from the current location. This is silent (no location
+    // analytics event) and forces an immediate refresh once permission is granted
+    // at runtime (matches the native sample apps).
     if (previous != null &&
         status != previous &&
         _grantedStatuses.contains(status)) {
-      CustomerIO.location.requestLocationUpdate();
+      CustomerIO.geofence.refreshFromCurrentLocation();
     }
   }
 

--- a/customerio-flutter.api
+++ b/customerio-flutter.api
@@ -12,7 +12,8 @@ public final class CustomerIO {
 		CustomerIOPlatform? platform,
 		CustomerIOMessagingPushPlatform? pushMessaging,
 		CustomerIOMessagingInAppPlatform? inAppMessaging,
-		CustomerIOLocationPlatform? location
+		CustomerIOLocationPlatform? location,
+		CustomerIOGeofencePlatform? geofence
 	): CustomerIO;
 	public fun deleteDeviceToken();
 	public fun identify(
@@ -37,6 +38,7 @@ public final class CustomerIO {
 		required String deviceToken,
 		required MetricEvent event
 	);
+	static public val geofence: CustomerIOGeofencePlatform;
 	static public val inAppMessaging: CustomerIOMessagingInAppPlatform;
 	static public val instance: CustomerIO;
 	static public val location: CustomerIOLocationPlatform;
@@ -87,6 +89,12 @@ public final class CustomerIOConfigIos {
 	public fun new(bool? allowBackgroundDelivery): CustomerIOConfigIos;
 	public fun toMap(): Map<String, dynamic>;
 	public val allowBackgroundDelivery: bool?;
+}
+
+public final class CustomerIOGeofencePlatform {
+	public fun new(): CustomerIOGeofencePlatform;
+	public fun refreshFromCurrentLocation();
+	static public var instance: CustomerIOGeofencePlatform;
 }
 
 public final class CustomerIOLocationPlatform {
@@ -164,8 +172,16 @@ public final class EventType {
 }
 
 public final class GeofenceConfig {
-	public fun new(): GeofenceConfig;
+	public fun new(GeofenceLocationMode locationMode): GeofenceConfig;
 	public fun toMap(): Map<String, dynamic>;
+	public val locationMode: GeofenceLocationMode;
+}
+
+public final class GeofenceLocationMode {
+	static public val automatic: GeofenceLocationMode;
+	static public val manual: GeofenceLocationMode;
+	public val rawValue: String;
+	static public val values: List<GeofenceLocationMode>;
 }
 
 public final class InAppConfig {

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -16,6 +16,9 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
     #if canImport(CioLocation)
     private var locationChannelHandler: CustomerIOLocation!
     #endif
+    #if canImport(CioLocationGeofence)
+    private var geofenceChannelHandler: CustomerIOGeofence!
+    #endif
     private var messagingPushChannelHandler: CustomerIOMessagingPush!
 
     private let logger: CioInternalCommon.Logger = DIGraphShared.shared.logger
@@ -29,6 +32,9 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
         instance.inAppMessagingChannelHandler = CustomerIOInAppMessaging(with: registrar)
         #if canImport(CioLocation)
         instance.locationChannelHandler = CustomerIOLocation(with: registrar)
+        #endif
+        #if canImport(CioLocationGeofence)
+        instance.geofenceChannelHandler = CustomerIOGeofence(with: registrar)
         #endif
         instance.messagingPushChannelHandler = CustomerIOMessagingPush(with: registrar)
     }
@@ -195,9 +201,16 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
             }
 
             #if canImport(CioLocationGeofence)
-            // Geofence runs automatically once registered; relies on the location module above.
-            if geofenceConfigured {
-                _ = sdkConfigBuilder.addModule(GeofenceModule())
+            // Geofence relies on the location module above.
+            if let geofenceConfig = params["geofence"] as? [String: AnyHashable] {
+                let locationMode: GeofenceLocationMode
+                switch (geofenceConfig["locationMode"] as? String)?.uppercased() {
+                case "MANUAL":
+                    locationMode = .manual
+                default:
+                    locationMode = .automatic
+                }
+                _ = sdkConfigBuilder.addModule(GeofenceModule(config: GeofenceModuleConfig(locationMode: locationMode)))
             }
             #endif
             #endif

--- a/ios/customer_io/Sources/customer_io/Geofence/CustomerIOGeofence.swift
+++ b/ios/customer_io/Sources/customer_io/Geofence/CustomerIOGeofence.swift
@@ -1,0 +1,45 @@
+#if canImport(CioLocationGeofence)
+import CioInternalCommon
+import CioLocationGeofence
+import Flutter
+import Foundation
+
+public class CustomerIOGeofence: NSObject, FlutterPlugin {
+    private var methodChannel: FlutterMethodChannel?
+    private let logger: Logger = DIGraphShared.shared.logger
+
+    public static func register(with _: FlutterPluginRegistrar) {}
+
+    init(with registrar: FlutterPluginRegistrar) {
+        super.init()
+
+        methodChannel = FlutterMethodChannel(name: "customer_io_geofence", binaryMessenger: registrar.messenger())
+
+        guard let methodChannel = methodChannel else {
+            print("customer_io_geofence methodChannel is nil")
+            return
+        }
+
+        registrar.addMethodCallDelegate(self, channel: methodChannel)
+    }
+
+    deinit {
+        methodChannel?.setMethodCallHandler(nil)
+        methodChannel = nil
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "refreshFromCurrentLocation":
+            call.nativeNoArgs(result: result, handler: refreshFromCurrentLocation)
+
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func refreshFromCurrentLocation() {
+        CustomerIO.geofence.refreshFromCurrentLocation()
+    }
+}
+#endif

--- a/lib/config/geofence_config.dart
+++ b/lib/config/geofence_config.dart
@@ -1,12 +1,19 @@
+import '../customer_io_enums.dart';
+
 /// Configuration for the optional Geofence module.
 ///
-/// Geofence runs automatically once enabled and has no options yet. Providing a
-/// [GeofenceConfig] opts the app into geofence monitoring; this also enables the
-/// Location module, which geofence depends on.
+/// Providing a [GeofenceConfig] opts the app into geofence monitoring; this also
+/// enables the Location module, which geofence depends on.
 class GeofenceConfig {
-  GeofenceConfig();
+  /// How the module acquires the device location it needs for geofencing.
+  /// Defaults to [GeofenceLocationMode.automatic].
+  final GeofenceLocationMode locationMode;
+
+  GeofenceConfig({this.locationMode = GeofenceLocationMode.automatic});
 
   Map<String, dynamic> toMap() {
-    return {};
+    return {
+      'locationMode': locationMode.rawValue,
+    };
   }
 }

--- a/lib/customer_io.dart
+++ b/lib/customer_io.dart
@@ -7,6 +7,7 @@ import 'customer_io_config.dart';
 import 'customer_io_enums.dart';
 import 'data_pipelines/customer_io_platform_interface.dart';
 import 'extensions/map_extensions.dart';
+import 'geofence/platform_interface.dart';
 import 'location/platform_interface.dart';
 import 'messaging_in_app/platform_interface.dart';
 import 'messaging_push/platform_interface.dart';
@@ -18,6 +19,7 @@ class CustomerIO {
   final CustomerIOMessagingPushPlatform _pushMessaging;
   final CustomerIOMessagingInAppPlatform _inAppMessaging;
   final CustomerIOLocationPlatform _location;
+  final CustomerIOGeofencePlatform _geofence;
 
   /// Private constructor to enforce singleton pattern
   CustomerIO._({
@@ -25,12 +27,14 @@ class CustomerIO {
     CustomerIOMessagingPushPlatform? pushMessaging,
     CustomerIOMessagingInAppPlatform? inAppMessaging,
     CustomerIOLocationPlatform? location,
+    CustomerIOGeofencePlatform? geofence,
   })  : _platform = platform ?? CustomerIOPlatform.instance,
         _pushMessaging =
             pushMessaging ?? CustomerIOMessagingPushPlatform.instance,
         _inAppMessaging =
             inAppMessaging ?? CustomerIOMessagingInAppPlatform.instance,
-        _location = location ?? CustomerIOLocationPlatform.instance;
+        _location = location ?? CustomerIOLocationPlatform.instance,
+        _geofence = geofence ?? CustomerIOGeofencePlatform.instance;
 
   /// Get the singleton instance of CustomerIO
   static CustomerIO get instance {
@@ -50,12 +54,14 @@ class CustomerIO {
     CustomerIOMessagingPushPlatform? pushMessaging,
     CustomerIOMessagingInAppPlatform? inAppMessaging,
     CustomerIOLocationPlatform? location,
+    CustomerIOGeofencePlatform? geofence,
   }) {
     _instance = CustomerIO._(
       platform: platform,
       pushMessaging: pushMessaging,
       inAppMessaging: inAppMessaging,
       location: location,
+      geofence: geofence,
     );
     return _instance!;
   }
@@ -80,6 +86,11 @@ class CustomerIO {
   /// Access location functionality
   static CustomerIOLocationPlatform get location {
     return _instance?._location ?? CustomerIOLocationPlatform.instance;
+  }
+
+  /// Access geofence functionality
+  static CustomerIOGeofencePlatform get geofence {
+    return _instance?._geofence ?? CustomerIOGeofencePlatform.instance;
   }
 
   /// To initialize the plugin

--- a/lib/customer_io_enums.dart
+++ b/lib/customer_io_enums.dart
@@ -56,3 +56,18 @@ enum LocationTrackingMode {
 
   final String rawValue;
 }
+
+/// How the geofence module acquires the device location it needs for
+/// geofencing. Location acquired for geofencing is never sent to analytics.
+enum GeofenceLocationMode {
+  /// SDK acquires a fix itself when geofencing needs one and none is available
+  /// (default).
+  automatic(rawValue: 'AUTOMATIC'),
+
+  /// Host drives it via `CustomerIO.geofence.refreshFromCurrentLocation()`.
+  manual(rawValue: 'MANUAL');
+
+  const GeofenceLocationMode({required this.rawValue});
+
+  final String rawValue;
+}

--- a/lib/geofence/_native_constants.dart
+++ b/lib/geofence/_native_constants.dart
@@ -1,0 +1,4 @@
+/// Methods specific to Geofence module.
+class NativeMethods {
+  static const String refreshFromCurrentLocation = "refreshFromCurrentLocation";
+}

--- a/lib/geofence/method_channel.dart
+++ b/lib/geofence/method_channel.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import '_native_constants.dart';
+import 'platform_interface.dart';
+
+class CustomerIOGeofenceMethodChannel extends CustomerIOGeofencePlatform {
+  final MethodChannel methodChannel =
+      const MethodChannel('customer_io_geofence');
+
+  static bool _warnedNotEnabled = false;
+
+  /// Invokes a geofence method on the native side, handling all errors safely
+  /// for fire-and-forget calls. Logs a one-time warning if the geofence module
+  /// is not enabled.
+  Future<void> _invokeGeofenceMethod(String method,
+      [Map<String, dynamic> arguments = const {}]) async {
+    try {
+      await methodChannel.invokeMethod<void>(method, arguments);
+    } on MissingPluginException {
+      if (!_warnedNotEnabled && kDebugMode) {
+        _warnedNotEnabled = true;
+        debugPrint('Customer.io: Geofence module is not enabled. '
+            'To use geofence features, add the geofence subspec to your '
+            'Podfile (iOS) or set customerio_geofence_enabled=true in '
+            'gradle.properties (Android).');
+      }
+    } catch (ex) {
+      if (kDebugMode) {
+        debugPrint("Customer.io: Error invoking geofence method '$method': $ex");
+      }
+    }
+  }
+
+  @override
+  void refreshFromCurrentLocation() {
+    _invokeGeofenceMethod(NativeMethods.refreshFromCurrentLocation);
+  }
+}

--- a/lib/geofence/platform_interface.dart
+++ b/lib/geofence/platform_interface.dart
@@ -1,0 +1,28 @@
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import 'method_channel.dart';
+
+abstract class CustomerIOGeofencePlatform extends PlatformInterface {
+  CustomerIOGeofencePlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static CustomerIOGeofencePlatform _instance =
+      CustomerIOGeofenceMethodChannel();
+
+  static CustomerIOGeofencePlatform get instance => _instance;
+
+  static set instance(CustomerIOGeofencePlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  /// Requests a one-shot location fix and refreshes the nearby geofence set from
+  /// it, without emitting a location analytics event or caching the fix. Call
+  /// after the host app has been granted location permission; the SDK never
+  /// requests permission itself.
+  void refreshFromCurrentLocation() {
+    throw UnimplementedError(
+        'refreshFromCurrentLocation() has not been implemented.');
+  }
+}


### PR DESCRIPTION
## Summary

Exposes the geofence module's two new native additions through the Flutter plugin:

- **`GeofenceConfig.locationMode`** — new `GeofenceLocationMode { automatic, manual }` (default `automatic`). Controls whether the SDK self-acquires location for geofencing (`automatic`) or leaves it entirely to the host (`manual`). Serialized under the existing `geofence` config map.
- **`CustomerIO.geofence.refreshFromCurrentLocation()`** — requests a one-shot, **silent** location fix (no `CIO Location Update` analytics event, no caching) and refreshes the nearby geofence set from it. Routed through a new `customer_io_geofence` method channel on both platforms.

## Changes

**Dart plugin**
- `GeofenceLocationMode` enum (rawValues `AUTOMATIC`/`MANUAL`, matching the native constant names).
- New `lib/geofence/` module (`platform_interface` + `method_channel` + constants), mirroring `lib/location/`.
- `CustomerIO.geofence` accessor, mirroring `CustomerIO.location`.
- Regenerated `customerio-flutter.api`.

**Native bridges**
- Android `CustomerIOGeofence.kt`: parses `locationMode` into `GeofenceModuleConfig`; handles `refreshFromCurrentLocation` → `ModuleGeofence.instance().refreshFromCurrentLocation()`.
- iOS: new `Geofence/CustomerIOGeofence.swift` channel handler (guarded by `canImport(CioLocationGeofence)`); `CustomerIOPlugin.swift` registers it and passes `GeofenceModuleConfig(locationMode:)`.

**Sample app**
- Only the geofence-driven fetch after a background permission grant now calls `CustomerIO.geofence.refreshFromCurrentLocation()` (silent). The "SDK Location Request" demo button still exercises `CustomerIO.location.requestLocationUpdate()` — unchanged.

## Native dependencies

Requires the native additions:
- Android: customerio-android#768
- iOS: customerio-ios#1140

Targets `feature/geofence-on-device` (geofence isn't on `main` yet). Until those native PRs are released and the pinned native versions bump, the **sample-app build CI stays red** — the plugin's own checks (analyze, unit tests, API) are green.

## Testing
- `flutter analyze` clean; plugin unit tests pass (85).
- Device testing pending the native snapshots that carry these APIs.

## Ticket
https://linear.app/customerio/issue/MBL-1978/route-geofence-location-updates-through-an-internal-api

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches location/geofence initialization and runtime refresh on both platforms; behavior depends on unreleased native SDK APIs, but failures are mostly no-ops with logging when geofence is not enabled.
> 
> **Overview**
> Exposes two new geofence capabilities through the Flutter plugin: **`GeofenceConfig.locationMode`** (`automatic` / `manual`, default `automatic`) and **`CustomerIO.geofence.refreshFromCurrentLocation()`**, which triggers a one-shot, silent location fix and refreshes nearby geofences without a location analytics event.
> 
> Dart adds `GeofenceLocationMode`, a `lib/geofence/` module (platform interface + `customer_io_geofence` method channel), and a `CustomerIO.geofence` accessor parallel to `CustomerIO.location`. Android and iOS bridges parse `locationMode` into native `GeofenceModuleConfig` and forward `refreshFromCurrentLocation` to the native geofence module. The sample app switches post-permission geofence registration from `CustomerIO.location.requestLocationUpdate()` to the new silent geofence refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0757074791afa8dd0f906cbc6cf417e1f5bffa5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->