### PR TITLE
chore: align sample location tracking mode with SDK default

### DIFF
--- a/apps/flutter_sample_spm/lib/src/customer_io.dart
+++ b/apps/flutter_sample_spm/lib/src/customer_io.dart
@@ -75,7 +75,7 @@ class CustomerIOSDK extends ChangeNotifier {
           inAppConfig: inAppConfig,
           locationConfig: LocationConfig(
               trackingMode: _sdkConfig?.locationTrackingMode ??
-                  LocationTrackingMode.onAppStart),
+                  LocationTrackingMode.manual),
           geofenceConfig: GeofenceConfig(),
         ),
       );

--- a/apps/flutter_sample_spm/lib/src/screens/location.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/location.dart
@@ -173,18 +173,11 @@ class _LocationScreenState extends State<LocationScreen>
     context.showMessageDialog(
       'Allow background location?',
       'Geofence transitions only fire while the app is backgrounded if you grant '
-          '"Always"/"Allow all the time". If no prompt appears, use Open Settings.',
+          '"Always"/"Allow all the time".',
       actions: [
         TextButton(
           child: const Text('Cancel'),
           onPressed: () => Navigator.of(context).pop(),
-        ),
-        TextButton(
-          child: const Text('Open Settings'),
-          onPressed: () {
-            Navigator.of(context).pop();
-            _permissionChannel.invokeMethod('openAppSettings');
-          },
         ),
         TextButton(
           child: const Text('Continue'),

--- a/apps/flutter_sample_spm/lib/src/screens/settings.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/settings.dart
@@ -70,7 +70,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         TextEditingController(text: cioConfig?.flushInterval?.toString());
     _screenViewUse = cioConfig?.screenViewUse ?? ScreenView.all;
     _locationTrackingMode =
-        cioConfig?.locationTrackingMode ?? LocationTrackingMode.onAppStart;
+        cioConfig?.locationTrackingMode ?? LocationTrackingMode.manual;
     _featureTrackScreens = cioConfig?.screenTrackingEnabled ?? true;
     _featureTrackDeviceAttributes =
         cioConfig?.autoTrackDeviceAttributes ?? true;
@@ -128,7 +128,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           defaultConfig.flushInterval?.toString() ?? '';
       _screenViewUse = defaultConfig.screenViewUse ?? ScreenView.all;
       _locationTrackingMode =
-          defaultConfig.locationTrackingMode ?? LocationTrackingMode.onAppStart;
+          defaultConfig.locationTrackingMode ?? LocationTrackingMode.manual;
       _featureTrackScreens = defaultConfig.screenTrackingEnabled;
       _featureTrackDeviceAttributes =
           defaultConfig.autoTrackDeviceAttributes ?? true;


### PR DESCRIPTION
## Summary

Aligns the sample app's location tracking mode with the SDK default and tidies the background-location prompt.

### Location tracking mode → SDK default
The sample forced the tracking mode to **On App Start**, which differs from the SDK default (**manual**). It's now `manual` everywhere the mode is unset:
- SDK init ([`customer_io.dart`](apps/flutter_sample_spm/lib/src/customer_io.dart))
- the Settings picker's displayed value
- the "reset to defaults" path

So a fresh install reflects out-of-the-box SDK behaviour. (Existing installs keep whatever they previously persisted — the fallback only applies when the pref is unset.)

### Background-location prompt cleanup
Removed the redundant **Open Settings** button from the "Allow background location?" rationale dialog, leaving **Cancel** / **Continue**. Continue already handles every case — including routing to the settings dialog when permission is permanently denied — so the extra button (and its "use Open Settings" hint in the message) added no value.

## Testing
- Verified on a physical Android device (Pixel 6): fresh install defaults to **manual**; the rationale dialog now shows only Cancel/Continue.
- `flutter analyze` clean; plugin unit tests pass (85).

## Notes
Sample-app only (`flutter_sample_spm`; `lib/src` is symlinked so both samples pick it up). No plugin/SDK code touched.

Linear: MBL-2148

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app UI and config defaults only; no plugin or SDK changes.
> 
> **Overview**
> The Flutter sample app now treats **`LocationTrackingMode.manual`** as the fallback wherever location tracking mode is unset—SDK init in `customer_io.dart`, Settings UI initial state, and **Restore Defaults**—instead of **`onAppStart`**, so fresh installs match the SDK’s out-of-the-box behavior (saved prefs are unchanged).
> 
> The **Allow background location?** rationale dialog drops the redundant **Open Settings** action and shortens the copy; **Cancel** / **Continue** remain, with **Continue** still handling permanent denial via the existing settings flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0146f5ca4762ac315ca88bf38c04945af5821044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->