### PR TITLE
feat(live-activities): expose Live Activities / Live Notifications

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,10 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.18.2"
+    // Version can be overridden for local/CI verification via -PcioVersion=<version>
+    // (e.g. -PcioVersion=local to build against a mavenLocal build). The committed default
+    // tracks the intended published release.
+    def cioVersion = rootProject.findProperty("cioVersion") ?: "4.18.2"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/src/main/kotlin/io/customer/customer_io/CustomerIOPlugin.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/CustomerIOPlugin.kt
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull
 import io.customer.customer_io.bridge.NativeModuleBridge
 import io.customer.customer_io.bridge.nativeMapArgs
 import io.customer.customer_io.bridge.nativeNoArgs
+import io.customer.customer_io.liveactivities.CustomerIOLiveActivities
 import io.customer.customer_io.location.CustomerIOLocation
 import io.customer.customer_io.messaginginapp.CustomerIOInAppMessaging
 import io.customer.customer_io.messagingpush.CustomerIOPushMessaging
@@ -54,6 +55,9 @@ class CustomerIOPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         modules = buildList {
             add(CustomerIOPushMessaging(flutterPluginBinding))
             add(CustomerIOInAppMessaging(flutterPluginBinding))
+            // Live Activities / Live Notifications runtime methods (config is applied onto the
+            // push module's config builder during initialize).
+            add(CustomerIOLiveActivities(flutterPluginBinding))
             // Location module is optional - enabled via customerio_location_enabled gradle property
             if (BuildConfig.CIO_LOCATION_ENABLED) {
                 add(CustomerIOLocation(flutterPluginBinding))
@@ -222,12 +226,22 @@ class CustomerIOPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     )
                 }
             }
-            // Configure push messaging module based on config provided by customer app
+            // Configure push messaging module based on config provided by customer app.
+            // Live Notifications are hosted by the push module, so the `liveActivities` config is
+            // merged into the push config and applied onto the same MessagingPushModuleConfig.
             args.getAs<Map<String, Any>>(key = "push").let { pushConfig ->
+                val liveActivitiesConfig = args.getAs<Map<String, Any>>(key = "liveActivities")
+                val mergedConfig = (pushConfig ?: emptyMap()).let { base ->
+                    if (liveActivitiesConfig != null) {
+                        base + ("liveActivities" to liveActivitiesConfig)
+                    } else {
+                        base
+                    }
+                }
                 modules.filterIsInstance<CustomerIOPushMessaging>().forEach {
                     it.configureModule(
                         builder = this,
-                        config = pushConfig ?: emptyMap()
+                        config = mergedConfig
                     )
                 }
             }

