### PR TITLE
chore: fix sample app Android build on Flutter 3.44.5

### DIFF
--- a/apps/flutter_sample_cocoapods/android/app/build.gradle
+++ b/apps/flutter_sample_cocoapods/android/app/build.gradle
@@ -32,10 +32,8 @@ android {
     // The `compressReleaseAssets` task, is responsible for compressing the assets into a single archive file for release builds.
     // By adding a dependency on `copyFlutterAssetsRelease`, the code ensures that the app's assets
     // are copied to the correct location before they are compressed for release.
-    tasks.whenTaskAdded { task ->
-        if (task.name == 'compressReleaseAssets') {
-            task.dependsOn 'copyFlutterAssetsRelease'
-        }
+    tasks.matching { it.name == 'compressReleaseAssets' }.configureEach {
+        dependsOn 'copyFlutterAssetsRelease'
     }
 
     defaultConfig {

--- a/apps/flutter_sample_cocoapods/android/gradle.properties
+++ b/apps/flutter_sample_cocoapods/android/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
 customerio_location_enabled=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/apps/flutter_sample_spm/android/app/build.gradle
+++ b/apps/flutter_sample_spm/android/app/build.gradle
@@ -32,10 +32,8 @@ android {
     // The `compressReleaseAssets` task, is responsible for compressing the assets into a single archive file for release builds.
     // By adding a dependency on `copyFlutterAssetsRelease`, the code ensures that the app's assets
     // are copied to the correct location before they are compressed for release.
-    tasks.whenTaskAdded { task ->
-        if (task.name == 'compressReleaseAssets') {
-            task.dependsOn 'copyFlutterAssetsRelease'
-        }
+    tasks.matching { it.name == 'compressReleaseAssets' }.configureEach {
+        dependsOn 'copyFlutterAssetsRelease'
     }
 
     defaultConfig {

--- a/apps/flutter_sample_spm/android/gradle.properties
+++ b/apps/flutter_sample_spm/android/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
 customerio_location_enabled=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false


### PR DESCRIPTION
## Summary

The sample apps' Android build broke when CI's Flutter `stable` channel auto-updated **3.44.4 → 3.44.5**:

```
> Could not create task ':app:copyJniLibsflutterBuildDebug'.
   > Task with name 'compileFlutterBuildDebug' not found in project ':app'.
```

### Root cause
Flutter 3.44.5's Gradle plugin creates `copyJniLibs<variant>` through the new AGP variant API and *looks up* the `compileFlutterBuild<variant>` task that the legacy `applicationVariants` callback registers. Both sample apps' `app/build.gradle` used the **eager** `tasks.whenTaskAdded { }` API, which forced `copyJniLibs…` to realize during configuration — before that compile task existed — so task creation failed.

This is purely a toolchain incompatibility, not a dependency or SDK issue: it reproduces on a clean `main` checkout with 3.44.5, and fails *before* any CustomerIO dependency resolution.

### Fix
Replace the deprecated eager `whenTaskAdded` with the lazy `tasks.matching { }.configureEach { }` API (the recommended replacement), so the `compressReleaseAssets → copyFlutterAssetsRelease` dependency is wired without forcing early task realization.

```diff
-    tasks.whenTaskAdded { task ->
-        if (task.name == 'compressReleaseAssets') {
-            task.dependsOn 'copyFlutterAssetsRelease'
-        }
-    }
+    tasks.matching { it.name == 'compressReleaseAssets' }.configureEach {
+        dependsOn 'copyFlutterAssetsRelease'
+    }
```

Applied to both sample apps (`flutter_sample_spm` + `flutter_sample_cocoapods`).

Also commits the `android.builtInKotlin=false` / `android.newDsl=false` flags that Flutter 3.44.5's migrator writes to each app's `gradle.properties` on every build — committing them keeps the working tree clean instead of regenerating (and dirtying) on each build. They opt out of the new Kotlin/DSL migration for now (behavior unchanged); the full migration is part of the toolchain-bump follow-up below.

## Verified locally (Flutter 3.44.5)
- `flutter_sample_spm`: clean `flutter clean` + `flutter build apk --debug` → ✅
- `flutter_sample_cocoapods`: clean build → ✅

## Notes
- Not related to the geofence work — this is a general sample-app toolchain fix, hence targeting `main` (to be back-merged into `feature/geofence-on-device`).
- **Out of scope / follow-up:** Flutter 3.44.5 also warns that Gradle `8.11.1`, AGP `8.9.3`, and Kotlin `2.1.21` "will soon be dropped." Those are non-blocking deprecation warnings (build is green); the version bumps carry their own risk and will be handled in a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app-only Gradle configuration changes with no product SDK or auth/data impact; behavior of the asset task dependency is preserved.
> 
> **Overview**
> Restores Android builds for the **flutter_sample_spm** and **flutter_sample_cocoapods** sample apps after Flutter **3.44.5** broke configuration with `compileFlutterBuildDebug` / `copyJniLibs` task ordering.
> 
> In each app's `app/build.gradle`, the eager **`tasks.whenTaskAdded`** hook for **`compressReleaseAssets → copyFlutterAssetsRelease`** is replaced with **`tasks.matching { }.configureEach`**, so that dependency is applied lazily and Gradle no longer realizes Flutter JNI tasks too early during configuration.
> 
> Each sample's **`gradle.properties`** now commits **`android.builtInKotlin=false`** and **`android.newDsl=false`** from the Flutter migrator so local builds stay clean without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f2c45a6be1a9f12191b8799a58880d21b33c7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

