### PR TITLE
fix: add iOS app delegate lifecycle regression fixture

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -47,3 +47,19 @@ For a guided interactive walkthrough:
 
 - **PRs and pushes**: both apps are built to verify SPM and CocoaPods compatibility
 - **SDK releases**: only the primary app is built
+
+## iOS App Delegate Regression Check
+
+Both samples register a `quick_actions` lifecycle delegate to verify that the
+Customer.io app delegate wrapper preserves the wrapped Flutter app delegate's
+Objective-C protocol conformance and forwarding behavior.
+
+1. Launch the sample once so it registers the **Test Flutter lifecycle** Home
+   Screen quick action.
+2. Terminate the app, long-press its Home Screen icon, and select the action.
+   Confirm the banner ends in `(1)`.
+3. Press Home without terminating the app, select the action again, and confirm
+   the same banner ends in `(2)`.
+
+Run the check on both the SPM and CocoaPods samples whenever the native iOS SDK
+pin or app delegate integration changes.

--- a/apps/flutter_sample_cocoapods/lib/main.dart
+++ b/apps/flutter_sample_cocoapods/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 import 'src/app.dart';
 import 'src/auth.dart';
+import 'src/quick_action_probe.dart';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -51,11 +52,16 @@ void main() async {
         properties: {"payload": notificationResponse.payload});
   });
 
+  // Quick Actions registers an application delegate with Flutter. Keeping it
+  // in the sample protects the CioAppDelegateWrapper lifecycle integration.
+  final quickActionProbe = QuickActionProbe();
+  await quickActionProbe.initialize();
+
   // Load SDK configurations
   await dotenv.load(fileName: ".env");
   // Wait for user state to be updated
   AmiAppAuth auth = AmiAppAuth();
   await auth.updateState();
   // Initialize and run app
-  runApp(AmiApp(auth: auth));
+  runApp(AmiApp(auth: auth, quickActionProbe: quickActionProbe));
 }

--- a/apps/flutter_sample_cocoapods/pubspec.lock
+++ b/apps/flutter_sample_cocoapods/pubspec.lock
@@ -503,6 +503,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
+  quick_actions:
+    dependency: "direct main"
+    description:
+      name: quick_actions
+      sha256: "7e35dd6a21f5bbd21acf6899039eaf85001a5ac26d52cbd6a8a2814505b90798"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  quick_actions_android:
+    dependency: transitive
+    description:
+      name: quick_actions_android
+      sha256: "6fbdda87fbedd0602b91f35d870c2cbcb6d053bc863efb76c6e7f60f1d8e3fd6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.30"
+  quick_actions_ios:
+    dependency: transitive
+    description:
+      name: quick_actions_ios
+      sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
+  quick_actions_platform_interface:
+    dependency: transitive
+    description:
+      name: quick_actions_platform_interface
+      sha256: "1fec7068db5122cd019e9340d3d7be5d36eab099695ef3402c7059ee058329a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/apps/flutter_sample_cocoapods/pubspec.lock
+++ b/apps/flutter_sample_cocoapods/pubspec.lock
@@ -503,24 +503,8 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
-  quick_actions:
-    dependency: "direct main"
-    description:
-      name: quick_actions
-      sha256: "7e35dd6a21f5bbd21acf6899039eaf85001a5ac26d52cbd6a8a2814505b90798"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
-  quick_actions_android:
-    dependency: transitive
-    description:
-      name: quick_actions_android
-      sha256: "6fbdda87fbedd0602b91f35d870c2cbcb6d053bc863efb76c6e7f60f1d8e3fd6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.30"
   quick_actions_ios:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: quick_actions_ios
       sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
@@ -717,5 +701,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/apps/flutter_sample_cocoapods/pubspec.yaml
+++ b/apps/flutter_sample_cocoapods/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   flutter_local_notifications: ^19.5.0
   dotenv: ^4.2.0
   path: ^1.9.0