--- a/android/src/main/kotlin/io/customer/customer_io/liveactivities/CustomerIOLiveActivities.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/liveactivities/CustomerIOLiveActivities.kt
@@ -1,0 +1,191 @@
+package io.customer.customer_io.liveactivities
+
+import android.graphics.Color
+import io.customer.customer_io.bridge.NativeModuleBridge
+import io.customer.customer_io.bridge.nativeMapArgs
+import io.customer.customer_io.utils.getAs
+import io.customer.messagingpush.MessagingPushModuleConfig
+import io.customer.messagingpush.ModuleMessagingPushFCM
+import io.customer.messagingpush.livenotification.LiveNotificationAsset
+import io.customer.messagingpush.livenotification.LiveNotificationBranding
+import io.customer.messagingpush.livenotification.LiveNotificationData
+import io.customer.messagingpush.livenotification.LiveNotificationType
+import io.customer.sdk.CustomerIOBuilder
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Flutter module implementation for Live Activities / Live Notifications.
+ *
+ * Live Notifications are hosted by the FCM push module ([ModuleMessagingPushFCM]); this bridge maps
+ * the wrapper's template payloads to [LiveNotificationData] and forwards them at runtime. The module
+ * *config* (enabled templates, custom types, branding) is applied onto the same
+ * [MessagingPushModuleConfig] the push module builds (see [applyLiveActivitiesConfig]); this handler
+ * therefore does not add a module of its own.
+ */
+internal class CustomerIOLiveActivities(
+    pluginBinding: FlutterPlugin.FlutterPluginBinding,
+) : NativeModuleBridge, MethodChannel.MethodCallHandler {
+    override val moduleName: String = "LiveActivities"
+    override val flutterCommunicationChannel: MethodChannel =
+        MethodChannel(pluginBinding.binaryMessenger, "customer_io_live_activities")
+    private val logger: Logger = SDKComponent.logger
+
+    // Live Notifications are hosted by the FCM push module. Reach it via the module registry
+    // (the SDK-internal MODULE_NAME constant is not accessible, so use the literal value).
+    private fun getPushModule(): ModuleMessagingPushFCM? = runCatching {
+        SDKComponent.modules[PUSH_FCM_MODULE_NAME] as? ModuleMessagingPushFCM
+    }.onFailure {
+        logger.error("Live Notifications: push module is not initialized. Ensure the SDK is initialized with live activity templates enabled.")
+    }.getOrNull()
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "start" -> call.nativeMapArgs(result, ::start)
+            "update" -> call.nativeMapArgs(result, ::update)
+            "end" -> call.nativeMapArgs(result, ::end)
+            "startCustom" -> call.nativeMapArgs(result, ::startCustom)
+            "handleDeepLinkOpen" -> call.nativeMapArgs(result, ::handleDeepLinkOpen)
+            else -> super.onMethodCall(call, result)
+        }
+    }
+
+    private fun start(args: Map<String, Any>): String {
+        val module = requireNotNull(getPushModule()) { MODULE_UNAVAILABLE }
+        val payload = requireNotNull(args.getAs<Map<String, Any>>("payload")) {
+            "payload is required"
+        }
+        return module.startLiveNotification(parseData(payload))
+    }
+
+    private fun update(args: Map<String, Any>) {
+        val module = requireNotNull(getPushModule()) { MODULE_UNAVAILABLE }
+        val activityId = requireNotNull(args.getAs<String>("activityId")) {
+            "activityId is required"
+        }
+        val payload = requireNotNull(args.getAs<Map<String, Any>>("payload")) {
+            "payload is required"
+        }
+        module.updateLiveNotification(activityId, parseData(payload))
+    }
+
+    private fun end(args: Map<String, Any>) {
+        val module = requireNotNull(getPushModule()) { MODULE_UNAVAILABLE }
+        val activityId = requireNotNull(args.getAs<String>("activityId")) {
+            "activityId is required"
+        }
+        module.endLiveNotification(activityId)
+    }
+
+    private fun startCustom(args: Map<String, Any>): String {
+        val module = requireNotNull(getPushModule()) { MODULE_UNAVAILABLE }
+        val activityType = requireNotNull(args.getAs<String>("activityType")) {
+            "activityType is required"
+        }
+        val data = args.getAs<Map<String, Any>>("data") ?: emptyMap()
+        return module.startLiveNotification(activityType, data)
+    }
+
+    // Deep-link/opened attribution for Live Activities is an iOS-only concept; no-op on Android.
+    private fun handleDeepLinkOpen(args: Map<String, Any>): Boolean = false
+
+    private fun parseData(payload: Map<String, Any>): LiveNotificationData {
+        return when (val type = payload.getAs<String>("type")) {
+            "segments" -> LiveNotificationData.Segments(
+                header = payload.requireString("header"),
+                status = payload.requireString("status"),
+                substatus = payload.getAs<String>("substatus"),
+                segmentsTotal = payload.requireInt("segmentsTotal"),
+                segmentsComplete = payload.requireInt("segmentsComplete"),
+                trailingText = payload.getAs<String>("trailingText"),
+            )
+
+            "countdownTimer" -> LiveNotificationData.CountdownTimer(
+                header = payload.requireString("header"),
+                title = payload.requireString("title"),
+                statusMessage = payload.getAs<String>("statusMessage"),
+                endTime = payload.getAs<Number>("endTime")?.toLong(),
+            )
+
+            else -> throw IllegalArgumentException("Unknown live activity template type: $type")
+        }
+    }
+
+    private fun Map<String, Any>.requireString(key: String): String =
+        requireNotNull(getAs<String>(key)) { "$key is required" }
+
+    private fun Map<String, Any>.requireInt(key: String): Int =
+        requireNotNull(getAs<Number>(key)) { "$key is required" }.toInt()
+
+    /**
+     * No-op: Live Notification configuration is applied onto the FCM push module's config builder
+     * via [applyLiveActivitiesConfig] rather than by adding a separate module.
+     */
+    override fun configureModule(builder: CustomerIOBuilder, config: Map<String, Any>) {}
+
+    companion object {
+        private const val PUSH_FCM_MODULE_NAME = "MessagingPushFCM"
+        private const val MODULE_UNAVAILABLE =
+            "Live Notifications are unavailable. Enable live activity templates in the SDK config."
+
+        /**
+         * Applies live activity configuration onto the FCM push module's config builder. Live
+         * Notifications are hosted by [ModuleMessagingPushFCM], so their config (enabled templates,
+         * custom types, branding) is set on the same [MessagingPushModuleConfig].
+         *
+         * @param builder the push module's config builder.
+         * @param config the `liveActivities` config map from the customer app.
+         */
+        internal fun applyLiveActivitiesConfig(
+            builder: MessagingPushModuleConfig.Builder,
+            config: Map<String, Any>,
+        ) {
+            val templateTypes = config.getAs<List<*>>("templates")
+                ?.mapNotNull { it as? String }
+                ?.mapNotNull { name ->
+                    when (name) {
+                        "segments" -> LiveNotificationType.SEGMENTS
+                        "countdownTimer" -> LiveNotificationType.COUNTDOWN_TIMER
+                        else -> null
+                    }
+                }
+                .orEmpty()
+            if (templateTypes.isNotEmpty()) {
+                builder.enableLiveNotificationTypes(*templateTypes.toTypedArray())
+            }
+
+            val customTypes = config.getAs<List<*>>("customTypes")
+                ?.mapNotNull { it as? String }
+                .orEmpty()
+            if (customTypes.isNotEmpty()) {
+                builder.enableCustomLiveNotificationTypes(*customTypes.toTypedArray())
+            }
+
+            val branding = config.getAs<Map<String, Any>>("branding")
+            if (branding != null) {
+                val accentColor = branding.getAs<String>("accentColorHex")
+                    ?.let { runCatching { Color.parseColor(it) }.getOrNull() }
+                    ?: Color.TRANSPARENT
+                val logoUrl = branding.getAs<String>("logoUrl")
+                val smallIcon = branding.getAs<String>("smallIconResource")
+                    ?.let { name ->
+                        val context = SDKComponent.android().applicationContext
+                        context.resources
+                            .getIdentifier(name, "drawable", context.packageName)
+                            .takeIf { it != 0 }
+                    }
+                builder.setLiveNotificationBranding(
+                    LiveNotificationBranding(
+                        companyName = branding.getAs<String>("companyName").orEmpty(),
+                        accentColor = accentColor,
+                        smallIcon = smallIcon,
+                        logo = logoUrl?.let { LiveNotificationAsset.RemoteUrl(it) },
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/io/customer/customer_io/messagingpush/CustomerIOPushMessaging.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messagingpush/CustomerIOPushMessaging.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import io.customer.customer_io.bridge.NativeModuleBridge
 import io.customer.customer_io.bridge.nativeMapArgs
 import io.customer.customer_io.bridge.nativeNoArgs
+import io.customer.customer_io.liveactivities.CustomerIOLiveActivities
 import io.customer.customer_io.utils.getAs
 import io.customer.customer_io.utils.takeIfNotBlank
 import io.customer.messagingpush.CustomerIOFirebaseMessagingService
@@ -98,6 +99,14 @@ internal class CustomerIOPushMessaging(
         val module = ModuleMessagingPushFCM(
             moduleConfig = MessagingPushModuleConfig.Builder().apply {
                 setPushClickBehavior(pushClickBehavior = pushClickBehavior)
+                // Live Notifications are hosted by the FCM push module, so their config is applied
+                // onto the same MessagingPushModuleConfig.
+                config.getAs<Map<String, Any>>(key = "liveActivities")?.let { liveActivitiesConfig ->
+                    CustomerIOLiveActivities.applyLiveActivitiesConfig(
+                        builder = this,
+                        config = liveActivitiesConfig,
+                    )
+                }
             }.build(),
         )
         builder.addCustomerIOModule(module)

--- a/apps/flutter_sample_spm/lib/src/app.dart
+++ b/apps/flutter_sample_spm/lib/src/app.dart
@@ -13,6 +13,7 @@ import 'screens/dashboard.dart';
 import 'screens/events.dart';
 import 'screens/inbox_messages.dart';
 import 'screens/inline_messages.dart';
+import 'screens/live_activities.dart';
 import 'screens/location.dart';
 import 'screens/login.dart';
 import 'screens/settings.dart';
@@ -156,6 +157,11 @@ class _AmiAppState extends State<AmiApp> {
               name: Screen.locationTest.name,
               path: Screen.locationTest.path,
               builder: (context, state) => const LocationScreen(),
+            ),
+            GoRoute(
+              name: Screen.liveActivitiesTest.name,
+              path: Screen.liveActivitiesTest.path,
+              builder: (context, state) => const LiveActivitiesScreen(),
             ),
           ],
         ),

--- a/apps/flutter_sample_spm/lib/src/data/screen.dart
+++ b/apps/flutter_sample_spm/lib/src/data/screen.dart
@@ -13,7 +13,8 @@ enum Screen {
       name: 'Custom Profile Attribute', path: 'attributes/profile'),
   inlineMessages(name: 'Inline Messages Test', path: 'inline-messages'),
   inboxMessages(name: 'Inbox Messages', path: 'inbox-messages'),
-  locationTest(name: 'Location', path: 'location');
+  locationTest(name: 'Location', path: 'location'),
+  liveActivitiesTest(name: 'Live Activities', path: 'live-activities');
 
   const Screen({
     required this.name,

--- a/apps/flutter_sample_spm/lib/src/screens/dashboard.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/dashboard.dart
@@ -312,6 +312,7 @@ enum _ActionItem {
   inlineMessages,
   inboxMessages,
   location,
+  liveActivities,
   showPushPrompt,
   showLocalPush,
   signOut,
@@ -334,6 +335,8 @@ extension _ActionNames on _ActionItem {
         return 'Inbox Messages';
       case _ActionItem.location:
         return 'Test Location';
+      case _ActionItem.liveActivities:
+        return 'Test Live Activities';
       case _ActionItem.showPushPrompt:
         return 'Show Push Prompt';
       case _ActionItem.showLocalPush:
@@ -359,6 +362,8 @@ extension _ActionNames on _ActionItem {
         return 'Inbox Messages Button';
       case _ActionItem.location:
         return 'Location Button';
+      case _ActionItem.liveActivities:
+        return 'Live Activities Button';
       case _ActionItem.showPushPrompt:
         return 'Show Push Prompt Button';
       case _ActionItem.showLocalPush:
@@ -384,6 +389,8 @@ extension _ActionNames on _ActionItem {
         return Screen.inboxMessages;
       case _ActionItem.location:
         return Screen.locationTest;
+      case _ActionItem.liveActivities:
+        return Screen.liveActivitiesTest;
       case _ActionItem.showPushPrompt:
         return null;
       case _ActionItem.showLocalPush:

--- a/apps/flutter_sample_spm/lib/src/screens/live_activities.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/live_activities.dart
@@ -1,0 +1,259 @@
+import 'package:customer_io/customer_io.dart';
+import 'package:flutter/material.dart';
+
+import '../components/container.dart';
+import '../components/scroll_view.dart';
+import '../theme/sizes.dart';
+import '../utils/extensions.dart';
+
+class LiveActivitiesScreen extends StatefulWidget {
+  const LiveActivitiesScreen({super.key});
+
+  @override
+  State<LiveActivitiesScreen> createState() => _LiveActivitiesScreenState();
+}
+
+class _LiveActivitiesScreenState extends State<LiveActivitiesScreen> {
+  String? _activityId;
+  String _statusText = 'No live activity started yet';
+
+  Future<void> _startSegments() async {
+    try {
+      final id = await CustomerIO.liveActivities.start(
+        const LiveActivityPayload.segments(
+          header: 'Order #1234',
+          status: 'Preparing your order',
+          substatus: 'Kitchen is working on it',
+          segmentsTotal: 4,
+          segmentsComplete: 1,
+          trailingText: 'ETA 20 min',
+        ),
+      );
+      setState(() {
+        _activityId = id;
+        _statusText = 'Started segments activity: $id';
+      });
+      if (!mounted) return;
+      context.showSnackBar('Started segments activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  Future<void> _startCountdown() async {
+    try {
+      final endTime =
+          DateTime.now().add(const Duration(minutes: 10)).millisecondsSinceEpoch ~/
+              1000;
+      final id = await CustomerIO.liveActivities.start(
+        LiveActivityPayload.countdownTimer(
+          header: 'Flash Sale',
+          title: 'Ends soon!',
+          statusMessage: 'Hurry before it is gone',
+          endTime: endTime,
+        ),
+      );
+      setState(() {
+        _activityId = id;
+        _statusText = 'Started countdown activity: $id';
+      });
+      if (!mounted) return;
+      context.showSnackBar('Started countdown activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  Future<void> _update() async {
+    final id = _activityId;
+    if (id == null) {
+      context.showSnackBar('Start an activity first');
+      return;
+    }
+    try {
+      await CustomerIO.liveActivities.update(
+        id,
+        const LiveActivityPayload.segments(
+          header: 'Order #1234',
+          status: 'Out for delivery',
+          substatus: 'Your courier is on the way',
+          segmentsTotal: 4,
+          segmentsComplete: 3,
+          trailingText: 'ETA 5 min',
+        ),
+      );
+      setState(() {
+        _statusText = 'Updated activity: $id';
+      });
+      if (!mounted) return;
+      context.showSnackBar('Updated activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  Future<void> _end() async {
+    final id = _activityId;
+    if (id == null) {
+      context.showSnackBar('Start an activity first');
+      return;
+    }
+    try {
+      await CustomerIO.liveActivities.end(id);
+      setState(() {
+        _statusText = 'Ended activity: $id';
+        _activityId = null;
+      });
+      if (!mounted) return;
+      context.showSnackBar('Ended activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  void _onError(Object ex) {
+    setState(() {
+      _statusText = 'Error: $ex';
+    });
+    if (!mounted) return;
+    context.showSnackBar('Error: $ex');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Sizes sizes = Theme.of(context).extension<Sizes>()!;
+    final theme = Theme.of(context);
+
+    return AppContainer(
+      appBar: AppBar(
+        backgroundColor: null,
+      ),
+      body: FullScreenScrollView(
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 24.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Live Activities Testing',
+                style: theme.textTheme.titleLarge,
+              ),
+              const SizedBox(height: 24),
+              _SectionCard(
+                title: 'Start',
+                description:
+                    'Starts a Live Activity (iOS) / Live Notification (Android) for a built-in template.',
+                child: Column(
+                  children: [
+                    FilledButton(
+                      style: FilledButton.styleFrom(
+                        minimumSize: sizes.buttonDefault(),
+                      ),
+                      onPressed: _startSegments,
+                      child: const Text('Start Segments'),
+                    ),
+                    const SizedBox(height: 12),
+                    FilledButton(
+                      style: FilledButton.styleFrom(
+                        minimumSize: sizes.buttonDefault(),
+                      ),
+                      onPressed: _startCountdown,
+                      child: const Text('Start Countdown Timer'),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              _SectionCard(
+                title: 'Update / End',
+                description:
+                    'Updates the running activity with a new full state, or ends it.',
+                child: Column(
+                  children: [
+                    FilledButton(
+                      style: FilledButton.styleFrom(
+                        minimumSize: sizes.buttonDefault(),
+                      ),
+                      onPressed: _update,
+                      child: const Text('Update Activity'),
+                    ),
+                    const SizedBox(height: 12),
+                    FilledButton(
+                      style: FilledButton.styleFrom(
+                        minimumSize: sizes.buttonDefault(),
+                      ),
+                      onPressed: _end,
+                      child: const Text('End Activity'),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  _statusText,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  final String title;
+  final String description;
+  final Widget child;
+
+  const _SectionCard({
+    required this.title,
+    required this.description,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 12),
+          child,
+          const SizedBox(height: 8),
+          Text(
+            description,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/docs/live-activities.md
+++ b/docs/live-activities.md
@@ -1,0 +1,103 @@
+# Live Activities (iOS) / Live Notifications (Android)
+
+`CustomerIO.liveActivities` shows a live, updating notification driven by a built-in template.
+Two templates ship today: **Segments** and **Countdown Timer**.
+
+- **Android** renders built-in templates entirely inside the SDK — **no native code required**.
+- **iOS** requires a **Widget Extension** in your app to render (ActivityKit has no data-only
+  entry point). The built-in templates' SwiftUI ships in the SDK, so your widget file is ~10 lines
+  (below). Live Activities need **iOS 16.2+** (push-to-start needs 17.2+).
+
+## Enable templates at init
+
+```dart
+await CustomerIO.instance.initialize(
+  config: CustomerIOConfig(
+    cdpApiKey: '…',
+    liveActivitiesConfig: LiveActivitiesConfig(
+      templates: [LiveActivityTemplate.segments, LiveActivityTemplate.countdownTimer],
+      // Android-only branding (iOS branding is compiled into the widget):
+      branding: LiveActivitiesBranding(
+        companyName: 'Acme',
+        accentColorHex: '#FF6D00',
+        logoUrl: 'https://…/logo.png',
+      ),
+    ),
+  ),
+);
+```
+
+## Start / update / end
+
+```dart
+// Segments
+final id = await CustomerIO.liveActivities.start(
+  LiveActivityPayload.segments(
+    header: 'Order #4021',
+    status: 'Preparing your order',
+    segmentsTotal: 4,
+    segmentsComplete: 1,
+  ),
+);
+
+// update() replaces the whole content-state — pass the FULL desired state each time.
+await CustomerIO.liveActivities.update(
+  id,
+  LiveActivityPayload.segments(
+    header: 'Order #4021',
+    status: 'Out for delivery',
+    segmentsTotal: 4,
+    segmentsComplete: 3,
+  ),
+);
+
+await CustomerIO.liveActivities.end(id);
+
+// Countdown Timer — endTime is epoch SECONDS
+final c = await CustomerIO.liveActivities.start(
+  LiveActivityPayload.countdownTimer(
+    header: 'Flash Sale',
+    title: '50% off ends in',
+    endTime: DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000,
+  ),
+);
+```
+
+`start` returns an `activityId` — the only handle you need for `update`/`end`. There is no
+lifecycle event callback; delivery/lifecycle metrics are reported to Customer.io automatically.
+
+### Custom types
+
+`startCustom(activityType, data)` starts an app-defined type. **Android** renders it via your
+`CustomerIOPushNotificationCallback.createLiveNotification` callback. **On iOS this throws** —
+custom types require a native Widget Extension + `ActivityAttributes` and an `adopt()` call.
+
+### Deep-link / opened metric (iOS)
+
+Call `CustomerIO.liveActivities.handleDeepLinkOpen(url)` from your URL-handling entry point to
+report an `opened` metric when the app is opened from a tapped Live Activity. No-op on Android.
+
+## iOS setup (one time)
+
+1. Add `NSSupportsLiveActivities = YES` to your app's `Info.plist`.
+2. Add a **Widget Extension** target (File ▸ New ▸ Target ▸ Widget Extension). In its target,
+   depend on `CustomerIO/LiveActivitiesTemplates` and `CustomerIO/LiveActivitiesAttributes`
+   (CocoaPods) or the `LiveActivities_Templates` / `LiveActivities_Attributes` SwiftPM products.
+3. Replace the generated widget bundle with the built-in templates:
+   ```swift
+   import WidgetKit
+   import CioLiveActivities_Templates   // ships CIOSegmentsLiveActivity, CIOCountdownTimerLiveActivity
+   import CioLiveActivities_Attributes
+
+   @main
+   struct CIOLiveActivitiesWidgets: WidgetBundle {
+       var body: some Widget {
+           CIOSegmentsLiveActivity()
+           CIOCountdownTimerLiveActivity()
+       }
+   }
+   ```
+
+## Android setup
+
+Nothing beyond the standard `messaging-push-fcm` setup — built-in templates render in-SDK.

--- a/ios/customer_io.podspec
+++ b/ios/customer_io.podspec
@@ -24,6 +24,10 @@ Pod::Spec.new do |s|
   # Native SDK dependencies that are required for the Flutter plugin to work.
   s.dependency "CustomerIO/DataPipelines", native_sdk_version
   s.dependency "CustomerIO/MessagingInApp", native_sdk_version
+  # Live Activities (iOS) native rendering + built-in templates.
+  # NOTE: requires native_sdk_version to include Live Activities (>= the LA release).
+  s.dependency "CustomerIO/LiveActivities", native_sdk_version
+  s.dependency "CustomerIO/LiveActivitiesTemplates", native_sdk_version
 
   # If we do not specify a default_subspec, then *all* dependencies inside of *all* the subspecs will be downloaded by cocoapods.
   # We want customers to opt into push dependencies especially because the FCM subpsec downloads Firebase dependencies.

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -79,7 +79,12 @@ var targetDependencies: [Target.Dependency] = [
     .product(name: "DataPipelines", package: "customerio-ios"),
     .product(name: "MessagingInApp", package: "customerio-ios"),
     .product(name: "MessagingPushFCM", package: "customerio-ios"),
-    .product(name: "CioFirebaseWrapper", package: "customerio-ios-fcm")
+    .product(name: "CioFirebaseWrapper", package: "customerio-ios-fcm"),
+    // Live Activities (iOS) native rendering + built-in templates.
+    // NOTE: requires the customerio-ios pin below to include Live Activities (>= the LA release).
+    .product(name: "LiveActivities", package: "customerio-ios"),
+    .product(name: "LiveActivities_Attributes", package: "customerio-ios"),
+    .product(name: "LiveActivities_Templates", package: "customerio-ios")
 ]
 
 if useLocation {

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -14,6 +14,7 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
     private var locationChannelHandler: CustomerIOLocation!
     #endif
     private var messagingPushChannelHandler: CustomerIOMessagingPush!
+    private var liveActivitiesChannelHandler: CustomerIOLiveActivities!
 
     private let logger: CioInternalCommon.Logger = DIGraphShared.shared.logger
 
@@ -28,6 +29,7 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
         instance.locationChannelHandler = CustomerIOLocation(with: registrar)
         #endif
         instance.messagingPushChannelHandler = CustomerIOMessagingPush(with: registrar)
+        instance.liveActivitiesChannelHandler = CustomerIOLiveActivities(with: registrar)
     }
 
     deinit {
@@ -187,6 +189,9 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
 
             // Initialize in-app messaging with provided config
             inAppMessagingChannelHandler.configureModule(params: params)
+
+            // Initialize Live Activities module from the `liveActivities` config (iOS 16.2+).
+            liveActivitiesChannelHandler.initializeModule(params: params)
 
             logger.debug("Customer.io SDK initialized with config: \(params)")
         } catch {

--- a/ios/customer_io/Sources/customer_io/LiveActivities/CustomerIOLiveActivities.swift
+++ b/ios/customer_io/Sources/customer_io/LiveActivities/CustomerIOLiveActivities.swift
@@ -1,0 +1,249 @@
+import Flutter
+import Foundation
+#if canImport(CioLiveActivities)
+import ActivityKit
+import CioLiveActivities
+import CioLiveActivities_Attributes
+import CioLiveActivities_Templates
+#endif
+
+/// Flutter plugin sub-handler for Live Activities.
+///
+/// Gated on `canImport(CioLiveActivities)` and iOS 16.2+. Custom activity types are rejected on
+/// iOS because they require a native Widget Extension and an `adopt(_:)` call and cannot be
+/// data-driven from Dart.
+public class CustomerIOLiveActivities: NSObject, FlutterPlugin {
+    private var methodChannel: FlutterMethodChannel?
+
+    #if canImport(CioLiveActivities)
+    /// The held Live Activities module (not a singleton in the native SDK), created during SDK init.
+    private var module: LiveActivitiesModule?
+
+    /// Type-erased handles keyed by activity id. The native `start` returns a generic
+    /// `CIOLiveActivity<Attributes>` that can't be stored in a homogeneous map, so we keep closures
+    /// that capture the concrete handle and rebuild its content-state from a Dart map on update.
+    private struct ActivityBox {
+        let update: ([String: Any]) async throws -> Void
+        let end: () async -> Void
+    }
+
+    private var activities: [String: ActivityBox] = [:]
+    private let lock = NSLock()
+    #endif
+
+    public static func register(with _: FlutterPluginRegistrar) {}
+
+    init(with registrar: FlutterPluginRegistrar) {
+        super.init()
+
+        let channel = FlutterMethodChannel(name: "customer_io_live_activities", binaryMessenger: registrar.messenger())
+        methodChannel = channel
+        registrar.addMethodCallDelegate(self, channel: channel)
+    }
+
+    deinit {
+        methodChannel?.setMethodCallHandler(nil)
+        methodChannel = nil
+    }
+
+    /// Initialize the Live Activities module from the SDK config's `liveActivities` key. Registers
+    /// the enabled built-in template attribute types so `start` can request them.
+    func initializeModule(params: [String: AnyHashable]) {
+        #if canImport(CioLiveActivities)
+        guard let laConfig = params["liveActivities"] as? [String: AnyHashable] else { return }
+        guard #available(iOS 16.2, *) else { return }
+        let templates = (laConfig["templates"] as? [String]) ?? []
+        var builder = LiveActivityConfigBuilder()
+        if templates.contains("segments") {
+            builder = builder.register(CIOSegmentsAttributes.self)
+        }
+        if templates.contains("countdownTimer") {
+            builder = builder.register(CIOCountdownTimerAttributes.self)
+        }
+        module = LiveActivitiesModule.initialize(builder.build())
+        #endif
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let args = call.arguments as? [String: Any] ?? [:]
+        switch call.method {
+        case "start":
+            start(args, result: result)
+
+        case "update":
+            update(args, result: result)
+
+        case "end":
+            end(args, result: result)
+
+        case "startCustom":
+            startCustom(args, result: result)
+
+        case "handleDeepLinkOpen":
+            handleDeepLinkOpen(args, result: result)
+
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    // MARK: - Bridge methods
+
+    private func start(_ args: [String: Any], result: @escaping FlutterResult) {
+        #if canImport(CioLiveActivities)
+        guard #available(iOS 16.2, *), let module = module else {
+            return result(Self.unavailableError())
+        }
+        guard let map = args["payload"] as? [String: Any], let type = map["type"] as? String else {
+            return result(FlutterError(code: "live_activity_start_failed", message: "payload.type is required", details: nil))
+        }
+        do {
+            let id: String
+            switch type {
+            case "segments":
+                let handle = try module.start(
+                    CIOSegmentsAttributes(header: map["header"] as? String ?? ""),
+                    contentState: try Self.segmentsState(from: map)
+                )
+                store(handle: handle, contentBuilder: Self.segmentsState)
+                id = handle.id
+            case "countdownTimer":
+                let handle = try module.start(
+                    CIOCountdownTimerAttributes(header: map["header"] as? String ?? ""),
+                    contentState: try Self.countdownState(from: map)
+                )
+                store(handle: handle, contentBuilder: Self.countdownState)
+                id = handle.id
+            default:
+                return result(FlutterError(code: "live_activity_start_failed", message: "Unknown live activity template type: \(type)", details: nil))
+            }
+            result(id)
+        } catch {
+            result(FlutterError(code: "live_activity_start_failed", message: error.localizedDescription, details: nil))
+        }
+        #else
+        result(Self.unavailableError())
+        #endif
+    }
+
+    private func update(_ args: [String: Any], result: @escaping FlutterResult) {
+        #if canImport(CioLiveActivities)
+        guard let activityId = args["activityId"] as? String else {
+            return result(FlutterError(code: "live_activity_update_failed", message: "activityId is required", details: nil))
+        }
+        lock.lock()
+        let box = activities[activityId]
+        lock.unlock()
+        guard let box = box else {
+            return result(FlutterError(code: "live_activity_update_failed", message: "No live activity found for id \(activityId)", details: nil))
+        }
+        guard let map = args["payload"] as? [String: Any] else {
+            return result(FlutterError(code: "live_activity_update_failed", message: "payload is required", details: nil))
+        }
+        Task {
+            do {
+                try await box.update(map)
+                result(true)
+            } catch {
+                result(FlutterError(code: "live_activity_update_failed", message: error.localizedDescription, details: nil))
+            }
+        }
+        #else
+        result(Self.unavailableError())
+        #endif
+    }
+
+    private func end(_ args: [String: Any], result: @escaping FlutterResult) {
+        #if canImport(CioLiveActivities)
+        guard let activityId = args["activityId"] as? String else {
+            return result(FlutterError(code: "live_activity_end_failed", message: "activityId is required", details: nil))
+        }
+        lock.lock()
+        let box = activities.removeValue(forKey: activityId)
+        lock.unlock()
+        // Unknown/already-ended id is treated as success (idempotent end).
+        guard let box = box else { return result(true) }
+        Task {
+            await box.end()
+            result(true)
+        }
+        #else
+        result(Self.unavailableError())
+        #endif
+    }
+
+    private func startCustom(_: [String: Any], result: @escaping FlutterResult) {
+        // Custom activity types on iOS require a native Widget Extension + ActivityAttributes and an
+        // `adopt(_:)` call; they cannot be data-driven from Dart.
+        result(FlutterError(
+            code: "live_activity_custom_unsupported_ios",
+            message: "Custom live activity types are not supported from Dart on iOS. Use a native Widget Extension and adopt().",
+            details: nil
+        ))
+    }
+
+    private func handleDeepLinkOpen(_ args: [String: Any], result: @escaping FlutterResult) {
+        #if canImport(CioLiveActivities)
+        guard let urlString = args["url"] as? String, let module = module, let parsed = URL(string: urlString) else {
+            return result(false)
+        }
+        result(module.handleDeepLinkOpen(parsed))
+        #else
+        result(false)
+        #endif
+    }
+
+    // MARK: - Helpers
+
+    #if canImport(CioLiveActivities)
+    @available(iOS 16.2, *)
+    private func store<A: ActivityAttributes>(
+        handle: CIOLiveActivity<A>,
+        contentBuilder: @escaping ([String: Any]) throws -> A.ContentState
+    ) {
+        let box = ActivityBox(
+            update: { map in await handle.update(try contentBuilder(map)) },
+            end: { await handle.end() }
+        )
+        lock.lock()
+        activities[handle.id] = box
+        lock.unlock()
+    }
+
+    @available(iOS 16.2, *)
+    private static func segmentsState(from map: [String: Any]) throws -> CIOSegmentsAttributes.ContentState {
+        CIOSegmentsAttributes.ContentState(
+            status: map["status"] as? String ?? "",
+            substatus: map["substatus"] as? String,
+            segmentsTotal: intValue(map["segmentsTotal"]),
+            segmentsComplete: intValue(map["segmentsComplete"]),
+            trailingText: map["trailingText"] as? String
+        )
+    }
+
+    @available(iOS 16.2, *)
+    private static func countdownState(from map: [String: Any]) throws -> CIOCountdownTimerAttributes.ContentState {
+        var endTime: EpochSecondsDate?
+        if let seconds = map["endTime"] as? NSNumber {
+            endTime = EpochSecondsDate(Date(timeIntervalSince1970: seconds.doubleValue))
+        }
+        return CIOCountdownTimerAttributes.ContentState(
+            title: map["title"] as? String ?? "",
+            statusMessage: map["statusMessage"] as? String,
+            endTime: endTime
+        )
+    }
+
+    private static func intValue(_ any: Any?) -> Int {
+        (any as? NSNumber)?.intValue ?? 0
+    }
+    #endif
+
+    private static func unavailableError() -> FlutterError {
+        FlutterError(
+            code: "live_activity_module_unavailable",
+            message: "Live Activities are unavailable. Enable live activity templates in the SDK config and add the widget extension.",
+            details: nil
+        )
+    }
+}

--- a/lib/config/customer_io_config.dart
+++ b/lib/config/customer_io_config.dart
@@ -1,6 +1,7 @@
 import '../customer_io_enums.dart';
 import '../customer_io_plugin_version.dart' as plugin_info show version;
 import 'in_app_config.dart';
+import 'live_activities_config.dart';
 import 'location_config.dart';
 import 'push_config.dart';
 
@@ -22,6 +23,7 @@ class CustomerIOConfig {
   final InAppConfig? inAppConfig;
   final PushConfig pushConfig;
   final LocationConfig? locationConfig;
+  final LiveActivitiesConfig? liveActivitiesConfig;
 
   CustomerIOConfig({
     required this.cdpApiKey,
@@ -38,6 +40,7 @@ class CustomerIOConfig {
     this.inAppConfig,
     PushConfig? pushConfig,
     this.locationConfig,
+    this.liveActivitiesConfig,
   }) : pushConfig = pushConfig ?? PushConfig();
 
   Map<String, dynamic> toMap() {
@@ -56,6 +59,7 @@ class CustomerIOConfig {
       'inApp': inAppConfig?.toMap(),
       'push': pushConfig.toMap(),
       'location': locationConfig?.toMap(),
+      'liveActivities': liveActivitiesConfig?.toMap(),
       'version': version,
       'source': source
     };

--- a/lib/config/live_activities_config.dart
+++ b/lib/config/live_activities_config.dart
@@ -1,0 +1,64 @@
+import '../customer_io_enums.dart';
+
+/// Branding applied to Live Notifications on Android.
+///
+/// This is Android-only; on iOS the Live Activity appearance is defined by the
+/// app's Widget Extension and these values are ignored.
+class LiveActivitiesBranding {
+  /// Company/brand name shown on the notification.
+  final String? companyName;
+
+  /// Accent color as a `#RRGGBB` hex string.
+  final String? accentColorHex;
+
+  /// Remote URL for a logo asset.
+  final String? logoUrl;
+
+  /// Name of a drawable resource used as the small icon.
+  final String? smallIconResource;
+
+  LiveActivitiesBranding({
+    this.companyName,
+    this.accentColorHex,
+    this.logoUrl,
+    this.smallIconResource,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'companyName': companyName,
+      'accentColorHex': accentColorHex,
+      'logoUrl': logoUrl,
+      'smallIconResource': smallIconResource,
+    };
+  }
+}
+
+/// Configuration for the Live Activities (iOS) / Live Notifications (Android) module.
+class LiveActivitiesConfig {
+  /// Built-in templates to enable.
+  final List<LiveActivityTemplate> templates;
+
+  /// Custom (app-defined) live activity type identifiers to enable.
+  ///
+  /// Custom types are rendered by the app on Android; on iOS they require a
+  /// native Widget Extension and cannot be started from Dart.
+  final List<String> customTypes;
+
+  /// Branding for Live Notifications (Android only).
+  final LiveActivitiesBranding? branding;
+
+  LiveActivitiesConfig({
+    this.templates = const [],
+    this.customTypes = const [],
+    this.branding,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'templates': templates.map((template) => template.rawValue).toList(),
+      'customTypes': customTypes,
+      'branding': branding?.toMap(),
+    };
+  }
+}

--- a/lib/customer_io.dart
+++ b/lib/customer_io.dart
@@ -7,9 +7,13 @@ import 'customer_io_config.dart';
 import 'customer_io_enums.dart';
 import 'data_pipelines/customer_io_platform_interface.dart';
 import 'extensions/map_extensions.dart';
+import 'liveActivities/platform_interface.dart';
 import 'location/platform_interface.dart';
 import 'messaging_in_app/platform_interface.dart';
 import 'messaging_push/platform_interface.dart';
+
+export 'liveActivities/live_activity_payload.dart';
+export 'liveActivities/platform_interface.dart';
 
 class CustomerIO {
   static CustomerIO? _instance;
@@ -18,6 +22,7 @@ class CustomerIO {
   final CustomerIOMessagingPushPlatform _pushMessaging;
   final CustomerIOMessagingInAppPlatform _inAppMessaging;
   final CustomerIOLocationPlatform _location;
+  final CustomerIOLiveActivitiesPlatform _liveActivities;
 
   /// Private constructor to enforce singleton pattern
   CustomerIO._({
@@ -25,12 +30,15 @@ class CustomerIO {
     CustomerIOMessagingPushPlatform? pushMessaging,
     CustomerIOMessagingInAppPlatform? inAppMessaging,
     CustomerIOLocationPlatform? location,
+    CustomerIOLiveActivitiesPlatform? liveActivities,
   })  : _platform = platform ?? CustomerIOPlatform.instance,
         _pushMessaging =
             pushMessaging ?? CustomerIOMessagingPushPlatform.instance,
         _inAppMessaging =
             inAppMessaging ?? CustomerIOMessagingInAppPlatform.instance,
-        _location = location ?? CustomerIOLocationPlatform.instance;
+        _location = location ?? CustomerIOLocationPlatform.instance,
+        _liveActivities =
+            liveActivities ?? CustomerIOLiveActivitiesPlatform.instance;
 
   /// Get the singleton instance of CustomerIO
   static CustomerIO get instance {
@@ -50,12 +58,14 @@ class CustomerIO {
     CustomerIOMessagingPushPlatform? pushMessaging,
     CustomerIOMessagingInAppPlatform? inAppMessaging,
     CustomerIOLocationPlatform? location,
+    CustomerIOLiveActivitiesPlatform? liveActivities,
   }) {
     _instance = CustomerIO._(
       platform: platform,
       pushMessaging: pushMessaging,
       inAppMessaging: inAppMessaging,
       location: location,
+      liveActivities: liveActivities,
     );
     return _instance!;
   }
@@ -80,6 +90,12 @@ class CustomerIO {
   /// Access location functionality
   static CustomerIOLocationPlatform get location {
     return _instance?._location ?? CustomerIOLocationPlatform.instance;
+  }
+
+  /// Access Live Activities (iOS) / Live Notifications (Android) functionality
+  static CustomerIOLiveActivitiesPlatform get liveActivities {
+    return _instance?._liveActivities ??
+        CustomerIOLiveActivitiesPlatform.instance;
   }
 
   /// To initialize the plugin

--- a/lib/customer_io_config.dart
+++ b/lib/customer_io_config.dart
@@ -1,4 +1,5 @@
 export 'config/customer_io_config.dart';
 export 'config/in_app_config.dart';
+export 'config/live_activities_config.dart';
 export 'config/location_config.dart';
 export 'config/push_config.dart';

--- a/lib/customer_io_enums.dart
+++ b/lib/customer_io_enums.dart
@@ -41,6 +41,22 @@ enum PushClickBehaviorAndroid {
 /// inApp - to only display in-app messages and not send screen events to destinations.
 enum ScreenView { all, inApp }
 
+/// Built-in Live Activity (iOS) / Live Notification (Android) templates.
+///
+/// The raw values are the string keys shared verbatim by both native SDKs and
+/// used inside [LiveActivityPayload] maps.
+enum LiveActivityTemplate {
+  /// Segmented progress template (header, status, substatus, segment counts).
+  segments(rawValue: 'segments'),
+
+  /// Countdown timer template (header, title, status message, end time).
+  countdownTimer(rawValue: 'countdownTimer');
+
+  const LiveActivityTemplate({required this.rawValue});
+
+  final String rawValue;
+}
+
 /// Location tracking mode for the CustomerIO Location module.
 enum LocationTrackingMode {
   /// Location tracking is disabled. All location operations no-op.

--- a/lib/liveActivities/_native_constants.dart
+++ b/lib/liveActivities/_native_constants.dart
@@ -1,0 +1,17 @@
+/// Methods specific to the Live Activities module.
+class NativeMethods {
+  static const String start = "start";
+  static const String update = "update";
+  static const String end = "end";
+  static const String startCustom = "startCustom";
+  static const String handleDeepLinkOpen = "handleDeepLinkOpen";
+}
+
+/// Method parameters specific to the Live Activities module.
+class NativeMethodParams {
+  static const String activityId = "activityId";
+  static const String payload = "payload";
+  static const String activityType = "activityType";
+  static const String data = "data";
+  static const String url = "url";
+}

--- a/lib/liveActivities/live_activity_payload.dart
+++ b/lib/liveActivities/live_activity_payload.dart
@@ -1,0 +1,115 @@
+import '../customer_io_enums.dart';
+
+/// Payload describing the full desired state of a Live Activity (iOS) /
+/// Live Notification (Android).
+///
+/// ActivityKit replaces the content-state wholesale on every update, so callers
+/// must always pass the complete desired state to both
+/// [CustomerIOLiveActivitiesPlatform.start] and
+/// [CustomerIOLiveActivitiesPlatform.update].
+///
+/// The field names are identical across both platforms and map directly to the
+/// native template attributes.
+abstract class LiveActivityPayload {
+  /// The built-in template this payload targets.
+  final LiveActivityTemplate type;
+
+  const LiveActivityPayload(this.type);
+
+  /// Serializes the payload into a flat map understood by the native handlers.
+  Map<String, dynamic> toMap();
+
+  /// Creates a payload for the [LiveActivityTemplate.segments] template.
+  const factory LiveActivityPayload.segments({
+    required String header,
+    required String status,
+    String? substatus,
+    required int segmentsTotal,
+    required int segmentsComplete,
+    String? trailingText,
+  }) = SegmentsLiveActivityPayload;
+
+  /// Creates a payload for the [LiveActivityTemplate.countdownTimer] template.
+  const factory LiveActivityPayload.countdownTimer({
+    required String header,
+    required String title,
+    String? statusMessage,
+    int? endTime,
+  }) = CountdownTimerLiveActivityPayload;
+}
+
+/// Payload for the segmented progress template.
+class SegmentsLiveActivityPayload extends LiveActivityPayload {
+  /// Static, non-changing header shown on the activity (an attribute, not state).
+  final String header;
+
+  /// Primary status line.
+  final String status;
+
+  /// Optional secondary status line.
+  final String? substatus;
+
+  /// Total number of segments.
+  final int segmentsTotal;
+
+  /// Number of segments completed so far.
+  final int segmentsComplete;
+
+  /// Optional trailing text (e.g. an ETA or count).
+  final String? trailingText;
+
+  const SegmentsLiveActivityPayload({
+    required this.header,
+    required this.status,
+    this.substatus,
+    required this.segmentsTotal,
+    required this.segmentsComplete,
+    this.trailingText,
+  }) : super(LiveActivityTemplate.segments);
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'type': type.rawValue,
+      'header': header,
+      'status': status,
+      'substatus': substatus,
+      'segmentsTotal': segmentsTotal,
+      'segmentsComplete': segmentsComplete,
+      'trailingText': trailingText,
+    };
+  }
+}
+
+/// Payload for the countdown timer template.
+class CountdownTimerLiveActivityPayload extends LiveActivityPayload {
+  /// Static, non-changing header shown on the activity (an attribute, not state).
+  final String header;
+
+  /// Primary title line.
+  final String title;
+
+  /// Optional status message.
+  final String? statusMessage;
+
+  /// End time as epoch **seconds**. When null, no countdown is rendered.
+  final int? endTime;
+
+  const CountdownTimerLiveActivityPayload({
+    required this.header,
+    required this.title,
+    this.statusMessage,
+    this.endTime,
+  }) : super(LiveActivityTemplate.countdownTimer);
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'type': type.rawValue,
+      'header': header,
+      'title': title,
+      'statusMessage': statusMessage,
+      'endTime': endTime,
+    };
+  }
+}

--- a/lib/liveActivities/method_channel.dart
+++ b/lib/liveActivities/method_channel.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/services.dart';
+
+import '_native_constants.dart';
+import 'live_activity_payload.dart';
+import 'platform_interface.dart';
+
+/// An implementation of [CustomerIOLiveActivitiesPlatform] that uses method channels.
+class CustomerIOLiveActivitiesMethodChannel
+    extends CustomerIOLiveActivitiesPlatform {
+  final MethodChannel methodChannel =
+      const MethodChannel('customer_io_live_activities');
+
+  @override
+  Future<String> start(LiveActivityPayload payload) async {
+    try {
+      final result = await methodChannel.invokeMethod<String>(
+        NativeMethods.start,
+        {NativeMethodParams.payload: payload.toMap()},
+      );
+      return result ?? '';
+    } on MissingPluginException {
+      throw _notEnabled();
+    }
+  }
+
+  @override
+  Future<void> update(String activityId, LiveActivityPayload payload) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        NativeMethods.update,
+        {
+          NativeMethodParams.activityId: activityId,
+          NativeMethodParams.payload: payload.toMap(),
+        },
+      );
+    } on MissingPluginException {
+      throw _notEnabled();
+    }
+  }
+
+  @override
+  Future<void> end(String activityId) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        NativeMethods.end,
+        {NativeMethodParams.activityId: activityId},
+      );
+    } on MissingPluginException {
+      throw _notEnabled();
+    }
+  }
+
+  @override
+  Future<String> startCustom(
+      String activityType, Map<String, dynamic> data) async {
+    try {
+      final result = await methodChannel.invokeMethod<String>(
+        NativeMethods.startCustom,
+        {
+          NativeMethodParams.activityType: activityType,
+          NativeMethodParams.data: data,
+        },
+      );
+      return result ?? '';
+    } on MissingPluginException {
+      throw _notEnabled();
+    }
+  }
+
+  @override
+  Future<bool> handleDeepLinkOpen(String url) async {
+    try {
+      final result = await methodChannel.invokeMethod<bool>(
+        NativeMethods.handleDeepLinkOpen,
+        {NativeMethodParams.url: url},
+      );
+      return result ?? false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+
+  StateError _notEnabled() => StateError(
+        'Customer.io: Live Activities module is not enabled. Enable live '
+        'activity templates in the SDK config (liveActivities) before using '
+        'this feature.',
+      );
+}

--- a/lib/liveActivities/platform_interface.dart
+++ b/lib/liveActivities/platform_interface.dart
@@ -1,0 +1,58 @@
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import 'live_activity_payload.dart';
+import 'method_channel.dart';
+
+/// The interface that implementations of the Live Activities module must implement.
+///
+/// Live Activities (iOS) / Live Notifications (Android) are exposed here. There is
+/// intentionally no lifecycle event listener/stream, as neither native SDK exposes one.
+abstract class CustomerIOLiveActivitiesPlatform extends PlatformInterface {
+  CustomerIOLiveActivitiesPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static CustomerIOLiveActivitiesPlatform _instance =
+      CustomerIOLiveActivitiesMethodChannel();
+
+  static CustomerIOLiveActivitiesPlatform get instance => _instance;
+
+  static set instance(CustomerIOLiveActivitiesPlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  /// Starts a Live Activity for a built-in template and returns its activity id.
+  Future<String> start(LiveActivityPayload payload) {
+    throw UnimplementedError('start() has not been implemented.');
+  }
+
+  /// Updates a running Live Activity with the full desired state.
+  ///
+  /// ActivityKit replaces content-state wholesale, so [payload] must contain the
+  /// complete desired state, not a partial diff.
+  Future<void> update(String activityId, LiveActivityPayload payload) {
+    throw UnimplementedError('update() has not been implemented.');
+  }
+
+  /// Ends a running Live Activity. Ending an unknown/already-ended id is a no-op.
+  Future<void> end(String activityId) {
+    throw UnimplementedError('end() has not been implemented.');
+  }
+
+  /// Starts a custom (app-defined) Live Activity type and returns its activity id.
+  ///
+  /// On Android the app renders the activity via its registered callback. On iOS
+  /// custom types are rejected because they require a native Widget Extension and
+  /// an `adopt(_:)` call; the returned future completes with an error.
+  Future<String> startCustom(String activityType, Map<String, dynamic> data) {
+    throw UnimplementedError('startCustom() has not been implemented.');
+  }
+
+  /// Reports an opened metric for a Live Activity deep link.
+  ///
+  /// Returns true if the SDK handled the url (iOS only); returns false on Android.
+  Future<bool> handleDeepLinkOpen(String url) {
+    throw UnimplementedError('handleDeepLinkOpen() has not been implemented.');
+  }
+}

--- a/test/customer_io_config_test.dart
+++ b/test/customer_io_config_test.dart
@@ -1,5 +1,6 @@
 import 'package:customer_io/config/customer_io_config.dart';
 import 'package:customer_io/config/in_app_config.dart';
+import 'package:customer_io/config/live_activities_config.dart';
 import 'package:customer_io/config/push_config.dart';
 import 'package:customer_io/customer_io_enums.dart';
 import 'package:customer_io/customer_io_plugin_version.dart' as plugin_info;
@@ -110,6 +111,7 @@ void main() {
         'inApp': inAppConfig.toMap(),
         'push': pushConfig.toMap(),
         'location': null,
+        'liveActivities': null,
         'version': config.version,
         'source': config.source,
       };
@@ -168,6 +170,66 @@ void main() {
       final expectedMap = {'siteId': 'testSiteId'};
 
       expect(inAppConfig.toMap(), expectedMap);
+    });
+  });
+
+  group('LiveActivitiesConfig', () {
+    test('should default to empty templates/customTypes and null branding', () {
+      final config = LiveActivitiesConfig();
+
+      expect(config.templates, isEmpty);
+      expect(config.customTypes, isEmpty);
+      expect(config.branding, isNull);
+
+      final map = config.toMap();
+      expect(map['templates'], isEmpty);
+      expect(map['customTypes'], isEmpty);
+      expect(map['branding'], isNull);
+    });
+
+    test('should serialize templates to their raw string values', () {
+      final config = LiveActivitiesConfig(
+        templates: [
+          LiveActivityTemplate.segments,
+          LiveActivityTemplate.countdownTimer,
+        ],
+        customTypes: ['rideStatus'],
+      );
+
+      final map = config.toMap();
+      expect(map['templates'], ['segments', 'countdownTimer']);
+      expect(map['customTypes'], ['rideStatus']);
+    });
+
+    test('should serialize branding fields', () {
+      final config = LiveActivitiesConfig(
+        templates: [LiveActivityTemplate.segments],
+        branding: LiveActivitiesBranding(
+          companyName: 'Acme',
+          accentColorHex: '#FF0000',
+          logoUrl: 'https://example.com/logo.png',
+          smallIconResource: 'ic_notification',
+        ),
+      );
+
+      final branding = config.toMap()['branding'] as Map;
+      expect(branding['companyName'], 'Acme');
+      expect(branding['accentColorHex'], '#FF0000');
+      expect(branding['logoUrl'], 'https://example.com/logo.png');
+      expect(branding['smallIconResource'], 'ic_notification');
+    });
+
+    test('CustomerIOConfig includes liveActivities in toMap()', () {
+      final config = CustomerIOConfig(
+        cdpApiKey: 'testApiKey',
+        liveActivitiesConfig: LiveActivitiesConfig(
+          templates: [LiveActivityTemplate.countdownTimer],
+        ),
+      );
+
+      final map = config.toMap();
+      expect(map['liveActivities'], isNotNull);
+      expect((map['liveActivities'] as Map)['templates'], ['countdownTimer']);
     });
   });
 

--- a/test/liveActivities/method_channel_test.dart
+++ b/test/liveActivities/method_channel_test.dart
@@ -1,0 +1,141 @@
+import 'package:customer_io/customer_io.dart';
+import 'package:customer_io/liveActivities/method_channel.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Verifies the Live Activities method channel invokes the correct native
+/// method names with the expected argument shapes.
+void main() {
+  const MethodChannel channel = MethodChannel('customer_io_live_activities');
+  final Map<String, dynamic> methodInvocations = {};
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    methodInvocations.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      methodInvocations[methodCall.method] = methodCall.arguments;
+      switch (methodCall.method) {
+        case 'start':
+        case 'startCustom':
+          return 'activity-123';
+        case 'update':
+        case 'end':
+          return null;
+        case 'handleDeepLinkOpen':
+          return true;
+        default:
+          throw MissingPluginException();
+      }
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('start() sends segments payload and returns the activity id', () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    final id = await platform.start(
+      const LiveActivityPayload.segments(
+        header: 'Order',
+        status: 'Preparing',
+        substatus: 'In kitchen',
+        segmentsTotal: 4,
+        segmentsComplete: 1,
+        trailingText: 'ETA 20 min',
+      ),
+    );
+
+    expect(id, 'activity-123');
+    expect(methodInvocations.containsKey('start'), isTrue);
+    final args = methodInvocations['start'] as Map;
+    final payload = args['payload'] as Map;
+    expect(payload['type'], 'segments');
+    expect(payload['header'], 'Order');
+    expect(payload['status'], 'Preparing');
+    expect(payload['substatus'], 'In kitchen');
+    expect(payload['segmentsTotal'], 4);
+    expect(payload['segmentsComplete'], 1);
+    expect(payload['trailingText'], 'ETA 20 min');
+  });
+
+  test('start() sends countdownTimer payload with epoch-seconds endTime',
+      () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    await platform.start(
+      const LiveActivityPayload.countdownTimer(
+        header: 'Sale',
+        title: 'Ends soon',
+        statusMessage: 'Hurry',
+        endTime: 1893456000,
+      ),
+    );
+
+    final args = methodInvocations['start'] as Map;
+    final payload = args['payload'] as Map;
+    expect(payload['type'], 'countdownTimer');
+    expect(payload['header'], 'Sale');
+    expect(payload['title'], 'Ends soon');
+    expect(payload['statusMessage'], 'Hurry');
+    expect(payload['endTime'], 1893456000);
+  });
+
+  test('update() sends activityId and full payload', () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    await platform.update(
+      'activity-123',
+      const LiveActivityPayload.segments(
+        header: 'Order',
+        status: 'Out for delivery',
+        segmentsTotal: 4,
+        segmentsComplete: 3,
+      ),
+    );
+
+    final args = methodInvocations['update'] as Map;
+    expect(args['activityId'], 'activity-123');
+    final payload = args['payload'] as Map;
+    expect(payload['type'], 'segments');
+    expect(payload['status'], 'Out for delivery');
+    expect(payload['segmentsComplete'], 3);
+    expect(payload['substatus'], isNull);
+  });
+
+  test('end() sends the activityId', () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    await platform.end('activity-123');
+
+    final args = methodInvocations['end'] as Map;
+    expect(args['activityId'], 'activity-123');
+  });
+
+  test('startCustom() sends activityType and data, returns id', () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    final id = await platform.startCustom('rideStatus', {'driver': 'Alex'});
+
+    expect(id, 'activity-123');
+    final args = methodInvocations['startCustom'] as Map;
+    expect(args['activityType'], 'rideStatus');
+    expect((args['data'] as Map)['driver'], 'Alex');
+  });
+
+  test('handleDeepLinkOpen() sends the url and returns the native result',
+      () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    final handled =
+        await platform.handleDeepLinkOpen('https://example.com/deep');
+
+    expect(handled, isTrue);
+    final args = methodInvocations['handleDeepLinkOpen'] as Map;
+    expect(args['url'], 'https://example.com/deep');
+  });
+}


### PR DESCRIPTION
Adds `CustomerIO.liveActivities` (start/update/end/startCustom/handleDeepLinkOpen) bridging the native Live Activities (iOS) / Live Notifications (Android) feature: built-in Segments + Countdown Timer templates, init config (templates, custom types, Android branding), a sample-app demo screen, unit tests, and docs.

- **Android**: renders in-SDK, zero native code. Verified — example app assembles against the native LN build; `flutter analyze` clean, `flutter test` green (incl. new LA tests).
- **iOS**: requires a Widget Extension (documented); Swift is `canImport`-gated and mirrors the RN bridge.

Depends on unreleased native: Android Live Notifications and the iOS Live Activities SwiftPM/CocoaPods release. Native pins (`android/build.gradle` cioVersion, `pubspec.yaml` native_sdk_version, `Package.swift` customerio-ios) must be bumped to that release before merge. Draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)