### PR TITLE
feat(sample): Visual Inbox demo screen in the Flutter sample app

### DIFF
--- a/apps/flutter_sample_cocoapods/pubspec.lock
+++ b/apps/flutter_sample_cocoapods/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.1.2"
   dbus:
     dependency: transitive
     description:

--- a/apps/flutter_sample_spm/lib/src/app.dart
+++ b/apps/flutter_sample_spm/lib/src/app.dart
@@ -13,6 +13,7 @@ import 'screens/attributes.dart';
 import 'screens/dashboard.dart';
 import 'screens/events.dart';
 import 'screens/inbox_messages.dart';
+import 'screens/inbox_ui.dart';
 import 'screens/inline_messages.dart';
 import 'screens/location.dart';
 import 'screens/login.dart';
@@ -157,6 +158,11 @@ class _AmiAppState extends State<AmiApp> {
               name: Screen.inboxMessages.name,
               path: Screen.inboxMessages.path,
               builder: (context, state) => const InboxMessagesScreen(),
+            ),
+            GoRoute(
+              name: Screen.inboxUi.name,
+              path: Screen.inboxUi.path,
+              builder: (context, state) => const InboxUiScreen(),
             ),
             GoRoute(
               name: Screen.locationTest.name,

--- a/apps/flutter_sample_spm/lib/src/data/screen.dart
+++ b/apps/flutter_sample_spm/lib/src/data/screen.dart
@@ -13,6 +13,7 @@ enum Screen {
       name: 'Custom Profile Attribute', path: 'attributes/profile'),
   inlineMessages(name: 'Inline Messages Test', path: 'inline-messages'),
   inboxMessages(name: 'Inbox Messages', path: 'inbox-messages'),
+  inboxUi(name: 'Inbox UI Components', path: 'inbox-ui'),
   locationTest(name: 'Location', path: 'location');
 
   const Screen({

--- a/apps/flutter_sample_spm/lib/src/screens/dashboard.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/dashboard.dart
@@ -311,6 +311,7 @@ enum _ActionItem {
   profileAttributes,
   inlineMessages,
   inboxMessages,
+  inboxUi,
   location,
   showPushPrompt,
   showLocalPush,
@@ -332,6 +333,8 @@ extension _ActionNames on _ActionItem {
         return 'Test Inline Messages';
       case _ActionItem.inboxMessages:
         return 'Inbox Messages';
+      case _ActionItem.inboxUi:
+        return 'Inbox UI Components';
       case _ActionItem.location:
         return 'Test Location';
       case _ActionItem.showPushPrompt:
@@ -357,6 +360,8 @@ extension _ActionNames on _ActionItem {
         return 'Inline Messages Button';
       case _ActionItem.inboxMessages:
         return 'Inbox Messages Button';
+      case _ActionItem.inboxUi:
+        return 'Inbox UI Components Button';
       case _ActionItem.location:
         return 'Location Button';
       case _ActionItem.showPushPrompt:
@@ -382,6 +387,8 @@ extension _ActionNames on _ActionItem {
         return Screen.inlineMessages;
       case _ActionItem.inboxMessages:
         return Screen.inboxMessages;
+      case _ActionItem.inboxUi:
+        return Screen.inboxUi;
       case _ActionItem.location:
         return Screen.locationTest;
       case _ActionItem.showPushPrompt:

--- a/apps/flutter_sample_spm/lib/src/screens/inbox_ui.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/inbox_ui.dart
@@ -1,0 +1,215 @@
+import 'dart:developer';
+
+import 'package:customer_io/customer_io.dart';
+import 'package:customer_io/customer_io_widgets.dart';
+import 'package:customer_io/messaging_in_app.dart';
+import 'package:flutter/material.dart';
+
+import '../components/container.dart';
+
+/// Demonstrates the three native Visual Notification Inbox UI components exposed
+/// via PlatformView:
+///   1. NotificationInboxOverlay (drop-in bell + slide-out panel)
+///   2. NotificationInboxBell    (bell only; host opens its own UI)
+///   3. NotificationInboxView    (the Jist-rendered message list)
+///
+/// Message actions are handled by the global InboxEventListener (bridged
+/// separately); these widgets only render UI and surface widget-level callbacks.
+class InboxUiScreen extends StatefulWidget {
+  const InboxUiScreen({super.key});
+
+  @override
+  State<InboxUiScreen> createState() => _InboxUiScreenState();
+}
+
+class _InboxUiScreenState extends State<InboxUiScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  /// Last inbox event surfaced by the global [InboxEventListener], shown on-screen.
+  String _lastInboxEvent = 'No inbox events yet';
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+
+    // Register a global inbox event listener. While registered, the Flutter host
+    // owns inbox action navigation (the SDK suppresses its default handling).
+    CustomerIO.inAppMessaging.setInboxEventListener(
+      _DemoInboxEventListener(
+        onEvent: (summary) {
+          log('[InboxEventListener] $summary');
+          if (mounted) {
+            setState(() => _lastInboxEvent = summary);
+          }
+        },
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    // Clear the listener so the SDK restores its default action handling.
+    CustomerIO.inAppMessaging.setInboxEventListener(null);
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppContainer(
+      appBar: AppBar(
+        title: const Text('Inbox UI Components'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Overlay'),
+            Tab(text: 'Bell'),
+            Tab(text: 'List'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildOverlayTab(),
+          _buildBellTab(),
+          _buildListTab(),
+        ],
+      ),
+    );
+  }
+
+  // 1. Drop-in overlay (bell + slide-out panel). The overlay paints itself over
+  // the whole area, so we let it fill a Stack on top of placeholder content.
+  Widget _buildOverlayTab() {
+    return Stack(
+      children: [
+        const Center(
+          child: Padding(
+            padding: EdgeInsets.all(24),
+            child: Text(
+              'NotificationInboxOverlay renders a floating bell and a slide-out '
+              'panel on top of your content. Tap the bell to open the panel.',
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        // The overlay manages its own layout; give it the full area.
+        const Positioned.fill(
+          child: NotificationInboxOverlay(),
+        ),
+        // Readout LAST, so it paints above the overlay. Native platform views draw over earlier
+        // Flutter siblings in a Stack (notably on Android), so ordering this before the overlay hid
+        // the very callbacks this screen exists to show.
+        Positioned(
+          top: 8,
+          left: 8,
+          right: 8,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'last inbox event: $_lastInboxEvent',
+                style: const TextStyle(fontSize: 12),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  // 2. Bell only — host opens its own UI on tap (here we push the list screen).
+  Widget _buildBellTab() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Padding(
+            padding: EdgeInsets.all(24),
+            child: Text(
+              'NotificationInboxBell renders only the bell. On tap, the host '
+              'decides what to show.',
+              textAlign: TextAlign.center,
+            ),
+          ),
+          SizedBox(
+            width: 64,
+            height: 64,
+            child: NotificationInboxBell(
+              onTap: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const _InboxListPage(),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // 3. The Jist-rendered message list, embedded directly.
+  Widget _buildListTab() {
+    return const NotificationInboxView();
+  }
+}
+
+/// Demo [InboxEventListener] that reports each callback as a short summary
+/// string. All callbacks are observational; because a listener is registered,
+/// the host owns inbox action navigation (the SDK does not open urls itself).
+class _DemoInboxEventListener implements InboxEventListener {
+  _DemoInboxEventListener({required this.onEvent});
+
+  final void Function(String summary) onEvent;
+
+  @override
+  void messageActionTaken(
+      InboxMessage message, String actionName, String actionValue) {
+    onEvent(
+        'actionTaken queueId=${message.queueId} action=$actionName value=$actionValue');
+  }
+
+  @override
+  void messageShown(InboxMessage message) {
+    onEvent('shown queueId=${message.queueId}');
+  }
+
+  @override
+  void messageOpened(InboxMessage message) {
+    onEvent('opened queueId=${message.queueId}');
+  }
+
+  @override
+  void messageDismissed(InboxMessage message) {
+    onEvent('dismissed queueId=${message.queueId}');
+  }
+}
+
+/// A simple screen hosting just the [NotificationInboxView], used to demonstrate
+/// the host-opens-its-own-UI flow from [NotificationInboxBell].
+class _InboxListPage extends StatelessWidget {
+  const _InboxListPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return AppContainer(
+      appBar: AppBar(
+        title: const Text('Notification Inbox'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: const NotificationInboxView(),
+    );
+  }
+}

--- a/apps/flutter_sample_spm/lib/src/screens/inbox_ui.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/inbox_ui.dart
@@ -7,14 +7,13 @@ import 'package:flutter/material.dart';
 
 import '../components/container.dart';
 
-/// Demonstrates the three native Visual Notification Inbox UI components exposed
-/// via PlatformView:
-///   1. NotificationInboxOverlay (drop-in bell + slide-out panel)
-///   2. NotificationInboxBell    (bell only; host opens its own UI)
-///   3. NotificationInboxView    (the Jist-rendered message list)
+/// Demonstrates the two native Visual Notification Inbox UI components exposed via
+/// PlatformView:
+///   1. NotificationInboxBell — the branded bell; tapping it opens the SDK's own panel
+///   2. NotificationInboxView — the Jist-rendered message list
 ///
 /// Message actions are handled by the global InboxEventListener (bridged
-/// separately); these widgets only render UI and surface widget-level callbacks.
+/// separately); these widgets only render UI.
 class InboxUiScreen extends StatefulWidget {
   const InboxUiScreen({super.key});
 
@@ -32,7 +31,7 @@ class _InboxUiScreenState extends State<InboxUiScreen>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 3, vsync: this);
+    _tabController = TabController(length: 2, vsync: this);
 
     // Register a global inbox event listener. While registered, the Flutter host
     // owns inbox action navigation (the SDK suppresses its default handling).
@@ -68,7 +67,6 @@ class _InboxUiScreenState extends State<InboxUiScreen>
         bottom: TabBar(
           controller: _tabController,
           tabs: const [
-            Tab(text: 'Overlay'),
             Tab(text: 'Bell'),
             Tab(text: 'List'),
           ],
@@ -77,7 +75,6 @@ class _InboxUiScreenState extends State<InboxUiScreen>
       body: TabBarView(
         controller: _tabController,
         children: [
-          _buildOverlayTab(),
           _buildBellTab(),
           _buildListTab(),
         ],
@@ -85,47 +82,8 @@ class _InboxUiScreenState extends State<InboxUiScreen>
     );
   }
 
-  // 1. Drop-in overlay (bell + slide-out panel). The overlay paints itself over
-  // the whole area, so we let it fill a Stack on top of placeholder content.
-  Widget _buildOverlayTab() {
-    return Stack(
-      children: [
-        const Center(
-          child: Padding(
-            padding: EdgeInsets.all(24),
-            child: Text(
-              'NotificationInboxOverlay renders a floating bell and a slide-out '
-              'panel on top of your content. Tap the bell to open the panel.',
-              textAlign: TextAlign.center,
-            ),
-          ),
-        ),
-        // The overlay manages its own layout; give it the full area.
-        const Positioned.fill(
-          child: NotificationInboxOverlay(),
-        ),
-        // Readout LAST, so it paints above the overlay. Native platform views draw over earlier
-        // Flutter siblings in a Stack (notably on Android), so ordering this before the overlay hid
-        // the very callbacks this screen exists to show.
-        Positioned(
-          top: 8,
-          left: 8,
-          right: 8,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'last inbox event: $_lastInboxEvent',
-                style: const TextStyle(fontSize: 12),
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-
-  // 2. Bell only — host opens its own UI on tap (here we push the list screen).
+  // 1. The branded bell. Tapping it opens the SDK's own panel — the host presents
+  // nothing. `onTap` is observational only.
   Widget _buildBellTab() {
     return Center(
       child: Column(
@@ -134,22 +92,29 @@ class _InboxUiScreenState extends State<InboxUiScreen>
           const Padding(
             padding: EdgeInsets.all(24),
             child: Text(
-              'NotificationInboxBell renders only the bell. On tap, the host '
-              'decides what to show.',
+              'Tapping the bell opens the inbox panel the SDK owns. Remote branding '
+              'styles the bell; this screen decides where it sits.',
               textAlign: TextAlign.center,
             ),
           ),
+          // 88 not 64: the native composition insets its 56 bell by 16 per side, so a
+          // smaller box squeezes the circle onto the glyph.
           SizedBox(
-            width: 64,
-            height: 64,
+            width: 88,
+            height: 88,
             child: NotificationInboxBell(
               onTap: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const _InboxListPage(),
-                  ),
-                );
+                if (mounted) {
+                  setState(() => _lastInboxEvent = 'bell tapped');
+                }
               },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+              'last inbox event: $_lastInboxEvent',
+              style: const TextStyle(fontSize: 12),
             ),
           ),
         ],
@@ -157,7 +122,7 @@ class _InboxUiScreenState extends State<InboxUiScreen>
     );
   }
 
-  // 3. The Jist-rendered message list, embedded directly.
+  // 2. The Jist-rendered message list, embedded directly.
   Widget _buildListTab() {
     return const NotificationInboxView();
   }
@@ -191,25 +156,5 @@ class _DemoInboxEventListener implements InboxEventListener {
   @override
   void messageDismissed(InboxMessage message) {
     onEvent('dismissed queueId=${message.queueId}');
-  }
-}
-
-/// A simple screen hosting just the [NotificationInboxView], used to demonstrate
-/// the host-opens-its-own-UI flow from [NotificationInboxBell].
-class _InboxListPage extends StatelessWidget {
-  const _InboxListPage();
-
-  @override
-  Widget build(BuildContext context) {
-    return AppContainer(
-      appBar: AppBar(
-        title: const Text('Notification Inbox'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ),
-      body: const NotificationInboxView(),
-    );
   }
 }

--- a/apps/flutter_sample_spm/lib/src/screens/inbox_ui.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/inbox_ui.dart
@@ -4,6 +4,7 @@ import 'package:customer_io/customer_io.dart';
 import 'package:customer_io/customer_io_widgets.dart';
 import 'package:customer_io/messaging_in_app.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../components/container.dart';
 
@@ -47,8 +48,45 @@ class _InboxUiScreenState extends State<InboxUiScreen>
             setState(() => _lastInboxEvent = summary);
           }
         },
+        onAction: _openInboxAction,
       ),
     );
+  }
+
+  /// Navigates for a tapped inbox action.
+  ///
+  /// Registering a listener makes this app the owner of inbox action navigation — the native
+  /// forwarder reports every action as host-handled, so the SDK opens nothing and a listener that
+  /// only logs would make inbox taps look broken. Hand the value to the OS the way the SDK would:
+  /// this app's own `flutter-spm` scheme round-trips back through its deep-link handling, anything
+  /// else opens externally.
+  Future<void> _openInboxAction(String actionValue) async {
+    if (actionValue.isEmpty) {
+      return;
+    }
+
+    final uri = Uri.tryParse(actionValue);
+    if (uri == null) {
+      log('[InboxEventListener] unparseable action value: $actionValue');
+      if (mounted) {
+        setState(() => _lastInboxEvent = 'could not parse $actionValue');
+      }
+      return;
+    }
+
+    // Deliberately no `canLaunchUrl` precheck: on iOS it reports false for any scheme missing from
+    // LSApplicationQueriesSchemes even when launching would succeed, so it would refuse valid links.
+    try {
+      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      if (!launched && mounted) {
+        setState(() => _lastInboxEvent = 'could not open $actionValue');
+      }
+    } catch (error) {
+      log('[InboxEventListener] failed to open $actionValue: $error');
+      if (mounted) {
+        setState(() => _lastInboxEvent = 'could not open $actionValue');
+      }
+    }
   }
 
   @override
@@ -142,18 +180,22 @@ class _InboxUiScreenState extends State<InboxUiScreen>
 }
 
 /// Demo [InboxEventListener] that reports each callback as a short summary
-/// string. All callbacks are observational; because a listener is registered,
-/// the host owns inbox action navigation (the SDK does not open urls itself).
+/// string. Because a listener is registered, the host owns inbox action navigation — the SDK does
+/// not open urls itself — so [onAction] carries the tapped action's value out to be navigated.
 class _DemoInboxEventListener implements InboxEventListener {
-  _DemoInboxEventListener({required this.onEvent});
+  _DemoInboxEventListener({required this.onEvent, required this.onAction});
 
   final void Function(String summary) onEvent;
+
+  /// Called with the action's resolved value (typically its url) so the host can navigate.
+  final void Function(String actionValue) onAction;
 
   @override
   void messageActionTaken(
       InboxMessage message, String actionName, String actionValue) {
     onEvent(
         'actionTaken queueId=${message.queueId} action=$actionName value=$actionValue');
+    onAction(actionValue);
   }
 
   @override

--- a/apps/flutter_sample_spm/lib/src/screens/inbox_ui.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/inbox_ui.dart
@@ -28,6 +28,10 @@ class _InboxUiScreenState extends State<InboxUiScreen>
   /// Last inbox event surfaced by the global [InboxEventListener], shown on-screen.
   String _lastInboxEvent = 'No inbox events yet';
 
+  /// Last observational bell tap. Kept separate from [_lastInboxEvent]: the listener's
+  /// `shown` events fire as soon as the panel renders and would otherwise overwrite it.
+  String _lastBellTap = 'No bell taps yet';
+
   @override
   void initState() {
     super.initState();
@@ -104,17 +108,26 @@ class _InboxUiScreenState extends State<InboxUiScreen>
             height: 88,
             child: NotificationInboxBell(
               onTap: () {
+                log('[NotificationInboxBell] onTap (observational)');
                 if (mounted) {
-                  setState(() => _lastInboxEvent = 'bell tapped');
+                  setState(() => _lastBellTap = 'bell tapped');
                 }
               },
             ),
           ),
           Padding(
             padding: const EdgeInsets.all(16),
-            child: Text(
-              'last inbox event: $_lastInboxEvent',
-              style: const TextStyle(fontSize: 12),
+            child: Column(
+              children: [
+                Text(
+                  'last bell tap: $_lastBellTap',
+                  style: const TextStyle(fontSize: 12),
+                ),
+                Text(
+                  'last inbox event: $_lastInboxEvent',
+                  style: const TextStyle(fontSize: 12),
+                ),
+              ],
             ),
           ),
         ],

--- a/apps/flutter_sample_spm/pubspec.yaml
+++ b/apps/flutter_sample_spm/pubspec.yaml
@@ -40,6 +40,10 @@ dependencies:
     path: ../../
   email_validator: ^3.0.0
   go_router: ^14.2.3
+  # Inbox action navigation: registering an InboxEventListener makes this app own it, so the demo
+  # hands the action url to the OS the way the SDK would. Flutter has no built-in equivalent of
+  # React Native's Linking.
+  url_launcher: ^6.3.0
   shared_preferences: ^2.0.15
   flutter_dotenv: ^5.0.2
   package_info_plus: ^8.0.1


### PR DESCRIPTION
Stacked on #365 (SDK). Adds only the demo UI — no SDK changes.

A Visual Inbox screen in the SPM sample exercising both inbox widgets — the branded bell, whose tap opens the SDK's own panel, and the embedded message list — plus an on-screen readout of the `InboxEventListener` callbacks so the listener bridge can be checked by hand. Tapping a message action navigates via `url_launcher`: registering a listener makes the host own action navigation, so the demo has to do it.

Build wiring the samples need to resolve the unreleased native inbox — the cocoapods Podfile branch pins — deliberately lives in the SDK PR so that one stands on its own in CI.

Merge #365 first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app-only navigation and demo UI; no production SDK or auth changes in this diff.
> 
> **Overview**
> Adds an **Inbox UI Components** flow to the Flutter SPM sample so Visual Notification Inbox PlatformViews and the `InboxEventListener` bridge can be exercised manually.
> 
> A new `InboxUiScreen` (route `inbox-ui`, dashboard entry) uses tabs for **`NotificationInboxBell`** (observational `onTap` plus on-screen status) and an embedded **`NotificationInboxView`**. While the screen is open it registers a demo **`InboxEventListener`** that surfaces callback summaries and opens action URLs via **`url_launcher`** (listener registration makes the host own navigation). The listener is cleared on dispose.
> 
> Also bumps the path **`customer_io`** lockfile version in the cocoapods sample and adds **`url_launcher`** to the SPM sample `pubspec.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314b569857264aa7432f37f53fcc2636b451566b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