+  quick_actions: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/apps/flutter_sample_cocoapods/pubspec.yaml
+++ b/apps/flutter_sample_cocoapods/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   flutter_local_notifications: ^19.5.0
   dotenv: ^4.2.0
   path: ^1.9.0
-  quick_actions: ^1.1.0
+  quick_actions_ios: ^1.2.4
 
 dev_dependencies:
   flutter_test:

--- a/apps/flutter_sample_spm/lib/main.dart
+++ b/apps/flutter_sample_spm/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 import 'src/app.dart';
 import 'src/auth.dart';
+import 'src/quick_action_probe.dart';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -51,11 +52,16 @@ void main() async {
         properties: {"payload": notificationResponse.payload});
   });
 
+  // Quick Actions registers an application delegate with Flutter. Keeping it
+  // in the sample protects the CioAppDelegateWrapper lifecycle integration.
+  final quickActionProbe = QuickActionProbe();
+  await quickActionProbe.initialize();
+
   // Load SDK configurations
   await dotenv.load(fileName: ".env");
   // Wait for user state to be updated
   AmiAppAuth auth = AmiAppAuth();
   await auth.updateState();
   // Initialize and run app
-  runApp(AmiApp(auth: auth));
+  runApp(AmiApp(auth: auth, quickActionProbe: quickActionProbe));
 }

--- a/apps/flutter_sample_spm/lib/src/app.dart
+++ b/apps/flutter_sample_spm/lib/src/app.dart
@@ -8,6 +8,7 @@ import 'auth.dart';
 import 'color_schemes.g.dart';
 import 'customer_io.dart';
 import 'data/screen.dart';
+import 'quick_action_probe.dart';
 import 'screens/attributes.dart';
 import 'screens/dashboard.dart';
 import 'screens/events.dart';
@@ -23,8 +24,13 @@ import 'utils/logs.dart';
 /// Main entry point of AmiApp
 class AmiApp extends StatefulWidget {
   final AmiAppAuth auth;
+  final QuickActionProbe quickActionProbe;
 
-  const AmiApp({required this.auth, super.key});
+  const AmiApp({
+    required this.auth,
+    required this.quickActionProbe,
+    super.key,
+  });
 
   @override
   State<AmiApp> createState() => _AmiAppState();
@@ -193,6 +199,45 @@ class _AmiAppState extends State<AmiApp> {
           themeMode: ThemeMode.system,
           theme: _createTheme(false),
           darkTheme: _createTheme(true),
+          builder: (context, child) => Stack(
+            fit: StackFit.expand,
+            children: [
+              child ?? const SizedBox.shrink(),
+              AnimatedBuilder(
+                animation: widget.quickActionProbe,
+                builder: (context, _) {
+                  final action = widget.quickActionProbe.lastAction;
+                  if (action == null) {
+                    return const SizedBox.shrink();
+                  }
+                  final callbackCount = widget.quickActionProbe.callbackCount;
+
+                  return IgnorePointer(
+                    child: SafeArea(
+                      minimum: const EdgeInsets.all(16),
+                      child: Align(
+                        alignment: Alignment.bottomCenter,
+                        child: Material(
+                          elevation: 4,
+                          borderRadius: BorderRadius.circular(4),
+                          color: Theme.of(context).colorScheme.primaryContainer,
+                          child: Padding(
+                            padding: const EdgeInsets.all(12),
+                            child: Text(
+                              'Quick action received: $action ($callbackCount)',
+                              key: const ValueKey('quick_action_result'),
+                              semanticsLabel:
+                                  'Quick Action Result: $action ($callbackCount)',
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -258,6 +303,7 @@ class _AmiAppState extends State<AmiApp> {
 
     _auth.dispose();
     _customerIOSDK.dispose();
+    widget.quickActionProbe.dispose();
     _router.dispose();
 
     super.dispose();

--- a/apps/flutter_sample_spm/lib/src/quick_action_probe.dart
+++ b/apps/flutter_sample_spm/lib/src/quick_action_probe.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import 'package:quick_actions/quick_actions.dart';
+
+/// Exercises Flutter plugins that register an iOS application delegate.
+class QuickActionProbe extends ChangeNotifier {
+  static const shortcutType = 'lifecycle_probe';
+
+  final QuickActions _quickActions;
+
+  QuickActionProbe({QuickActions quickActions = const QuickActions()})
+      : _quickActions = quickActions;
+
+  String? _lastAction;
+  int _callbackCount = 0;
+
+  String? get lastAction => _lastAction;
+  int get callbackCount => _callbackCount;
+
+  Future<void> initialize() async {
+    await _quickActions.initialize(_handleAction);
+    await _quickActions.setShortcutItems(const [
+      ShortcutItem(
+        type: shortcutType,
+        localizedTitle: 'Test Flutter lifecycle',
+        localizedSubtitle: 'Verify the app delegate callback',
+      ),
+    ]);
+  }
+
+  void _handleAction(String shortcutType) {
+    _lastAction = shortcutType;
+    _callbackCount++;
+    notifyListeners();
+  }
+}

--- a/apps/flutter_sample_spm/lib/src/quick_action_probe.dart
+++ b/apps/flutter_sample_spm/lib/src/quick_action_probe.dart
@@ -1,14 +1,9 @@
 import 'package:flutter/foundation.dart';
-import 'package:quick_actions/quick_actions.dart';
+import 'package:quick_actions_ios/quick_actions_ios.dart';
 
 /// Exercises Flutter plugins that register an iOS application delegate.
 class QuickActionProbe extends ChangeNotifier {
   static const shortcutType = 'lifecycle_probe';
-
-  final QuickActions _quickActions;
-
-  QuickActionProbe({QuickActions quickActions = const QuickActions()})
-      : _quickActions = quickActions;
 
   String? _lastAction;
   int _callbackCount = 0;
@@ -17,8 +12,13 @@ class QuickActionProbe extends ChangeNotifier {
   int get callbackCount => _callbackCount;
 
   Future<void> initialize() async {
-    await _quickActions.initialize(_handleAction);
-    await _quickActions.setShortcutItems(const [
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return;
+    }
+
+    final quickActions = QuickActionsIos();
+    await quickActions.initialize(_handleAction);
+    await quickActions.setShortcutItems(const [
       ShortcutItem(
         type: shortcutType,
         localizedTitle: 'Test Flutter lifecycle',

--- a/apps/flutter_sample_spm/pubspec.lock
+++ b/apps/flutter_sample_spm/pubspec.lock
@@ -455,6 +455,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
+  quick_actions:
+    dependency: "direct main"
+    description:
+      name: quick_actions
+      sha256: "7e35dd6a21f5bbd21acf6899039eaf85001a5ac26d52cbd6a8a2814505b90798"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  quick_actions_android:
+    dependency: transitive
+    description:
+      name: quick_actions_android
+      sha256: "6fbdda87fbedd0602b91f35d870c2cbcb6d053bc863efb76c6e7f60f1d8e3fd6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.30"
+  quick_actions_ios:
+    dependency: transitive
+    description:
+      name: quick_actions_ios
+      sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
+  quick_actions_platform_interface:
+    dependency: transitive
+    description:
+      name: quick_actions_platform_interface
+      sha256: "1fec7068db5122cd019e9340d3d7be5d36eab099695ef3402c7059ee058329a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/apps/flutter_sample_spm/pubspec.lock
+++ b/apps/flutter_sample_spm/pubspec.lock
@@ -455,24 +455,8 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
-  quick_actions:
-    dependency: "direct main"
-    description:
-      name: quick_actions
-      sha256: "7e35dd6a21f5bbd21acf6899039eaf85001a5ac26d52cbd6a8a2814505b90798"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
-  quick_actions_android:
-    dependency: transitive
-    description:
-      name: quick_actions_android
-      sha256: "6fbdda87fbedd0602b91f35d870c2cbcb6d053bc863efb76c6e7f60f1d8e3fd6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.30"
   quick_actions_ios:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: quick_actions_ios
       sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
@@ -669,5 +653,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/apps/flutter_sample_spm/pubspec.yaml
+++ b/apps/flutter_sample_spm/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   flutter_local_notifications: ^19.5.0
   dotenv: ^4.2.0
   path: ^1.9.0
+  quick_actions: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/apps/flutter_sample_spm/pubspec.yaml
+++ b/apps/flutter_sample_spm/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   flutter_local_notifications: ^19.5.0
   dotenv: ^4.2.0
   path: ^1.9.0
-  quick_actions: ^1.1.0
+  quick_actions_ios: ^1.2.4
 
 dev_dependencies:
   flutter_test:

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -95,7 +95,7 @@ let package = Package(
         .library(name: "customer-io", targets: ["customer_io"])
     ],
     dependencies: [
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.5.3"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.6.1"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.5.3
+        native_sdk_version: 4.6.1
         firebase_wrapper_version: 1.0.0


### PR DESCRIPTION
## Summary

- add the official `quick_actions_ios` implementation to the CocoaPods and SwiftPM sample apps
- register an iOS-only lifecycle probe that displays a counted callback result
- document the cold and warm Home Screen regression procedure

## Why

MBL-1583 is caused by the native `CioAppDelegateWrapper` hiding the wrapped `FlutterAppDelegate`'s Objective-C protocol conformance from FlutterEngine. The production fix is in [customerio-ios#1163](https://github.com/customerio/customerio-ios/pull/1163).

This PR adds a durable sample-app fixture for the real failure mode. Flutter's native `QuickActionsPlugin` registers through both `addApplicationDelegate` and `addSceneDelegate`; the sample remains Android-neutral by initializing the iOS implementation only on iOS. The counter distinguishes a new warm callback from a stale cold-launch result.

## Dependency and release order

Keep this PR in draft until:

1. [customerio-ios#1163](https://github.com/customerio/customerio-ios/pull/1163) merges and is released.
2. The CocoaPods and SwiftPM native SDK pins are updated from `4.5.3` to that release in this PR.
3. Both sample apps are rebuilt and the documented quick-action check is repeated against the published artifacts.

## Validation

- Flutter SDK tests: 85/85 passed
- both sample apps analyzed; only the pre-existing unused Cupertino import and ignored `.env` diagnostics remain
- Android `testDebugUnitTest` passed for both samples (160 and 177 Gradle tasks); no Android quick-actions implementation is included
- both final iOS sample configurations built successfully for the simulator (SwiftPM and CocoaPods)
- CocoaPods sample built against the local patched native SDK:
  - terminated Home Screen quick action displayed callback `(1)`
  - warm/backgrounded app displayed callback `(2)` with the same PID
- SwiftPM sample built against the local patched native SDK:
  - terminated Home Screen quick action displayed callback `(1)`
  - warm/backgrounded app displayed callback `(2)` with the same PID
- `git diff --check`: passed

## Ticket

[MBL-1583](https://linear.app/customerio/issue/MBL-1583/cioappdelegatewrapper-breaks-flutter-addapplicationdelegate-method)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to sample apps, documentation, and dependency version pins; no production SDK logic changes.
> 
> **Overview**
> Adds a **manual regression fixture** for MBL-1583: both sample apps now depend on `quick_actions_ios` and wire a `QuickActionProbe` that registers a Home Screen shortcut and shows a counted callback banner so cold launch `(1)` vs warm `(2)` behavior is visible.
> 
> The SPM app gains `QuickActionProbe` (iOS-only init), startup wiring in `main`, and an overlay in `AmiApp`; CocoaPods gets the same via shared `lib/src` and matching `main` changes. **apps/README.md** documents the Home Screen quick-action procedure for both integration paths.
> 
> Native iOS pins move from **4.5.3 → 4.6.1** in the plugin `pubspec.yaml` and `ios/customer_io/Package.swift`; sample lockfiles pick up `quick_actions_ios` and updated Dart/Flutter SDK constraints from `pub get`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe16c9c21008f65907f8ee04b1a39f3edce15960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->