### PR TITLE
chore: Enable Live Notifications feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,34 @@ This is the official Customer.io Flutter plugin.
 
 You'll find our complete [SDK documentation here](https://customer.io/docs/sdk/flutter/). 
 
+# Live Activities
+
+Enable the activity types you use via `liveNotificationsConfig` in your `CustomerIOConfig`. On iOS, Live Activities are opt-in: add the `liveactivities` pod subspec (CocoaPods) or set `customerio_live_activities_enabled=true` in `android/gradle.properties` (Swift Package Manager), plus a Widget Extension that renders the SDK's built-in templates.
+
+iOS also requires `NSSupportsLiveActivities` in `ios/Runner/Info.plist`. Without it the system refuses to start any activity, so nothing appears even when everything else is configured:
+
+```xml
+<key>NSSupportsLiveActivities</key>
+<true/>
+```
+
+For an activity of your own, set `customType` to your reverse-DNS identifier and start it with `LiveActivityPayload.custom(data: {...})`. You supply the view: `CIOCustomAttributes` in your iOS Widget Extension, and the `createLiveNotification` callback on Android.
+
+**One manual step is required on iOS.** Forward every opened URL to the SDK from your `AppDelegate`, or taps on a Live Activity are not attributed. `CustomerIOLiveActivities` comes from the plugin, so import it — and note this only compiles once Live Activities are opted in above:
+
+```swift
+import customer_io
+
+override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+  // Reports an `opened` metric and returns the deep link to route to. A non-Customer.io URL comes
+  // back unchanged; `nil` means the activity carried no deep link, so there is nothing to open.
+  guard let routableUrl = CustomerIOLiveActivities.handleWidgetUrl(url) else { return true }
+  return super.application(app, open: routableUrl, options: options)
+}
+```
+
+Android needs no equivalent step.
+
 # Contributing
 
 Thanks for taking an interest in our project! We welcome your contributions. 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,8 +18,6 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
-        // TEMPORARY (REL-1): Live Notifications only exist in an unreleased branch snapshot.
-        maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
     }
 }
 
@@ -72,8 +70,7 @@ dependencies {
     // Version can be overridden for local/CI verification via -PcioVersion=<version>
     // (e.g. -PcioVersion=local to build against a mavenLocal build). The committed default
     // tracks the intended published release.
-    // TEMPORARY (REL-1): defaults to the unreleased Live Notifications branch snapshot.
-    def cioVersion = rootProject.findProperty("cioVersion") ?: "feature-live-notifications-SNAPSHOT"
+    def cioVersion = rootProject.findProperty("cioVersion") ?: "4.20.0"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,8 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
+        // TEMPORARY (REL-1): Live Notifications only exist in an unreleased branch snapshot.
+        maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
     }
 }
 
@@ -67,7 +69,11 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Customer.io SDK
-    def cioVersion = "4.18.2"
+    // Version can be overridden for local/CI verification via -PcioVersion=<version>
+    // (e.g. -PcioVersion=local to build against a mavenLocal build). The committed default
+    // tracks the intended published release.
+    // TEMPORARY (REL-1): defaults to the unreleased Live Notifications branch snapshot.
+    def cioVersion = rootProject.findProperty("cioVersion") ?: "feature-live-notifications-SNAPSHOT"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/src/main/kotlin/io/customer/customer_io/CustomerIOPlugin.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/CustomerIOPlugin.kt
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull
 import io.customer.customer_io.bridge.NativeModuleBridge
 import io.customer.customer_io.bridge.nativeMapArgs
 import io.customer.customer_io.bridge.nativeNoArgs
+import io.customer.customer_io.liveactivities.CustomerIOLiveActivities
 import io.customer.customer_io.location.CustomerIOLocation
 import io.customer.customer_io.messaginginapp.CustomerIOInAppMessaging
 import io.customer.customer_io.messagingpush.CustomerIOPushMessaging
@@ -54,6 +55,9 @@ class CustomerIOPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         modules = buildList {
             add(CustomerIOPushMessaging(flutterPluginBinding))
             add(CustomerIOInAppMessaging(flutterPluginBinding))
+            // Live Activities / Live Notifications runtime methods (config is applied onto the
+            // push module's config builder during initialize).
+            add(CustomerIOLiveActivities(flutterPluginBinding))
             // Location module is optional - enabled via customerio_location_enabled gradle property
             if (BuildConfig.CIO_LOCATION_ENABLED) {
                 add(CustomerIOLocation(flutterPluginBinding))
@@ -222,12 +226,22 @@ class CustomerIOPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     )
                 }
             }
-            // Configure push messaging module based on config provided by customer app
+            // Configure push messaging module based on config provided by customer app.
+            // Live Notifications are hosted by the push module, so the `liveNotifications` config is
+            // merged into the push config and applied onto the same MessagingPushModuleConfig.
             args.getAs<Map<String, Any>>(key = "push").let { pushConfig ->
+                val liveActivitiesConfig = args.getAs<Map<String, Any>>(key = "liveNotifications")
+                val mergedConfig = (pushConfig ?: emptyMap()).let { base ->
+                    if (liveActivitiesConfig != null) {
+                        base + ("liveNotifications" to liveActivitiesConfig)
+                    } else {
+                        base
+                    }
+                }
                 modules.filterIsInstance<CustomerIOPushMessaging>().forEach {
                     it.configureModule(
                         builder = this,
-                        config = pushConfig ?: emptyMap()
+                        config = mergedConfig
                     )
                 }
             }

--- a/android/src/main/kotlin/io/customer/customer_io/liveactivities/CustomerIOLiveActivities.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/liveactivities/CustomerIOLiveActivities.kt
@@ -1,0 +1,323 @@
+package io.customer.customer_io.liveactivities
+
+import android.graphics.Color
+import io.customer.customer_io.bridge.NativeModuleBridge
+import io.customer.customer_io.bridge.nativeMapArgs
+import io.customer.customer_io.utils.getAs
+import io.customer.messagingpush.MessagingPushModuleConfig
+import io.customer.messagingpush.ModuleMessagingPushFCM
+import io.customer.messagingpush.di.pushModuleConfig
+import io.customer.messagingpush.livenotification.LiveNotificationAsset
+import io.customer.messagingpush.livenotification.LiveNotificationBranding
+import io.customer.messagingpush.livenotification.LiveNotificationData
+import io.customer.messagingpush.livenotification.LiveNotificationType
+import io.customer.sdk.CustomerIOBuilder
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Flutter module implementation for Live Activities / Live Notifications.
+ *
+ * Live Notifications are hosted by the FCM push module ([ModuleMessagingPushFCM]); this bridge maps
+ * the wrapper's template payloads to [LiveNotificationData] and forwards them at runtime. The module
+ * *config* (enabled templates, custom types, branding) is applied onto the same
+ * [MessagingPushModuleConfig] the push module builds (see [applyLiveActivitiesConfig]); this handler
+ * therefore does not add a module of its own.
+ */
+// Public so host apps can register a custom Live Notification render callback via
+// [setLiveNotificationCallback]; the constructor stays internal (the plugin owns instantiation).
+class CustomerIOLiveActivities internal constructor(
+    pluginBinding: FlutterPlugin.FlutterPluginBinding,
+) : NativeModuleBridge, MethodChannel.MethodCallHandler {
+    override val moduleName: String = "LiveActivities"
+    override val flutterCommunicationChannel: MethodChannel =
+        MethodChannel(pluginBinding.binaryMessenger, "customer_io_live_activities")
+    private val logger: Logger = SDKComponent.logger
+
+    // Live Notifications are hosted by the FCM push module. Reach it via the module registry
+    // (the SDK-internal MODULE_NAME constant is not accessible, so use the literal value).
+    //
+    // Deliberately not runCatching: `as?` yields null instead of throwing, so a failure branch keyed
+    // on a thrown error would never run and the message below would never be logged.
+    private fun getPushModule(): ModuleMessagingPushFCM? {
+        val module = SDKComponent.modules[PUSH_FCM_MODULE_NAME] as? ModuleMessagingPushFCM
+        if (module == null) {
+            logger.error("Live Notifications: push module is not initialized. Ensure the SDK is initialized with live activity templates enabled.")
+        }
+        return module
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            // `start` is handled with the raw result rather than [nativeMapArgs] so it can report a
+            // type that isn't enabled under the same error code iOS uses; see [start].
+            "start" -> start(call, result)
+            "update" -> call.nativeMapArgs(result, ::update)
+            "end" -> call.nativeMapArgs(result, ::end)
+            else -> super.onMethodCall(call, result)
+        }
+    }
+
+    /**
+     * Starts a live notification and returns its id.
+     *
+     * Takes [result] directly because [nativeMapArgs] reports every failure under the method name:
+     * a type that isn't enabled has to arrive as [TYPE_NOT_REGISTERED_CODE] so the same mistake
+     * reads the same way on iOS and Android. That check is not optional — the native
+     * `startLiveNotification` mints an id whether or not the type is enabled, and
+     * `LiveNotificationHandler` then drops the notification at debug level, so without it the caller
+     * gets a real id and nothing ever renders.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun start(call: MethodCall, result: MethodChannel.Result) {
+        val args = call.arguments as? Map<String, Any> ?: emptyMap()
+        try {
+            val module = requireNotNull(getPushModule()) { MODULE_UNAVAILABLE }
+            val payload = requireNotNull(args.getAs<Map<String, Any>>("payload")) {
+                "payload is required"
+            }
+            // Custom types have no built-in template, so they take the SDK's untyped map path and are
+            // rendered by the app's own callback. Built-ins keep the typed path.
+            val isCustom = payload.getAs<String>("type") == CUSTOM_TYPE_DISCRIMINATOR
+            val activityType = if (isCustom) {
+                requireCustomActivityType()
+            } else {
+                payload.requireString("type")
+            }
+            if (activityType !in enabledActivityTypes()) {
+                return result.error(
+                    TYPE_NOT_REGISTERED_CODE,
+                    notRegisteredMessage(activityType),
+                    null,
+                )
+            }
+            val id = if (isCustom) {
+                module.startLiveNotification(activityType, customData(payload))
+            } else {
+                module.startLiveNotification(parseData(payload))
+            }
+            result.success(id)
+        } catch (ex: Throwable) {
+            result.error(call.method, ex.localizedMessage, ex)
+        }
+    }
+
+    private fun update(args: Map<String, Any>) {
+        val module = requireNotNull(getPushModule()) { MODULE_UNAVAILABLE }
+        val activityId = requireNotNull(args.getAs<String>("activityId")) {
+            "activityId is required"
+        }
+        val payload = requireNotNull(args.getAs<Map<String, Any>>("payload")) {
+            "payload is required"
+        }
+        if (payload.getAs<String>("type") == CUSTOM_TYPE_DISCRIMINATOR) {
+            module.updateLiveNotification(activityId, requireCustomActivityType(), customData(payload))
+        } else {
+            module.updateLiveNotification(activityId, parseData(payload))
+        }
+    }
+
+    /**
+     * Ends a live notification. Dart may send a `payload` for iOS, where a final content-state is
+     * what makes ActivityKit render a terminal state; Android renders its own terminal state (the
+     * notification simply stops being ongoing), so the key is ignored here.
+     */
+    private fun end(args: Map<String, Any>) {
+        val module = requireNotNull(getPushModule()) { MODULE_UNAVAILABLE }
+        val activityId = requireNotNull(args.getAs<String>("activityId")) {
+            "activityId is required"
+        }
+        module.endLiveNotification(activityId)
+    }
+
+    /**
+     * Identifiers the SDK will actually render, read from the live push module config rather than
+     * cached at init. The wrapper is not the only thing that can enable a type — an app (or a
+     * generated config plugin) may call `enableLiveNotificationTypes` on its own builder — and a
+     * cached copy would then be empty and refuse every start.
+     */
+    private fun enabledActivityTypes(): Set<String> =
+        SDKComponent.pushModuleConfig.liveNotificationTypes
+
+    /**
+     * The app's own identifier for the custom template. Absent means the app sent a custom payload
+     * without configuring `liveNotifications.customType` — say so, rather than starting a
+     * notification the allowlist would silently drop.
+     *
+     * Falls back to the live config for the same reason [enabledActivityTypes] reads it: the custom
+     * type may have been enabled without going through this wrapper. It is the one enabled
+     * identifier that isn't a built-in template, and there is only ever one.
+     */
+    private fun requireCustomActivityType(): String = requireNotNull(
+        customActivityType ?: enabledActivityTypes().firstOrNull { identifier ->
+            LiveNotificationType.entries.none { it.identifier == identifier }
+        },
+    ) {
+        "No custom Live Activity type is configured. Set `liveNotifications.customType` in your " +
+            "Customer.io SDK config to your own reverse-DNS identifier, and render it from your " +
+            "CustomerIOLiveNotificationsCallback."
+    }
+
+    /** Flattens the payload's `data` map. Android stringifies every value downstream anyway. */
+    private fun customData(payload: Map<String, Any>): Map<String, Any> =
+        payload.getAs<Map<String, Any>>("data") ?: emptyMap()
+
+    private fun parseData(payload: Map<String, Any>): LiveNotificationData {
+        return when (val type = payload.getAs<String>("type")) {
+            LiveNotificationType.SEGMENTS.identifier -> LiveNotificationData.Segments(
+                header = payload.requireString("header"),
+                status = payload.requireString("status"),
+                substatus = payload.getAs<String>("substatus"),
+                segmentsTotal = payload.requireInt("segmentsTotal"),
+                segmentsComplete = payload.requireInt("segmentsComplete"),
+                trailingText = payload.getAs<String>("trailingText"),
+            )
+
+            LiveNotificationType.COUNTDOWN_TIMER.identifier -> LiveNotificationData.CountdownTimer(
+                header = payload.requireString("header"),
+                title = payload.requireString("title"),
+                statusMessage = payload.getAs<String>("statusMessage"),
+                endTime = payload.getAs<Number>("endTime")?.toLong(),
+            )
+
+            // A newer native SDK may know this type even though this wrapper build doesn't.
+            // Reject softly (the caller turns this into a FlutterError) rather than crash.
+            else -> throw IllegalArgumentException("Unsupported Live Activity template: $type")
+        }
+    }
+
+    private fun Map<String, Any>.requireString(key: String): String =
+        requireNotNull(getAs<String>(key)) { "$key is required" }
+
+    private fun Map<String, Any>.requireInt(key: String): Int =
+        requireNotNull(getAs<Number>(key)) { "$key is required" }.toInt()
+
+    /**
+     * No-op: Live Notification configuration is applied onto the FCM push module's config builder
+     * via [applyLiveActivitiesConfig] rather than by adding a separate module.
+     */
+    override fun configureModule(builder: CustomerIOBuilder, config: Map<String, Any>) {}
+
+    companion object {
+        private const val PUSH_FCM_MODULE_NAME = "MessagingPushFCM"
+        private const val MODULE_UNAVAILABLE =
+            "Live Notifications are unavailable. Enable live activity templates in the SDK config."
+
+        // Discriminator Dart sends for the custom template. Not a wire identifier — the notification
+        // is started under the app's own `liveNotifications.customType`.
+        private const val CUSTOM_TYPE_DISCRIMINATOR = "custom"
+
+        // Mirrors the iOS handler's code so the same mistake reads the same way on both platforms.
+        private const val TYPE_NOT_REGISTERED_CODE = "live_activity_type_not_registered"
+
+        private fun notRegisteredMessage(activityType: String): String =
+            "Live Activity type '$activityType' is not registered. Add it to " +
+                "`liveNotifications.types` in your Customer.io SDK config (or set " +
+                "`liveNotifications.customType` for a custom type), and make sure your app renders it."
+
+        // The app's own identifier for the custom template, captured from config at SDK init. Only a
+        // hint: `requireCustomActivityType` falls back to the live config, which is authoritative
+        // however the type was enabled.
+        @Volatile
+        private var customActivityType: String? = null
+
+        /**
+         * App-provided callback used to render custom (app-defined) Live Notifications. The native
+         * push callback can only be set at SDK build time, so the host app must register this
+         * *before* initializing the Customer.io SDK from Dart; it is then applied onto the push
+         * module's config in [applyLiveActivitiesConfig].
+         */
+        @Volatile
+        private var liveNotificationCallback:
+            io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback? = null
+
+        /**
+         * Registers the callback used to render custom Live Notifications. Must be called before the
+         * Customer.io SDK is initialized from Dart.
+         */
+        @JvmStatic
+        fun setLiveNotificationCallback(
+            callback: io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback,
+        ) {
+            liveNotificationCallback = callback
+        }
+
+        /**
+         * Applies live activity configuration onto the FCM push module's config builder. Live
+         * Notifications are hosted by [ModuleMessagingPushFCM], so their config (enabled templates,
+         * custom types, branding) is set on the same [MessagingPushModuleConfig].
+         *
+         * @param builder the push module's config builder.
+         * @param config the `liveNotifications` config map from the customer app.
+         */
+        internal fun applyLiveActivitiesConfig(
+            builder: MessagingPushModuleConfig.Builder,
+            config: Map<String, Any>,
+        ) {
+            // Custom live notifications require the host app to render them; apply the callback the
+            // app registered before SDK init (see [setLiveNotificationCallback]).
+            liveNotificationCallback?.let { builder.setLiveNotificationCallback(it) }
+
+            // Unrecognized identifiers are ignored: a newer native SDK may ship types this
+            // wrapper build doesn't know, and that must never break the ones it does know.
+            val templateTypes = config.getAs<List<*>>("types")
+                ?.mapNotNull { it as? String }
+                ?.mapNotNull { identifier ->
+                    LiveNotificationType.entries.firstOrNull { it.identifier == identifier }
+                }
+                .orEmpty()
+            if (templateTypes.isNotEmpty()) {
+                builder.enableLiveNotificationTypes(*templateTypes.toTypedArray())
+            }
+
+            // The custom template. Allowlisting the identifier is both necessary and sufficient:
+            // LiveNotificationHandler drops any push whose activityType isn't in this set, and a type
+            // with no built-in template falls through to the host app's render callback.
+            //
+            // Assigned unconditionally: a re-initialize that drops `customType` must clear it, or
+            // `start` would keep minting notifications under an identifier no longer allowlisted —
+            // which the handler then discards, leaving the caller with an id and nothing on screen.
+            val customType = config.getAs<String>("customType")?.trim()?.takeIf { it.isNotEmpty() }
+            customActivityType = customType
+            if (customType != null) {
+                builder.enableCustomLiveNotificationTypes(customType)
+            }
+
+            val branding = config.getAs<Map<String, Any>>("branding")
+            if (branding != null) {
+                val accentColor = branding.getAs<String>("accentColorHex")
+                    ?.let { runCatching { Color.parseColor(it) }.getOrNull() }
+                    ?: Color.TRANSPARENT
+                // A bundled drawable is preferred over a remote URL: it renders without a network
+                // round-trip, so the logo is present on the very first frame.
+                val logo = branding.getAs<String>("logoResource")
+                    ?.let { name -> drawableResId(name)?.let(LiveNotificationAsset::Drawable) }
+                    ?: branding.getAs<String>("logoUrl")?.let(LiveNotificationAsset::RemoteUrl)
+                val smallIcon = branding.getAs<String>("smallIconResource")
+                    ?.let { name -> drawableResId(name) }
+                builder.setLiveNotificationBranding(
+                    LiveNotificationBranding(
+                        companyName = branding.getAs<String>("companyName").orEmpty(),
+                        accentColor = accentColor,
+                        smallIcon = smallIcon,
+                        logo = logo,
+                    ),
+                )
+            }
+        }
+
+        /**
+         * Resolve a bundled drawable by name, or `null` when the host app doesn't ship one under
+         * that name — a missing asset must degrade to "no image", never crash rendering.
+         */
+        private fun drawableResId(name: String): Int? {
+            val context = SDKComponent.android().applicationContext
+            return context.resources
+                .getIdentifier(name, "drawable", context.packageName)
+                .takeIf { it != 0 }
+        }
+    }
+}

--- a/android/src/main/kotlin/io/customer/customer_io/messagingpush/CustomerIOPushMessaging.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messagingpush/CustomerIOPushMessaging.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import io.customer.customer_io.bridge.NativeModuleBridge
 import io.customer.customer_io.bridge.nativeMapArgs
 import io.customer.customer_io.bridge.nativeNoArgs
+import io.customer.customer_io.liveactivities.CustomerIOLiveActivities
 import io.customer.customer_io.utils.getAs
 import io.customer.customer_io.utils.takeIfNotBlank
 import io.customer.messagingpush.CustomerIOFirebaseMessagingService
@@ -98,6 +99,14 @@ internal class CustomerIOPushMessaging(
         val module = ModuleMessagingPushFCM(
             moduleConfig = MessagingPushModuleConfig.Builder().apply {
                 setPushClickBehavior(pushClickBehavior = pushClickBehavior)
+                // Live Notifications are hosted by the FCM push module, so their config is applied
+                // onto the same MessagingPushModuleConfig.
+                config.getAs<Map<String, Any>>(key = "liveNotifications")?.let { liveActivitiesConfig ->
+                    CustomerIOLiveActivities.applyLiveActivitiesConfig(
+                        builder = this,
+                        config = liveActivitiesConfig,
+                    )
+                }
             }.build(),
         )
         builder.addCustomerIOModule(module)

--- a/apps/flutter_sample_cocoapods/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter_sample_cocoapods/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
-        android:name="${applicationName}"
+        android:name="io.customer.testbed.flutter.MainApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="Flutter Pods">
         <activity

--- a/apps/flutter_sample_cocoapods/android/gradle.properties
+++ b/apps/flutter_sample_cocoapods/android/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
 customerio_location_enabled=true
+customerio_live_activities_enabled=true
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator

--- a/apps/flutter_sample_cocoapods/fastlane/Appfile
+++ b/apps/flutter_sample_cocoapods/fastlane/Appfile
@@ -3,6 +3,10 @@ team_id "2YC97BQN3N"
 app_identifier([
   "io.customer.testbed.flutter.cocoapods",
   "io.customer.testbed.flutter.cocoapods.notification-service",
+  # CI builds this app with `flutter build ios --no-codesign`, so this identifier is not needed for
+  # CI to pass. It is here for the same reason the notification-service one is: running the sample
+  # on a device needs a development profile for every embedded extension.
+  "io.customer.testbed.flutter.cocoapods.LiveActivityWidget",
 ])
 
 package_name("io.customer.testbed.flutter.cocoapods")

--- a/apps/flutter_sample_cocoapods/ios/LiveActivityWidget/Info.plist
+++ b/apps/flutter_sample_cocoapods/ios/LiveActivityWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>LiveActivityWidget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/apps/flutter_sample_cocoapods/ios/LiveActivityWidget/LiveActivityWidgetBundle.swift
+++ b/apps/flutter_sample_cocoapods/ios/LiveActivityWidget/LiveActivityWidgetBundle.swift
@@ -1,0 +1,16 @@
+import CioLiveActivities_Attributes
+import CioLiveActivities_Templates
+import SwiftUI
+import WidgetKit
+
+// Renders the Customer.io built-in Live Activity templates. The SwiftUI lives in the SDK, so this
+// widget bundle is all the app needs. Add more `CIO…LiveActivity()` entries as templates ship.
+@main
+struct LiveActivityWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        CIOSegmentsLiveActivity()
+        CIOCountdownTimerLiveActivity()
+        // Custom template: the SDK owns the attributes type, the app owns the view.
+        RideshareLiveActivity()
+    }
+}

--- a/apps/flutter_sample_cocoapods/ios/LiveActivityWidget/RideshareLiveActivity.swift
+++ b/apps/flutter_sample_cocoapods/ios/LiveActivityWidget/RideshareLiveActivity.swift
@@ -1,0 +1,57 @@
+import ActivityKit
+import CioLiveActivities_Attributes
+import SwiftUI
+import WidgetKit
+
+/// SwiftUI rendering for the sample app's custom "rideshare" Live Activity.
+///
+/// The built-in Customer.io templates ship their SwiftUI in the SDK; a custom activity's UI is owned
+/// by the app. What the SDK does provide is the attributes *type*: ``CIOCustomAttributes`` carries an
+/// untyped `data` map, which is what lets Dart start and update this activity without the app
+/// defining a Swift type a method channel could never reach.
+///
+/// The keys read below are the ones the Dart screen sends. Every value is a string, so parse whatever
+/// you need at render time. Add this to `LiveActivityWidgetBundle`.
+@available(iOS 16.2, *)
+struct RideshareLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: CIOCustomAttributes.self) { context in
+            // Lock screen / banner presentation.
+            VStack(alignment: .leading, spacing: 4) {
+                // Headline follows `status` rather than hardcoding "is on the way": the demo ends
+                // the activity with a terminal status ("Arrived"), and a headline that ignores it
+                // leaves the lock screen contradicting itself.
+                Text(context.state.data["status"] ?? "Rideshare")
+                    .font(.headline)
+                Text(context.state.data["driverName"] ?? "")
+                Text("ETA \(context.state.data["etaMinutes"] ?? "—") min")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+            // Required on any custom template: this is what carries the tap URL the SDK
+            // reports `opened` from and routes the deep link with. The bundled templates do
+            // the same on both their lock screen and Dynamic Island.
+            .cioWidgetUrl(context.state.cioMetadata)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Text(context.state.data["driverName"] ?? "")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("\(context.state.data["etaMinutes"] ?? "—") min")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.state.data["status"] ?? "")
+                }
+            } compactLeading: {
+                Image(systemName: "car.fill")
+            } compactTrailing: {
+                Text("\(context.state.data["etaMinutes"] ?? "")m")
+            } minimal: {
+                Image(systemName: "car.fill")
+            }
+            .cioWidgetUrl(context.state.cioMetadata)
+        }
+    }
+}

--- a/apps/flutter_sample_cocoapods/ios/Podfile
+++ b/apps/flutter_sample_cocoapods/ios/Podfile
@@ -45,6 +45,17 @@ target 'Runner' do
   # Uncomment only 1 of the lines below to install a version of the iOS SDK
   pod 'customer_io/fcm', :path => '.symlinks/plugins/customer_io/ios' # install podspec bundled with the plugin
   pod 'customer_io/location', :path => '.symlinks/plugins/customer_io/ios' # install location subspec for testing
+  pod 'customer_io/liveactivities', :path => '.symlinks/plugins/customer_io/ios' # opt in to Live Activities
+
+  # TEMPORARY (REL-1): the Live Activities pods are not on CocoaPods trunk yet, so pull the whole
+  # Customer.io iOS SDK from the branch that carries their podspecs. Remove once they ship.
+  %w[
+    CustomerIO CustomerIOCommon CustomerIODataPipelines CustomerIOTrackingMigration
+    CustomerIOMessagingPush CustomerIOMessagingPushFCM CustomerIOMessagingInApp CustomerIOLocation
+    CustomerIOLiveActivities CustomerIOLiveActivitiesAttributes CustomerIOLiveActivitiesTemplates
+  ].each do |cio_pod|
+    pod cio_pod, :git => "https://github.com/customerio/customerio-ios.git", :branch => "feat/live-activities"
+  end
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: "fcm")
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: "fcm")
 
@@ -58,6 +69,18 @@ target 'NotificationServiceExtension' do
   pod 'customer_io_richpush/fcm', :path => '.symlinks/plugins/customer_io/ios' # install podspec bundled with the plugin
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: true, push_service: "fcm")
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: true, push_service: "fcm")
+end
+
+# Live Activities Widget Extension: renders the built-in SDK templates plus the app-owned custom
+# one. The widget links the attributes + templates pods directly; it does not inherit the Runner
+# target's pods.
+target 'LiveActivityWidget' do
+  use_frameworks!
+  # TEMPORARY (REL-1): these pods are not on CocoaPods trunk yet, so pull them from the branch that
+  # carries their podspecs. Remove the :git/:branch overrides once Live Activities ships.
+  %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
+    pod cio_pod, :git => "https://github.com/customerio/customerio-ios.git", :branch => "feat/live-activities"
+  end
 end
 
 post_install do |installer|

--- a/apps/flutter_sample_cocoapods/ios/Podfile
+++ b/apps/flutter_sample_cocoapods/ios/Podfile
@@ -47,15 +47,6 @@ target 'Runner' do
   pod 'customer_io/location', :path => '.symlinks/plugins/customer_io/ios' # install location subspec for testing
   pod 'customer_io/liveactivities', :path => '.symlinks/plugins/customer_io/ios' # opt in to Live Activities
 
-  # TEMPORARY (REL-1): the Live Activities pods are not on CocoaPods trunk yet, so pull the whole
-  # Customer.io iOS SDK from the branch that carries their podspecs. Remove once they ship.
-  %w[
-    CustomerIO CustomerIOCommon CustomerIODataPipelines CustomerIOTrackingMigration
-    CustomerIOMessagingPush CustomerIOMessagingPushFCM CustomerIOMessagingInApp CustomerIOLocation
-    CustomerIOLiveActivities CustomerIOLiveActivitiesAttributes CustomerIOLiveActivitiesTemplates
-  ].each do |cio_pod|
-    pod cio_pod, :git => "https://github.com/customerio/customerio-ios.git", :branch => "feat/live-activities"
-  end
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: "fcm")
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: "fcm")
 
@@ -76,10 +67,10 @@ end
 # target's pods.
 target 'LiveActivityWidget' do
   use_frameworks!
-  # TEMPORARY (REL-1): these pods are not on CocoaPods trunk yet, so pull them from the branch that
-  # carries their podspecs. Remove the :git/:branch overrides once Live Activities ships.
+  # A widget extension cannot link the Flutter plugin pod, so it names the rendering pods itself.
+  # Keep the version in step with pubspec.yaml's native_sdk_version.
   %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
-    pod cio_pod, :git => "https://github.com/customerio/customerio-ios.git", :branch => "feat/live-activities"
+    pod cio_pod, '4.7.0'
   end
 end
 

--- a/apps/flutter_sample_cocoapods/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/flutter_sample_cocoapods/ios/Runner.xcodeproj/project.pbxproj
@@ -8,23 +8,35 @@
 
 /* Begin PBXBuildFile section */
 		0888D1012BEC428D66F8D1ED /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6615E32455EADFC1FBDD78CC /* GoogleService-Info.plist */; };
+		107246D092D4DE8EB06DE109 /* RideshareLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B316C244DD5C834D8CB18E /* RideshareLiveActivity.swift */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		28D5C8A276A8D41840EC08D2 /* Pods_LiveActivityWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37D30E58DEEC941787F6B7BB /* Pods_LiveActivityWidget.framework */; };
 		28EF97E17CEA8AA8F34B77F4 /* Pods_NotificationServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F682EA52D3CECA56F5B31766 /* Pods_NotificationServiceExtension.framework */; };
 		3006373429A1011F00D63963 /* Env.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3006373329A1011F00D63963 /* Env.swift */; };
 		3006373529A1011F00D63963 /* Env.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3006373329A1011F00D63963 /* Env.swift */; };
 		302D7E34295BEE78005CBB29 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302D7E33295BEE78005CBB29 /* NotificationService.swift */; };
 		302D7E38295BEE78005CBB29 /* NotificationServiceExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 302D7E31295BEE78005CBB29 /* NotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		3D9136AC49968A63653F34EB /* LiveActivityWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AA0AD51532CB6FE701C2DC /* LiveActivityWidgetBundle.swift */; };
+		5CEC7F662EEC16CC63ED1691 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 197B0B818009B3BB9BB96F80 /* Foundation.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
-		B7F5CCB42F87000000000001 /* PermissionChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		B7F5CCB42F87000000000001 /* PermissionChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */; };
 		E377A53B8DA8666B0D7793F5 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 959D89812F5C216E228A95E4 /* Pods_Runner.framework */; };
+		F9900D87A1D51D5B77B11693 /* LiveActivityWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3A754581ADAB131B962B39C2 /* LiveActivityWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		20A1E892891D887C51E26AA6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 97BCC0C849A5ABF970A93242;
+			remoteInfo = LiveActivityWidget;
+		};
 		302D7E36295BEE78005CBB29 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
@@ -42,6 +54,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				302D7E38295BEE78005CBB29 /* NotificationServiceExtension.appex in Embed Foundation Extensions */,
+				F9900D87A1D51D5B77B11693 /* LiveActivityWidget.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -61,16 +74,22 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		197B0B818009B3BB9BB96F80 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		28671DC5A9C36B0681126D45 /* Pods-LiveActivityWidget.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LiveActivityWidget.profile.xcconfig"; path = "Target Support Files/Pods-LiveActivityWidget/Pods-LiveActivityWidget.profile.xcconfig"; sourceTree = "<group>"; };
 		3006373329A1011F00D63963 /* Env.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Env.swift; sourceTree = "<group>"; };
 		30095F29295BC58F00D3389F /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		302D7E31295BEE78005CBB29 /* NotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		302D7E33295BEE78005CBB29 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		302D7E35295BEE78005CBB29 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		34AA0AD51532CB6FE701C2DC /* LiveActivityWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LiveActivityWidgetBundle.swift; path = LiveActivityWidget/LiveActivityWidgetBundle.swift; sourceTree = "<group>"; };
+		37D30E58DEEC941787F6B7BB /* Pods_LiveActivityWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LiveActivityWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A754581ADAB131B962B39C2 /* LiveActivityWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; name = LiveActivityWidget.appex; path = LiveActivityWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		6615E32455EADFC1FBDD78CC /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		71EE9BDB52E4E53C550AF42A /* Pods-LiveActivityWidget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LiveActivityWidget.debug.xcconfig"; path = "Target Support Files/Pods-LiveActivityWidget/Pods-LiveActivityWidget.debug.xcconfig"; sourceTree = "<group>"; };
+		737405D02DA3B8093353894A /* Pods-LiveActivityWidget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LiveActivityWidget.release.xcconfig"; path = "Target Support Files/Pods-LiveActivityWidget/Pods-LiveActivityWidget.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		B7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionChannelHandler.swift; sourceTree = "<group>"; };
 		78A3A48B351662F042A03F84 /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7A6258D5F4955F2DA8E8B7E3 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
@@ -84,6 +103,9 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		987BA8A89C6CB3EFD12C2CD6 /* Pods-NotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		B7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionChannelHandler.swift; sourceTree = "<group>"; };
+		D3B316C244DD5C834D8CB18E /* RideshareLiveActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RideshareLiveActivity.swift; path = LiveActivityWidget/RideshareLiveActivity.swift; sourceTree = "<group>"; };
+		DC62115B1DD0139219C318B5 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = LiveActivityWidget/Info.plist; sourceTree = "<group>"; };
 		E5766C6B53ABA56AEFB19225 /* Pods-NotificationServiceExtension.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.profile.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.profile.xcconfig"; sourceTree = "<group>"; };
 		EDFC0FD173F4E6F4048DC792 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		F62EE4FB6B9A8D86AD03E7BC /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
@@ -96,6 +118,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				28EF97E17CEA8AA8F34B77F4 /* Pods_NotificationServiceExtension.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		612A252ADFB0D45B7A3DC9AD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5CEC7F662EEC16CC63ED1691 /* Foundation.framework in Frameworks */,
+				28D5C8A276A8D41840EC08D2 /* Pods_LiveActivityWidget.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -120,6 +151,16 @@
 			path = NotificationServiceExtension;
 			sourceTree = "<group>";
 		};
+		3B9CC30C06217F6B6B80AFEE /* LiveActivityWidget */ = {
+			isa = PBXGroup;
+			children = (
+				34AA0AD51532CB6FE701C2DC /* LiveActivityWidgetBundle.swift */,
+				DC62115B1DD0139219C318B5 /* Info.plist */,
+				D3B316C244DD5C834D8CB18E /* RideshareLiveActivity.swift */,
+			);
+			name = LiveActivityWidget;
+			sourceTree = SOURCE_ROOT;
+		};
 		3E9C772F68D2059B32B4A97E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -129,8 +170,19 @@
 				7A6258D5F4955F2DA8E8B7E3 /* Pods-Runner.debug.xcconfig */,
 				F62EE4FB6B9A8D86AD03E7BC /* Pods-Runner.release.xcconfig */,
 				EDFC0FD173F4E6F4048DC792 /* Pods-Runner.profile.xcconfig */,
+				737405D02DA3B8093353894A /* Pods-LiveActivityWidget.release.xcconfig */,
+				71EE9BDB52E4E53C550AF42A /* Pods-LiveActivityWidget.debug.xcconfig */,
+				28671DC5A9C36B0681126D45 /* Pods-LiveActivityWidget.profile.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		84F227434A6401B17DB74A10 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				197B0B818009B3BB9BB96F80 /* Foundation.framework */,
+			);
+			name = iOS;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -156,6 +208,7 @@
 				3E9C772F68D2059B32B4A97E /* Pods */,
 				B5A766D2ED4D4067A36F2D1D /* Frameworks */,
 				6615E32455EADFC1FBDD78CC /* GoogleService-Info.plist */,
+				3B9CC30C06217F6B6B80AFEE /* LiveActivityWidget */,
 			);
 			sourceTree = "<group>";
 		};
@@ -164,6 +217,7 @@
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				302D7E31295BEE78005CBB29 /* NotificationServiceExtension.appex */,
+				3A754581ADAB131B962B39C2 /* LiveActivityWidget.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -190,6 +244,8 @@
 			children = (
 				F682EA52D3CECA56F5B31766 /* Pods_NotificationServiceExtension.framework */,
 				959D89812F5C216E228A95E4 /* Pods_Runner.framework */,
+				84F227434A6401B17DB74A10 /* iOS */,
+				37D30E58DEEC941787F6B7BB /* Pods_LiveActivityWidget.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -215,6 +271,24 @@
 			productReference = 302D7E31295BEE78005CBB29 /* NotificationServiceExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		97BCC0C849A5ABF970A93242 /* LiveActivityWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B22B8F72D94E010BEF4B5FB7 /* Build configuration list for PBXNativeTarget "LiveActivityWidget" */;
+			buildPhases = (
+				AAEC6E1AABD003EACDAF7EA8 /* [CP] Check Pods Manifest.lock */,
+				998D654CC9ED0E0C1EB4AF75 /* Sources */,
+				612A252ADFB0D45B7A3DC9AD /* Frameworks */,
+				D6C2AF3CF72D21444DAAFD8E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LiveActivityWidget;
+			productName = LiveActivityWidget;
+			productReference = 3A754581ADAB131B962B39C2 /* LiveActivityWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
@@ -234,6 +308,7 @@
 			);
 			dependencies = (
 				302D7E37295BEE78005CBB29 /* PBXTargetDependency */,
+				924FDE73BFD31CA94C8D4690 /* PBXTargetDependency */,
 			);
 			name = Runner;
 			packageProductDependencies = (
@@ -281,6 +356,7 @@
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
 				302D7E30295BEE78005CBB29 /* NotificationServiceExtension */,
+				97BCC0C849A5ABF970A93242 /* LiveActivityWidget */,
 			);
 		};
 /* End PBXProject section */
@@ -302,6 +378,13 @@
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 				0888D1012BEC428D66F8D1ED /* GoogleService-Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6C2AF3CF72D21444DAAFD8E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -400,6 +483,28 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		AAEC6E1AABD003EACDAF7EA8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-LiveActivityWidget-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		FB05793FCEE3100A134F8366 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -440,6 +545,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		998D654CC9ED0E0C1EB4AF75 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3D9136AC49968A63653F34EB /* LiveActivityWidgetBundle.swift in Sources */,
+				107246D092D4DE8EB06DE109 /* RideshareLiveActivity.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -447,6 +561,12 @@
 			isa = PBXTargetDependency;
 			target = 302D7E30295BEE78005CBB29 /* NotificationServiceExtension */;
 			targetProxy = 302D7E36295BEE78005CBB29 /* PBXContainerItemProxy */;
+		};
+		924FDE73BFD31CA94C8D4690 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = LiveActivityWidget;
+			target = 97BCC0C849A5ABF970A93242 /* LiveActivityWidget */;
+			targetProxy = 20A1E892891D887C51E26AA6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -670,6 +790,65 @@
 			};
 			name = Profile;
 		};
+		37AD36D9FCFC5B1CAD915E02 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 737405D02DA3B8093353894A /* Pods-LiveActivityWidget.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2YC97BQN3N;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = LiveActivityWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.customer.testbed.flutter.cocoapods.LiveActivityWidget;
+				PRODUCT_NAME = LiveActivityWidget;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development io.customer.testbed.flutter.cocoapods.LiveActivityWidget";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		8E5919CA7ED9094F5F6D5895 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 28671DC5A9C36B0681126D45 /* Pods-LiveActivityWidget.profile.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = LiveActivityWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.customer.testbed.flutter.cocoapods.LiveActivityWidget;
+				PRODUCT_NAME = LiveActivityWidget;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Profile;
+		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -839,6 +1018,36 @@
 			};
 			name = Release;
 		};
+		98E59CADE438A1839F73C171 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 71EE9BDB52E4E53C550AF42A /* Pods-LiveActivityWidget.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2YC97BQN3N;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = LiveActivityWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.customer.testbed.flutter.cocoapods.LiveActivityWidget;
+				PRODUCT_NAME = LiveActivityWidget;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development io.customer.testbed.flutter.cocoapods.LiveActivityWidget";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -868,6 +1077,16 @@
 				97C147061CF9000F007C117D /* Debug */,
 				97C147071CF9000F007C117D /* Release */,
 				249021D4217E4FDB00AE95B9 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B22B8F72D94E010BEF4B5FB7 /* Build configuration list for PBXNativeTarget "LiveActivityWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				37AD36D9FCFC5B1CAD915E02 /* Release */,
+				98E59CADE438A1839F73C171 /* Debug */,
+				8E5919CA7ED9094F5F6D5895 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/flutter_sample_cocoapods/ios/Runner/AppDelegate.swift
+++ b/apps/flutter_sample_cocoapods/ios/Runner/AppDelegate.swift
@@ -5,6 +5,7 @@ import CioMessagingPushFCM
 import FirebaseMessaging
 import FirebaseCore
 import CioFirebaseWrapper
+import customer_io
 
 @main
 class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
@@ -20,7 +21,7 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
 
         let controller = window?.rootViewController as! FlutterViewController
         permissionHandler.register(with: controller.binaryMessenger)
-        
+
         // Depending on the method you choose to install Firebase in your app,
         // you may need to add functions to this file, such as the following:
         // FirebaseApp.configure()
@@ -62,6 +63,15 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
     override func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         super.application(application, continue: userActivity, restorationHandler: restorationHandler)
         return false
+    }
+
+    // Reference pattern: report a Live Activity tap so Customer.io attributes an `opened` metric.
+    // A tap arrives here through the normal openURL path; the wrapper forwards the URL to the SDK.
+    // For a Customer.io widget URL this returns the customer's redirect target to route to (nil
+    // when it carries none); any other URL comes back unchanged, so existing deep links still work.
+    override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        guard let routableUrl = CustomerIOLiveActivities.handleWidgetUrl(url) else { return true }
+        return super.application(app, open: routableUrl, options: options)
     }
 }
 

--- a/apps/flutter_sample_cocoapods/ios/Runner/Info.plist
+++ b/apps/flutter_sample_cocoapods/ios/Runner/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/apps/flutter_sample_cocoapods/pubspec.lock
+++ b/apps/flutter_sample_cocoapods/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.1.2"
   dbus:
     dependency: transitive
     description:

--- a/apps/flutter_sample_spm/android/app/src/main/AndroidManifest.xml
+++ b/apps/flutter_sample_spm/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
-        android:name="${applicationName}"
+        android:name="io.customer.testbed.flutter.MainApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="Flutter">
         <activity

--- a/apps/flutter_sample_spm/android/gradle.properties
+++ b/apps/flutter_sample_spm/android/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
 customerio_location_enabled=true
+customerio_live_activities_enabled=true
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator

--- a/apps/flutter_sample_spm/fastlane/Appfile
+++ b/apps/flutter_sample_spm/fastlane/Appfile
@@ -3,6 +3,10 @@ team_id "2YC97BQN3N"
 app_identifier([
   "io.customer.testbed.flutter.spm",
   "io.customer.testbed.flutter.spm.notification-service",
+  # Required, for the same reason the notification-service one is: this app is the primary sample, so
+  # CI builds it signed via the `ios build` lane. Every embedded extension needs its own profile, or
+  # the widget is signed with a different certificate than the host app and the build fails.
+  "io.customer.testbed.flutter.spm.LiveActivityWidget",
 ])
 
 package_name("io.customer.testbed.flutter.spm")

--- a/apps/flutter_sample_spm/ios/LiveActivityWidget/Info.plist
+++ b/apps/flutter_sample_spm/ios/LiveActivityWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>LiveActivityWidget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/apps/flutter_sample_spm/ios/LiveActivityWidget/LiveActivityWidgetBundle.swift
+++ b/apps/flutter_sample_spm/ios/LiveActivityWidget/LiveActivityWidgetBundle.swift
@@ -1,0 +1,16 @@
+import CioLiveActivities_Attributes
+import CioLiveActivities_Templates
+import SwiftUI
+import WidgetKit
+
+// Renders the Customer.io built-in Live Activity templates. The SwiftUI lives in the SDK, so this
+// widget bundle is all the app needs. Add more `CIO…LiveActivity()` entries as templates ship.
+@main
+struct LiveActivityWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        CIOSegmentsLiveActivity()
+        CIOCountdownTimerLiveActivity()
+        // Custom template: the SDK owns the attributes type, the app owns the view.
+        RideshareLiveActivity()
+    }
+}

--- a/apps/flutter_sample_spm/ios/LiveActivityWidget/RideshareLiveActivity.swift
+++ b/apps/flutter_sample_spm/ios/LiveActivityWidget/RideshareLiveActivity.swift
@@ -1,0 +1,57 @@
+import ActivityKit
+import CioLiveActivities_Attributes
+import SwiftUI
+import WidgetKit
+
+/// SwiftUI rendering for the sample app's custom "rideshare" Live Activity.
+///
+/// The built-in Customer.io templates ship their SwiftUI in the SDK; a custom activity's UI is owned
+/// by the app. What the SDK does provide is the attributes *type*: ``CIOCustomAttributes`` carries an
+/// untyped `data` map, which is what lets Dart start and update this activity without the app
+/// defining a Swift type a method channel could never reach.
+///
+/// The keys read below are the ones the Dart screen sends. Every value is a string, so parse whatever
+/// you need at render time. Add this to `LiveActivityWidgetBundle`.
+@available(iOS 16.2, *)
+struct RideshareLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: CIOCustomAttributes.self) { context in
+            // Lock screen / banner presentation.
+            VStack(alignment: .leading, spacing: 4) {
+                // Headline follows `status` rather than hardcoding "is on the way": the demo ends
+                // the activity with a terminal status ("Arrived"), and a headline that ignores it
+                // leaves the lock screen contradicting itself.
+                Text(context.state.data["status"] ?? "Rideshare")
+                    .font(.headline)
+                Text(context.state.data["driverName"] ?? "")
+                Text("ETA \(context.state.data["etaMinutes"] ?? "—") min")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+            // Required on any custom template: this is what carries the tap URL the SDK
+            // reports `opened` from and routes the deep link with. The bundled templates do
+            // the same on both their lock screen and Dynamic Island.
+            .cioWidgetUrl(context.state.cioMetadata)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Text(context.state.data["driverName"] ?? "")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("\(context.state.data["etaMinutes"] ?? "—") min")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.state.data["status"] ?? "")
+                }
+            } compactLeading: {
+                Image(systemName: "car.fill")
+            } compactTrailing: {
+                Text("\(context.state.data["etaMinutes"] ?? "")m")
+            } minimal: {
+                Image(systemName: "car.fill")
+            }
+            .cioWidgetUrl(context.state.cioMetadata)
+        }
+    }
+}

--- a/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
@@ -14,13 +14,17 @@
 		302D7E34295BEE78005CBB29 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302D7E33295BEE78005CBB29 /* NotificationService.swift */; };
 		302D7E38295BEE78005CBB29 /* NotificationServiceExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 302D7E31295BEE78005CBB29 /* NotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		5AE1C3437204E2D906BF49A6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DC59BBB23D6A532BD30539D /* Foundation.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
-		A7F5CCB42F87000000000001 /* PermissionChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		A6B668154ECC2EF165DCC2E3 /* RideshareLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C513D11E43CFE11285240E /* RideshareLiveActivity.swift */; };
 		A7F5CCB32F85A5EE00654DD4 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = A7F5CCB22F85A5EE00654DD4 /* FlutterGeneratedPluginSwiftPackage */; };
+		A7F5CCB42F87000000000001 /* PermissionChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */; };
+		DAAC844099026EF69C0A2F66 /* LiveActivityWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = D135D93A5C195F10CDB42963 /* LiveActivityWidget.appex */; };
+		F4B0C28DAFBE7E24C89AE3B0 /* LiveActivityWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1798AA60F5079C5C86451C /* LiveActivityWidgetBundle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -30,6 +34,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 302D7E30295BEE78005CBB29;
 			remoteInfo = NotificationServiceExtension;
+		};
+		C16F2D5B76DBB5642F3614A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0DC4DBB0DDE07D562465E823;
+			remoteInfo = LiveActivityWidget;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -41,6 +52,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				302D7E38295BEE78005CBB29 /* NotificationServiceExtension.appex in Embed Foundation Extensions */,
+				DAAC844099026EF69C0A2F66 /* LiveActivityWidget.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -60,6 +72,7 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		1DC59BBB23D6A532BD30539D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		3006373329A1011F00D63963 /* Env.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Env.swift; sourceTree = "<group>"; };
 		30095F29295BC58F00D3389F /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		302D7E31295BEE78005CBB29 /* NotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -70,9 +83,11 @@
 		681FB9752F7CD18800BFFB0F /* NotificationServiceExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationServiceExtension.entitlements; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		A7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionChannelHandler.swift; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		79D24AE6E2C71E6994B72F5E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		8C1798AA60F5079C5C86451C /* LiveActivityWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveActivityWidgetBundle.swift; sourceTree = "<group>"; };
+		91C513D11E43CFE11285240E /* RideshareLiveActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RideshareLiveActivity.swift; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -80,9 +95,19 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A7F5CCB52F87000000000001 /* PermissionChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionChannelHandler.swift; sourceTree = "<group>"; };
+		D135D93A5C195F10CDB42963 /* LiveActivityWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LiveActivityWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		15E2BD3AF5951A3751A4C567 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5AE1C3437204E2D906BF49A6 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		302D7E2E295BEE78005CBB29 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -112,6 +137,22 @@
 			path = NotificationServiceExtension;
 			sourceTree = "<group>";
 		};
+		3EDA66FB63AE1086BA54230E /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				1DC59BBB23D6A532BD30539D /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		6490A60C67521ECCD00141B9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3EDA66FB63AE1086BA54230E /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -133,6 +174,8 @@
 				302D7E32295BEE78005CBB29 /* NotificationServiceExtension */,
 				97C146EF1CF9000F007C117D /* Products */,
 				6615E32455EADFC1FBDD78CC /* GoogleService-Info.plist */,
+				6490A60C67521ECCD00141B9 /* Frameworks */,
+				C6644C0853063B795A2C668A /* LiveActivityWidget */,
 			);
 			sourceTree = "<group>";
 		};
@@ -141,6 +184,7 @@
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				302D7E31295BEE78005CBB29 /* NotificationServiceExtension.appex */,
+				D135D93A5C195F10CDB42963 /* LiveActivityWidget.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -162,9 +206,41 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		C6644C0853063B795A2C668A /* LiveActivityWidget */ = {
+			isa = PBXGroup;
+			children = (
+				8C1798AA60F5079C5C86451C /* LiveActivityWidgetBundle.swift */,
+				91C513D11E43CFE11285240E /* RideshareLiveActivity.swift */,
+				79D24AE6E2C71E6994B72F5E /* Info.plist */,
+			);
+			name = LiveActivityWidget;
+			path = LiveActivityWidget;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0DC4DBB0DDE07D562465E823 /* LiveActivityWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EA94B0C8F58A0B4C9311943E /* Build configuration list for PBXNativeTarget "LiveActivityWidget" */;
+			buildPhases = (
+				6D2E61BBC115EDD5F117302A /* Sources */,
+				15E2BD3AF5951A3751A4C567 /* Frameworks */,
+				7E051D1053F0A45C52874546 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LiveActivityWidget;
+			packageProductDependencies = (
+				A9A0791B2FB8CCF3498BCB38 /* LiveActivities_Attributes */,
+				8AF62B69DD27659F4B6736FA /* LiveActivities_Templates */,
+			);
+			productName = LiveActivityWidget;
+			productReference = D135D93A5C195F10CDB42963 /* LiveActivityWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		302D7E30295BEE78005CBB29 /* NotificationServiceExtension */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 302D7E39295BEE78005CBB29 /* Build configuration list for PBXNativeTarget "NotificationServiceExtension" */;
@@ -201,6 +277,7 @@
 			);
 			dependencies = (
 				302D7E37295BEE78005CBB29 /* PBXTargetDependency */,
+				26F2E6E07430CB1CCB579E2D /* PBXTargetDependency */,
 			);
 			name = Runner;
 			packageProductDependencies = (
@@ -240,7 +317,8 @@
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+				1BE99B10B93B3864502FF8B1 /* XCRemoteSwiftPackageReference "customerio-ios" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
@@ -248,12 +326,20 @@
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
 				302D7E30295BEE78005CBB29 /* NotificationServiceExtension */,
+				0DC4DBB0DDE07D562465E823 /* LiveActivityWidget */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		302D7E2F295BEE78005CBB29 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7E051D1053F0A45C52874546 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -318,6 +404,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6D2E61BBC115EDD5F117302A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4B0C28DAFBE7E24C89AE3B0 /* LiveActivityWidgetBundle.swift in Sources */,
+				A6B668154ECC2EF165DCC2E3 /* RideshareLiveActivity.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EA1CF9000F007C117D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -332,6 +427,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		26F2E6E07430CB1CCB579E2D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = LiveActivityWidget;
+			target = 0DC4DBB0DDE07D562465E823 /* LiveActivityWidget */;
+			targetProxy = C16F2D5B76DBB5642F3614A0 /* PBXContainerItemProxy */;
+		};
 		302D7E37295BEE78005CBB29 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 302D7E30295BEE78005CBB29 /* NotificationServiceExtension */;
@@ -438,6 +539,31 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
+		};
+		272C8EE873213FBBD7CF6B67 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2YC97BQN3N;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = LiveActivityWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.customer.testbed.flutter.spm.LiveActivityWidget;
+				PRODUCT_NAME = LiveActivityWidget;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development io.customer.testbed.flutter.spm.LiveActivityWidget";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
 		};
 		302D7E3A295BEE78005CBB29 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -553,6 +679,52 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Profile;
+		};
+		483EA41652014A26827F1E68 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2YC97BQN3N;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = LiveActivityWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.customer.testbed.flutter.spm.LiveActivityWidget;
+				PRODUCT_NAME = LiveActivityWidget;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development io.customer.testbed.flutter.spm.LiveActivityWidget";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8F752491209B08F831CA9E83 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = LiveActivityWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.customer.testbed.flutter.spm.LiveActivityWidget;
+				PRODUCT_NAME = LiveActivityWidget;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
 		};
@@ -758,23 +930,54 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		EA94B0C8F58A0B4C9311943E /* Build configuration list for PBXNativeTarget "LiveActivityWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				272C8EE873213FBBD7CF6B67 /* Release */,
+				483EA41652014A26827F1E68 /* Debug */,
+				8F752491209B08F831CA9E83 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};
 /* End XCLocalSwiftPackageReference section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		1BE99B10B93B3864502FF8B1 /* XCRemoteSwiftPackageReference "customerio-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/customerio/customerio-ios.git";
+			requirement = {
+				branch = "feat/live-activities";
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FlutterGeneratedPluginSwiftPackage;
 		};
+		8AF62B69DD27659F4B6736FA /* LiveActivities_Templates */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1BE99B10B93B3864502FF8B1 /* XCRemoteSwiftPackageReference "customerio-ios" */;
+			productName = LiveActivities_Templates;
+		};
 		A7F5CCB22F85A5EE00654DD4 /* FlutterGeneratedPluginSwiftPackage */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+		A9A0791B2FB8CCF3498BCB38 /* LiveActivities_Attributes */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1BE99B10B93B3864502FF8B1 /* XCRemoteSwiftPackageReference "customerio-ios" */;
+			productName = LiveActivities_Attributes;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
@@ -954,8 +954,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/customerio/customerio-ios.git";
 			requirement = {
-				branch = "feat/live-activities";
-				kind = branch;
+				kind = exactVersion;
+				version = 4.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/apps/flutter_sample_spm/ios/Runner/AppDelegate.swift
+++ b/apps/flutter_sample_spm/ios/Runner/AppDelegate.swift
@@ -5,6 +5,7 @@ import CioMessagingPushFCM
 import FirebaseMessaging
 import FirebaseCore
 import CioFirebaseWrapper
+import customer_io
 
 @main
 class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
@@ -62,6 +63,14 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
     override func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         super.application(application, continue: userActivity, restorationHandler: restorationHandler)
         return false
+    }
+
+    // A tap arrives here through the normal openURL path; the wrapper forwards the URL to the SDK.
+    // For a Customer.io widget URL this returns the customer's redirect target to route to (nil
+    // when it carries none); any other URL comes back unchanged, so existing deep links still work.
+    override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        guard let routableUrl = CustomerIOLiveActivities.handleWidgetUrl(url) else { return true }
+        return super.application(app, open: routableUrl, options: options)
     }
 }
 

--- a/apps/flutter_sample_spm/ios/Runner/Info.plist
+++ b/apps/flutter_sample_spm/ios/Runner/Info.plist
@@ -102,5 +102,7 @@
 	<string>Required to send push notifications</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app uses your location to test Customer.io location tracking features.</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 </dict>
 </plist>

--- a/apps/flutter_sample_spm/lib/src/app.dart
+++ b/apps/flutter_sample_spm/lib/src/app.dart
@@ -13,6 +13,7 @@ import 'screens/dashboard.dart';
 import 'screens/events.dart';
 import 'screens/inbox_messages.dart';
 import 'screens/inline_messages.dart';
+import 'screens/live_activities.dart';
 import 'screens/location.dart';
 import 'screens/login.dart';
 import 'screens/settings.dart';
@@ -156,6 +157,11 @@ class _AmiAppState extends State<AmiApp> {
               name: Screen.locationTest.name,
               path: Screen.locationTest.path,
               builder: (context, state) => const LocationScreen(),
+            ),
+            GoRoute(
+              name: Screen.liveActivitiesTest.name,
+              path: Screen.liveActivitiesTest.path,
+              builder: (context, state) => const LiveActivitiesScreen(),
             ),
           ],
         ),

--- a/apps/flutter_sample_spm/lib/src/customer_io.dart
+++ b/apps/flutter_sample_spm/lib/src/customer_io.dart
@@ -74,6 +74,13 @@ class CustomerIOSDK extends ChangeNotifier {
           screenViewUse: _sdkConfig?.screenViewUse,
           inAppConfig: inAppConfig,
           locationConfig: LocationConfig(),
+          liveNotificationsConfig: LiveActivitiesConfig(
+            types: [
+              LiveActivityTemplate.segments,
+              LiveActivityTemplate.countdownTimer,
+            ],
+            customType: 'io.customer.livenotifications.custom.rideshare',
+          ),
         ),
       );
     } catch (ex) {

--- a/apps/flutter_sample_spm/lib/src/data/screen.dart
+++ b/apps/flutter_sample_spm/lib/src/data/screen.dart
@@ -13,7 +13,8 @@ enum Screen {
       name: 'Custom Profile Attribute', path: 'attributes/profile'),
   inlineMessages(name: 'Inline Messages Test', path: 'inline-messages'),
   inboxMessages(name: 'Inbox Messages', path: 'inbox-messages'),
-  locationTest(name: 'Location', path: 'location');
+  locationTest(name: 'Location', path: 'location'),
+  liveActivitiesTest(name: 'Live Activities', path: 'live-activities');
 
   const Screen({
     required this.name,

--- a/apps/flutter_sample_spm/lib/src/screens/dashboard.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/dashboard.dart
@@ -312,6 +312,7 @@ enum _ActionItem {
   inlineMessages,
   inboxMessages,
   location,
+  liveActivities,
   showPushPrompt,
   showLocalPush,
   signOut,
@@ -334,6 +335,8 @@ extension _ActionNames on _ActionItem {
         return 'Inbox Messages';
       case _ActionItem.location:
         return 'Test Location';
+      case _ActionItem.liveActivities:
+        return 'Test Live Activities';
       case _ActionItem.showPushPrompt:
         return 'Show Push Prompt';
       case _ActionItem.showLocalPush:
@@ -359,6 +362,8 @@ extension _ActionNames on _ActionItem {
         return 'Inbox Messages Button';
       case _ActionItem.location:
         return 'Location Button';
+      case _ActionItem.liveActivities:
+        return 'Live Activities Button';
       case _ActionItem.showPushPrompt:
         return 'Show Push Prompt Button';
       case _ActionItem.showLocalPush:
@@ -384,6 +389,8 @@ extension _ActionNames on _ActionItem {
         return Screen.inboxMessages;
       case _ActionItem.location:
         return Screen.locationTest;
+      case _ActionItem.liveActivities:
+        return Screen.liveActivitiesTest;
       case _ActionItem.showPushPrompt:
         return null;
       case _ActionItem.showLocalPush:

--- a/apps/flutter_sample_spm/lib/src/screens/live_activities.dart
+++ b/apps/flutter_sample_spm/lib/src/screens/live_activities.dart
@@ -1,0 +1,429 @@
+import 'package:customer_io/customer_io.dart';
+import 'package:flutter/material.dart';
+
+import '../components/container.dart';
+import '../components/scroll_view.dart';
+import '../theme/sizes.dart';
+import '../utils/extensions.dart';
+
+/// Content-state for the custom "rideshare" activity demonstrated here.
+///
+/// One code path on both platforms. The SDK owns the attributes type, so the payload is
+/// just a map of strings: iOS renders it from `CIOCustomAttributes` in the Widget
+/// Extension, Android from the app's `createLiveNotification` callback (registered in
+/// MainActivity). The activity is named by `customType` in the SDK config, not here.
+LiveActivityPayload _rideshare(String status, int etaMinutes) =>
+    LiveActivityPayload.custom(
+      // Values are strings — a bridge payload carries no schema, so the renderer parses
+      // whatever it needs.
+      data: {
+        'driverName': 'Alex',
+        'status': status,
+        'etaMinutes': '$etaMinutes',
+      },
+    );
+
+class LiveActivitiesScreen extends StatefulWidget {
+  const LiveActivitiesScreen({super.key});
+
+  @override
+  State<LiveActivitiesScreen> createState() => _LiveActivitiesScreenState();
+}
+
+class _LiveActivitiesScreenState extends State<LiveActivitiesScreen> {
+  String? _segmentsId;
+  int _segmentsComplete = 1;
+  String? _countdownId;
+  String? _customId;
+  String _statusText = 'No live activity started yet';
+
+  // MARK: - Segments
+
+  Future<void> _startSegments() async {
+    try {
+      final id = await CustomerIO.liveActivities.start(
+        LiveActivityPayload.segments(
+          header: 'Order #1234',
+          status: 'Preparing your order',
+          substatus: 'Kitchen is working on it',
+          segmentsTotal: 4,
+          segmentsComplete: _segmentsComplete,
+          trailingText: 'ETA 20 min',
+        ),
+      );
+      if (!mounted) return;
+      setState(() {
+        _segmentsId = id;
+        _statusText = 'Started segments activity: $id';
+      });
+      context.showSnackBar('Started segments activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  Future<void> _advanceSegments() async {
+    final id = _segmentsId;
+    if (id == null) {
+      context.showSnackBar('Start the segments activity first');
+      return;
+    }
+    final complete = (_segmentsComplete + 1).clamp(0, 4);
+    try {
+      await CustomerIO.liveActivities.update(
+        id,
+        LiveActivityPayload.segments(
+          header: 'Order #1234',
+          status: complete >= 4 ? 'Delivered' : 'Out for delivery',
+          substatus: complete >= 4
+              ? 'Enjoy your order'
+              : 'Your courier is on the way',
+          segmentsTotal: 4,
+          segmentsComplete: complete,
+          trailingText: complete >= 4 ? 'Done' : 'ETA 5 min',
+        ),
+      );
+      if (!mounted) return;
+      setState(() {
+        _segmentsComplete = complete;
+        _statusText = 'Advanced segments activity ($complete/4): $id';
+      });
+      context.showSnackBar('Advanced segments activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  Future<void> _endSegments() async {
+    final id = _segmentsId;
+    if (id == null) {
+      context.showSnackBar('Start the segments activity first');
+      return;
+    }
+    try {
+      // Pass a final content-state so iOS renders a terminal card instead of freezing on the last
+      // progress value. Android ignores it and renders its own terminal state.
+      await CustomerIO.liveActivities.end(
+        id,
+        payload: const LiveActivityPayload.segments(
+          header: 'Order #1234',
+          status: 'Delivered',
+          substatus: 'Enjoy your order',
+          segmentsTotal: 4,
+          segmentsComplete: 4,
+        ),
+      );
+      if (!mounted) return;
+      setState(() {
+        _statusText = 'Ended segments activity: $id';
+        _segmentsId = null;
+        _segmentsComplete = 1;
+      });
+      context.showSnackBar('Ended segments activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  // MARK: - Countdown Timer
+
+  Future<void> _startCountdown() async {
+    try {
+      final endTime =
+          DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/
+              1000;
+      final id = await CustomerIO.liveActivities.start(
+        LiveActivityPayload.countdownTimer(
+          header: 'Flash Sale',
+          title: 'Ends soon!',
+          statusMessage: 'Hurry before it is gone',
+          endTime: endTime,
+        ),
+      );
+      if (!mounted) return;
+      setState(() {
+        _countdownId = id;
+        _statusText = 'Started countdown activity: $id';
+      });
+      context.showSnackBar('Started countdown activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  Future<void> _endCountdown() async {
+    final id = _countdownId;
+    if (id == null) {
+      context.showSnackBar('Start the countdown activity first');
+      return;
+    }
+    try {
+      // Terminal state: drop the endTime so the card reads as finished rather than counting down.
+      await CustomerIO.liveActivities.end(
+        id,
+        payload: const LiveActivityPayload.countdownTimer(
+          header: 'Flash Sale',
+          title: 'Sale ended',
+          statusMessage: 'Thanks for shopping',
+        ),
+      );
+      if (!mounted) return;
+      setState(() {
+        _statusText = 'Ended countdown activity: $id';
+        _countdownId = null;
+      });
+      context.showSnackBar('Ended countdown activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  // MARK: - Custom (Rideshare)
+
+  Future<void> _startCustom() async {
+    try {
+      final id = await CustomerIO.liveActivities.start(
+        _rideshare('On the way', 5),
+      );
+      if (!mounted) return;
+      setState(() {
+        _customId = id;
+        _statusText = 'Started custom rideshare activity: $id';
+      });
+      context.showSnackBar('Started custom rideshare activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  Future<void> _updateCustom() async {
+    final id = _customId;
+    if (id == null) {
+      context.showSnackBar('Start the custom activity first');
+      return;
+    }
+    try {
+      await CustomerIO.liveActivities.update(id, _rideshare('Arriving now', 1));
+      if (!mounted) return;
+      setState(() {
+        _statusText = 'Updated custom rideshare activity: $id';
+      });
+      context.showSnackBar('Updated custom rideshare activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  Future<void> _endCustom() async {
+    final id = _customId;
+    if (id == null) {
+      context.showSnackBar('Start the custom activity first');
+      return;
+    }
+    try {
+      // A final content-state so the card reads as finished rather than freezing mid-trip.
+      await CustomerIO.liveActivities.end(
+        id,
+        payload: _rideshare('Arrived', 0),
+      );
+      if (!mounted) return;
+      setState(() {
+        _statusText = 'Ended custom rideshare activity: $id';
+        _customId = null;
+      });
+      context.showSnackBar('Ended custom rideshare activity');
+    } catch (ex) {
+      _onError(ex);
+    }
+  }
+
+  void _onError(Object ex) {
+    if (!mounted) return;
+    setState(() {
+      _statusText = 'Error: $ex';
+    });
+    context.showSnackBar('Error: $ex');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Sizes sizes = Theme.of(context).extension<Sizes>()!;
+    final theme = Theme.of(context);
+
+    return AppContainer(
+      appBar: AppBar(
+        backgroundColor: null,
+      ),
+      body: FullScreenScrollView(
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 24.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Live Activities Testing',
+                style: theme.textTheme.titleLarge,
+              ),
+              const SizedBox(height: 24),
+              _SectionCard(
+                title: 'Segments',
+                description:
+                    'Built-in segmented progress template. Advance increments the '
+                    'completed segments; End dismisses it.',
+                children: [
+                  _SectionButton(
+                    label: 'Start',
+                    sizes: sizes,
+                    onPressed: _startSegments,
+                  ),
+                  _SectionButton(
+                    label: 'Advance',
+                    sizes: sizes,
+                    onPressed: _advanceSegments,
+                  ),
+                  _SectionButton(
+                    label: 'End',
+                    sizes: sizes,
+                    onPressed: _endSegments,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              _SectionCard(
+                title: 'Countdown Timer',
+                description:
+                    'Built-in countdown template counting down to one hour from '
+                    'now.',
+                children: [
+                  _SectionButton(
+                    label: 'Start',
+                    sizes: sizes,
+                    onPressed: _startCountdown,
+                  ),
+                  _SectionButton(
+                    label: 'End',
+                    sizes: sizes,
+                    onPressed: _endCountdown,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              _SectionCard(
+                title: 'Custom (Rideshare)',
+                description:
+                    'Your own type, started the same way on both platforms. The SDK '
+                    'owns the attributes type; the app supplies the view — a '
+                    'NotificationCompat callback on Android, a Widget Extension on iOS.',
+                children: [
+                  _SectionButton(
+                    label: 'Start',
+                    sizes: sizes,
+                    onPressed: _startCustom,
+                  ),
+                  _SectionButton(
+                    label: 'Update',
+                    sizes: sizes,
+                    onPressed: _updateCustom,
+                  ),
+                  _SectionButton(
+                    label: 'End',
+                    sizes: sizes,
+                    onPressed: _endCustom,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  _statusText,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionButton extends StatelessWidget {
+  final String label;
+  final Sizes sizes;
+  final VoidCallback onPressed;
+
+  const _SectionButton({
+    required this.label,
+    required this.sizes,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: FilledButton(
+        style: FilledButton.styleFrom(
+          minimumSize: sizes.buttonDefault(),
+        ),
+        onPressed: onPressed,
+        child: Text(label),
+      ),
+    );
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  final String title;
+  final String description;
+  final List<Widget> children;
+
+  const _SectionCard({
+    required this.title,
+    required this.description,
+    required this.children,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            description,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 12),
+          ...children,
+        ],
+      ),
+    );
+  }
+}

--- a/apps/flutter_sample_spm/pubspec.lock
+++ b/apps/flutter_sample_spm/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.1.2"
   dbus:
     dependency: transitive
     description:

--- a/apps/shared/android/io/customer/testbed/flutter/MainApplication.kt
+++ b/apps/shared/android/io/customer/testbed/flutter/MainApplication.kt
@@ -1,0 +1,95 @@
+package io.customer.testbed.flutter
+
+import android.app.Application
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import io.customer.customer_io.liveactivities.CustomerIOLiveActivities
+import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+
+/**
+ * Shared by both sample apps (see `sourceSets` in each `android/app/build.gradle`), so both
+ * manifests name it in full: `io.customer.testbed.flutter.MainApplication`. That replaces
+ * Flutter's `${applicationName}` placeholder, which resolves to `android.app.Application` —
+ * the class extended here, so nothing is lost by overriding it.
+ */
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        // Registered here rather than in MainActivity because Android starts a process with no
+        // Activity whenever it delivers a push after the app's process was killed. Application
+        // onCreate runs in every process, an Activity's does not, so this is the only place a
+        // renderer can be registered in time for a pushed live notification.
+        CustomerIOLiveActivities.setLiveNotificationCallback(RideshareLiveNotificationCallback())
+    }
+}
+
+/**
+ * Sample app-owned renderer for the custom `rideshare` live notification type. Custom types have no
+ * built-in SDK template, so the app fully renders them here. Returning null for any other type lets
+ * the SDK fall back to its built-in templates.
+ *
+ * The `data` map Dart sends with `LiveActivityPayload.custom` arrives flattened in
+ * [CustomerIOParsedPushPayload.extras], keyed the same way.
+ */
+private class RideshareLiveNotificationCallback : CustomerIOLiveNotificationsCallback {
+    override fun createLiveNotification(
+        payload: CustomerIOParsedPushPayload,
+        context: Context,
+    ): Notification? {
+        val extras = payload.extras
+        if (extras.getString("notification_type") != RIDESHARE_TYPE) return null
+
+        // The SDK re-invokes this callback on the "end" event. Return a terminal, non-ongoing
+        // notification then so it can be dismissed instead of sticking around forever.
+        val ended = extras.getString("event") == "end"
+
+        val driverName = extras.getString("driverName") ?: "Your driver"
+        val status = extras.getString("status") ?: ""
+        // Every custom value is a string, here and in the pushed content-state; parse what you need.
+        val etaMinutes = extras.getString("etaMinutes")?.toDoubleOrNull()?.toInt()
+
+        // Mirrors the iOS widget's layout: status leads (as the title below), then the driver, then
+        // the ETA. `status` is not repeated here since it is already the title.
+        val body = listOfNotNull(
+            driverName,
+            etaMinutes?.let { "ETA $it min" },
+        ).joinToString(" • ")
+
+        ensureChannel(context)
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(context.applicationInfo.icon)
+            // Title follows `status`, matching the iOS widget's headline. Hardcoding "is on the way"
+            // left Android showing stale copy after an update that changed the status, while the
+            // body below already reflected the new state.
+            .setContentTitle(status.ifEmpty { if (ended) "Arrived" else "Rideshare" })
+            .setContentText(body)
+            .setOngoing(!ended)
+            .setOnlyAlertOnce(true)
+            .build()
+    }
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "Rideshare",
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ),
+            )
+        }
+    }
+
+    private companion object {
+        const val RIDESHARE_TYPE = "io.customer.livenotifications.custom.rideshare"
+        const val CHANNEL_ID = "rideshare_live_notification"
+    }
+}

--- a/customerio-flutter.api
+++ b/customerio-flutter.api
@@ -6,13 +6,36 @@ public final class CioLogLevel {
 	static public val values: List<CioLogLevel>;
 }
 
+public final class CountdownTimerLiveActivityPayload {
+	public fun new(
+		required String header,
+		required String title,
+		String? statusMessage,
+		int? endTime
+	): CountdownTimerLiveActivityPayload;
+	public fun toMap(): Map<String, dynamic>;
+	public val endTime: int?;
+	public val header: String;
+	public val statusMessage: String?;
+	public val title: String;
+	public val type: LiveActivityTemplate;
+}
+
+public final class CustomLiveActivityPayload {
+	public fun new(required Map<String, String> data): CustomLiveActivityPayload;
+	public fun toMap(): Map<String, dynamic>;
+	public val data: Map<String, String>;
+	public val type: LiveActivityTemplate;
+}
+
 public final class CustomerIO {
 	public fun clearIdentify();
 	static public fun createInstance(
 		CustomerIOPlatform? platform,
 		CustomerIOMessagingPushPlatform? pushMessaging,
 		CustomerIOMessagingInAppPlatform? inAppMessaging,
-		CustomerIOLocationPlatform? location
+		CustomerIOLocationPlatform? location,
+		CustomerIOLiveActivitiesPlatform? liveActivities
 	): CustomerIO;
 	public fun deleteDeviceToken();
 	public fun identify(
@@ -39,6 +62,7 @@ public final class CustomerIO {
 	);
 	static public val inAppMessaging: CustomerIOMessagingInAppPlatform;
 	static public val instance: CustomerIO;
+	static public val liveActivities: CustomerIOLiveActivitiesPlatform;
 	static public val location: CustomerIOLocationPlatform;
 	static public val pushMessaging: CustomerIOMessagingPushPlatform;
 }
@@ -58,7 +82,8 @@ public final class CustomerIOConfig {
 		ScreenView? screenViewUse,
 		InAppConfig? inAppConfig,
 		PushConfig? pushConfig,
-		LocationConfig? locationConfig
+		LocationConfig? locationConfig,
+		LiveActivitiesConfig? liveNotificationsConfig
 	): CustomerIOConfig;
 	public fun toMap(): Map<String, dynamic>;
 	public val apiHost: String?;
@@ -68,6 +93,7 @@ public final class CustomerIOConfig {
 	public val flushAt: int?;
 	public val flushInterval: int?;
 	public val inAppConfig: InAppConfig?;
+	public val liveNotificationsConfig: LiveActivitiesConfig?;
 	public val locationConfig: LocationConfig?;
 	public val logLevel: CioLogLevel?;
 	public val migrationSiteId: String?;
@@ -77,6 +103,20 @@ public final class CustomerIOConfig {
 	public val source: String;
 	public val trackApplicationLifecycleEvents: bool?;
 	public val version: String;
+}
+
+public final class CustomerIOLiveActivitiesPlatform {
+	public fun new(): CustomerIOLiveActivitiesPlatform;
+	public fun end(
+		String activityId,
+		LiveActivityPayload? payload
+	): Future<void> async;
+	public fun start(LiveActivityPayload payload): Future<String> async;
+	public fun update(
+		String activityId,
+		LiveActivityPayload payload
+	): Future<void> async;
+	static public var instance: CustomerIOLiveActivitiesPlatform;
 }
 
 public final class CustomerIOLocationPlatform {
@@ -245,6 +285,63 @@ public final class InlineInAppMessageView {
 	public val onActionClick: void Function(InAppMessage, String, String)?;
 }
 
+public final class LiveActivitiesBranding {
+	public fun new(
+		String? companyName,
+		String? accentColorHex,
+		String? logoResource,
+		String? logoUrl,
+		String? smallIconResource
+	): LiveActivitiesBranding;
+	public fun toMap(): Map<String, dynamic>;
+	public val accentColorHex: String?;
+	public val companyName: String?;
+	public val logoResource: String?;
+	public val logoUrl: String?;
+	public val smallIconResource: String?;
+}
+
+public final class LiveActivitiesConfig {
+	public fun new(
+		List<LiveActivityTemplate> types,
+		String? customType,
+		LiveActivitiesBranding? branding
+	): LiveActivitiesConfig;
+	public fun toMap(): Map<String, dynamic>;
+	public val branding: LiveActivitiesBranding?;
+	public val customType: String?;
+	public val types: List<LiveActivityTemplate>;
+}
+
+public final class LiveActivityPayload {
+	public fun countdownTimer(
+		required String header,
+		required String title,
+		String? statusMessage,
+		int? endTime
+	): LiveActivityPayload;
+	public fun custom(required Map<String, String> data): LiveActivityPayload;
+	public fun new(LiveActivityTemplate type): LiveActivityPayload;
+	public fun segments(
+		required String header,
+		required String status,
+		String? substatus,
+		required int segmentsTotal,
+		required int segmentsComplete,
+		String? trailingText
+	): LiveActivityPayload;
+	public fun toMap(): Map<String, dynamic>;
+	public val type: LiveActivityTemplate;
+}
+
+public final class LiveActivityTemplate {
+	static public val countdownTimer: LiveActivityTemplate;
+	static public val custom: LiveActivityTemplate;
+	public val rawValue: String;
+	static public val segments: LiveActivityTemplate;
+	static public val values: List<LiveActivityTemplate>;
+}
+
 public final class LocationConfig {
 	public fun new(LocationTrackingMode trackingMode): LocationConfig;
 	public fun toMap(): Map<String, dynamic>;
@@ -309,6 +406,25 @@ public final class ScreenView {
 	static public val all: ScreenView;
 	static public val inApp: ScreenView;
 	static public val values: List<ScreenView>;
+}
+
+public final class SegmentsLiveActivityPayload {
+	public fun new(
+		required String header,
+		required String status,
+		String? substatus,
+		required int segmentsTotal,
+		required int segmentsComplete,
+		String? trailingText
+	): SegmentsLiveActivityPayload;
+	public fun toMap(): Map<String, dynamic>;
+	public val header: String;
+	public val segmentsComplete: int;
+	public val segmentsTotal: int;
+	public val status: String;
+	public val substatus: String?;
+	public val trailingText: String?;
+	public val type: LiveActivityTemplate;
 }
 
 

--- a/ios/customer_io.podspec
+++ b/ios/customer_io.podspec
@@ -47,6 +47,16 @@ Pod::Spec.new do |s|
     ss.dependency "CustomerIO/Location", native_sdk_version
   end
 
+  # Live Activities are optional - customers must opt in by adding this subspec. Kept out of the
+  # parent spec on purpose: the Templates pod ships SwiftUI widget UI, which is dead weight for the
+  # majority of apps that never run a Live Activity. The plugin's Swift is guarded by
+  # `#if canImport(CioLiveActivities)`, so it compiles to no-ops when this subspec is absent.
+  # NOTE: requires native_sdk_version to include Live Activities (>= the LA release).
+  s.subspec 'liveactivities' do |ss|
+    ss.dependency "CustomerIO/LiveActivities", native_sdk_version
+    ss.dependency "CustomerIO/LiveActivitiesTemplates", native_sdk_version
+  end
+
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -118,7 +118,7 @@ let package = Package(
         .library(name: "customer-io", targets: ["customer_io"])
     ],
     dependencies: [
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.6.1"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.7.0"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -3,16 +3,18 @@
 import PackageDescription
 import Foundation
 
-// MARK: - Location Module Configuration
+// MARK: - Optional Module Configuration
 //
-// The Location module is optional and excluded by default.
-// To enable it, use ONE of these approaches (checked in this order):
+// The Location and Live Activities modules are optional and excluded by default.
+// To enable one, use ONE of these approaches (checked in this order):
 //
 // 1. Set in your Flutter app's android/gradle.properties (recommended, works for both platforms):
 //      customerio_location_enabled=true
+//      customerio_live_activities_enabled=true
 //
 // 2. Set an environment variable (required for Flutter add-to-app modules or custom project structures):
 //      CIO_LOCATION=true flutter build ios
+//      CIO_LIVE_ACTIVITIES=true flutter build ios
 //
 
 /// Reads a value for the given key from a Java-style .properties file.
@@ -52,28 +54,37 @@ func readGradleProperty(_ key: String, from startDir: String) -> String? {
     return nil
 }
 
-/// Determines whether the Location module should be included.
+/// Determines whether an optional module should be included.
 /// Checks gradle.properties first (file-based, persistent), then falls back to environment variable.
-/// Returns false if no configuration is found (Location is opt-in).
-let useLocation: Bool = {
+/// Returns false if no configuration is found — every module using this is opt-in.
+func isModuleEnabled(propertyKey: String, envKey: String) -> Bool {
     let env = ProcessInfo.processInfo.environment
-    let key = "customerio_location_enabled"
 
     // 1. Try gradle.properties via PWD (preserves symlink path in Flutter's SPM structure).
     if let pwd = env["PWD"],
-       let value = readGradleProperty(key, from: pwd) {
+       let value = readGradleProperty(propertyKey, from: pwd) {
         return value.lowercased() == "true"
     }
 
     // 2. Try gradle.properties via FileManager cwd (resolves symlinks; works for direct CLI usage).
     let cwd = FileManager.default.currentDirectoryPath
-    if let value = readGradleProperty(key, from: cwd) {
+    if let value = readGradleProperty(propertyKey, from: cwd) {
         return value.lowercased() == "true"
     }
 
     // 3. Fallback: environment variable (required for add-to-app modules and custom project layouts).
-    return env["CIO_LOCATION"]?.lowercased() == "true"
-}()
+    return env[envKey]?.lowercased() == "true"
+}
+
+let useLocation = isModuleEnabled(
+    propertyKey: "customerio_location_enabled",
+    envKey: "CIO_LOCATION"
+)
+
+let useLiveActivities = isModuleEnabled(
+    propertyKey: "customerio_live_activities_enabled",
+    envKey: "CIO_LIVE_ACTIVITIES"
+)
 
 var targetDependencies: [Target.Dependency] = [
     .product(name: "DataPipelines", package: "customerio-ios"),
@@ -86,6 +97,18 @@ if useLocation {
     targetDependencies.append(.product(name: "Location", package: "customerio-ios"))
 }
 
+// Live Activities (iOS) native rendering + built-in templates. Opt-in: the Templates product ships
+// SwiftUI widget UI that is dead weight for apps which never run a Live Activity. The plugin's Swift
+// is guarded by `#if canImport(CioLiveActivities)`, so it compiles to no-ops when this is off.
+// NOTE: requires the customerio-ios pin below to include Live Activities (>= the LA release).
+if useLiveActivities {
+    targetDependencies.append(contentsOf: [
+        .product(name: "LiveActivities", package: "customerio-ios"),
+        .product(name: "LiveActivities_Attributes", package: "customerio-ios"),
+        .product(name: "LiveActivities_Templates", package: "customerio-ios")
+    ])
+}
+
 let package = Package(
     name: "customer_io",
     platforms: [
@@ -95,7 +118,9 @@ let package = Package(
         .library(name: "customer-io", targets: ["customer_io"])
     ],
     dependencies: [
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.5.3"),
+        // TEMPORARY (REL-1): Live Activities products only exist on this branch. Restore an
+        // exact released version once they ship.
+        .package(url: "https://github.com/customerio/customerio-ios.git", branch: "feat/live-activities"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -14,6 +14,7 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
     private var locationChannelHandler: CustomerIOLocation!
     #endif
     private var messagingPushChannelHandler: CustomerIOMessagingPush!
+    private var liveActivitiesChannelHandler: CustomerIOLiveActivities!
 
     private let logger: CioInternalCommon.Logger = DIGraphShared.shared.logger
 
@@ -28,6 +29,7 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
         instance.locationChannelHandler = CustomerIOLocation(with: registrar)
         #endif
         instance.messagingPushChannelHandler = CustomerIOMessagingPush(with: registrar)
+        instance.liveActivitiesChannelHandler = CustomerIOLiveActivities(with: registrar)
     }
 
     deinit {
@@ -180,6 +182,15 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
                     mode = .manual
                 }
                 _ = sdkConfigBuilder.addModule(LocationModule(config: LocationConfig(mode: mode)))
+            }
+            #endif
+
+            #if canImport(CioLiveActivities)
+            // Register Live Activities from the `liveNotifications` config (iOS 16.2+). Adding it
+            // to the config builder — rather than initializing after the fact — is what enables
+            // push-to-start, since token registration happens during SDK init.
+            if let liveActivitiesModule = CustomerIOLiveActivities.module(from: params) {
+                _ = sdkConfigBuilder.addModule(liveActivitiesModule)
             }
             #endif
 

--- a/ios/customer_io/Sources/customer_io/LiveActivities/CustomerIOLiveActivities.swift
+++ b/ios/customer_io/Sources/customer_io/LiveActivities/CustomerIOLiveActivities.swift
@@ -1,0 +1,400 @@
+import CioDataPipelines
+import CioInternalCommon
+import Flutter
+import Foundation
+#if canImport(CioLiveActivities)
+import ActivityKit
+import CioLiveActivities
+import CioLiveActivities_Attributes
+import CioLiveActivities_Templates
+#endif
+
+/// Flutter plugin sub-handler for Live Activities.
+///
+/// Gated on `canImport(CioLiveActivities)` and iOS 16.2+. Custom activity types work from Dart
+/// through the SDK-owned `CIOCustomAttributes`: ActivityKit needs a concrete Swift type to register
+/// an activity and observe its push-to-start token, and a metatype can't cross a method channel, so
+/// the SDK owns the type and Dart supplies its values.
+public class CustomerIOLiveActivities: NSObject, FlutterPlugin {
+    private var methodChannel: FlutterMethodChannel?
+
+    #if canImport(CioLiveActivities)
+    /// Reverse-DNS activity type identifiers for the SDK's built-in templates. These are the same
+    /// strings the backend sends as `notificationType` and that Android's `LiveNotificationType`
+    /// exposes, so Dart, both native SDKs, and the wire format share one vocabulary.
+    enum TypeIdentifier {
+        static let segments = "io.customer.livenotifications.segments"
+        static let countdownTimer = "io.customer.livenotifications.countdowntimer"
+        /// Discriminator Dart sends for the custom template. Not a wire identifier — the activity is
+        /// reported under the app's own `liveNotifications.customType`.
+        static let custom = "custom"
+    }
+
+    /// Type-erased handles keyed by activity id. The native `start` returns a generic
+    /// `CIOLiveActivity<Attributes>` that can't be stored in a homogeneous map, so we keep closures
+    /// that capture the concrete handle and rebuild its content-state from a Dart map on update.
+    private struct ActivityBox {
+        let update: ([String: Any]) async throws -> Void
+        let end: ([String: Any]?) async throws -> Void
+    }
+
+    private var activities: [String: ActivityBox] = [:]
+    private let lock = NSLock()
+
+    /// Records an `update`/`end` aimed at an activity this process never started. Not surfaced to
+    /// Dart — see the call sites — but worth a log, because the same message covers both a genuine
+    /// caller mistake and the expected post-restart / push-started cases.
+    private static func logUnknownActivity(_ activityId: String, method: String) {
+        DIGraphShared.shared.logger.info(
+            "Live Activities: \(method) ignored — no activity with id \(activityId) was started by this app session. " +
+                "Activities started before an app restart, or started by a push, are not tracked in-process."
+        )
+    }
+    #endif
+
+    public static func register(with _: FlutterPluginRegistrar) {}
+
+    /// Reports an `opened` metric for a tapped Live Activity and returns the deep link to route to.
+    /// Call this from the app's `openURL` entry point so a Live Activity tap is attributed.
+    ///
+    /// - Returns: the customer's redirect URL for a Customer.io widget URL (`nil` when it carries
+    ///   none), or `url` unchanged when it isn't a Customer.io URL — so existing routing still
+    ///   handles non-CIO links.
+    #if canImport(CioLiveActivities)
+    @discardableResult
+    public static func handleWidgetUrl(_ url: URL) -> URL? {
+        CustomerIO.liveActivities.handleWidgetUrl(url)
+    }
+    #else
+    public static func handleWidgetUrl(_ url: URL) -> URL? { url }
+    #endif
+
+    init(with registrar: FlutterPluginRegistrar) {
+        super.init()
+
+        let channel = FlutterMethodChannel(name: "customer_io_live_activities", binaryMessenger: registrar.messenger())
+        methodChannel = channel
+        registrar.addMethodCallDelegate(self, channel: channel)
+    }
+
+    deinit {
+        methodChannel?.setMethodCallHandler(nil)
+        methodChannel = nil
+    }
+
+    #if canImport(CioLiveActivities)
+    /// Build the Live Activities module from the SDK config's `liveNotifications` key, for
+    /// registration on the SDK config builder at init. Registers the enabled built-in template
+    /// attribute types so `CustomerIO.liveActivities.start` can request them, and so push-to-start
+    /// tokens register for them at SDK init.
+    ///
+    /// Unrecognized type identifiers are ignored: a newer native SDK may ship templates this
+    /// wrapper build doesn't know, and that must never break registration of the ones it does.
+    static func module(from params: [String: AnyHashable]) -> LiveActivitiesModule? {
+        guard let liveConfig = params["liveNotifications"] as? [String: AnyHashable] else { return nil }
+        guard #available(iOS 16.2, *) else { return nil }
+        let types = (liveConfig["types"] as? [String]) ?? []
+        var builder = LiveActivityConfigBuilder()
+        for type in types {
+            switch type {
+            case TypeIdentifier.segments:
+                builder = builder.register(CIOSegmentsAttributes.self)
+            case TypeIdentifier.countdownTimer:
+                builder = builder.register(CIOCountdownTimerAttributes.self)
+            default:
+                continue
+            }
+        }
+        // The custom template registers one SDK-owned Swift type under the app's own identifier.
+        // That indirection is what lets a Dart app have a custom activity at all: the SDK needs a
+        // metatype to register and to observe push-to-start for, and a metatype can't cross a
+        // method channel.
+        //
+        // Nothing is cached from this: `start` learns that a custom activity isn't registered from
+        // the nil handle the SDK returns, which stays correct if the type was registered elsewhere.
+        if let customType = (liveConfig["customType"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !customType.isEmpty {
+            builder = builder.register(CIOCustomAttributes.self, identifier: customType)
+        }
+        return LiveActivitiesModule(config: builder.build())
+    }
+    #endif
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let args = call.arguments as? [String: Any] ?? [:]
+        switch call.method {
+        case "start":
+            start(args, result: result)
+
+        case "update":
+            update(args, result: result)
+
+        case "end":
+            end(args, result: result)
+
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    // MARK: - Bridge methods
+
+    private func start(_ args: [String: Any], result: @escaping FlutterResult) {
+        #if canImport(CioLiveActivities)
+        guard #available(iOS 16.2, *) else {
+            return result(Self.unavailableError())
+        }
+        guard let map = args["payload"] as? [String: Any], let type = map["type"] as? String else {
+            return result(FlutterError(code: "live_activity_start_failed", message: "payload.type is required", details: nil))
+        }
+        do {
+            // A nil handle means the module isn't registered or this type wasn't enabled. The
+            // native SDK logs and returns nil rather than throwing, so surface it as a
+            // FlutterError — never a crash.
+            let id: String
+            switch type {
+            case TypeIdentifier.segments:
+                guard let handle = try CustomerIO.liveActivities.start(
+                    CIOSegmentsAttributes(header: try Self.requireString(map, "header")),
+                    contentState: try Self.segmentsState(from: map)
+                ) else {
+                    return result(Self.notRegisteredError(type))
+                }
+                store(handle: handle, contentBuilder: Self.segmentsState)
+                id = handle.id
+            case TypeIdentifier.countdownTimer:
+                guard let handle = try CustomerIO.liveActivities.start(
+                    CIOCountdownTimerAttributes(header: try Self.requireString(map, "header")),
+                    contentState: try Self.countdownState(from: map)
+                ) else {
+                    return result(Self.notRegisteredError(type))
+                }
+                store(handle: handle, contentBuilder: Self.countdownState)
+                id = handle.id
+            case TypeIdentifier.custom:
+                // No pre-check on the configured identifier: an unregistered type already comes back
+                // as a nil handle, and that path is correct however the SDK was initialized — a
+                // check against wrapper-captured config would refuse a type registered elsewhere.
+                guard let handle = try CustomerIO.liveActivities.start(
+                    CIOCustomAttributes(),
+                    contentState: try Self.customState(from: map)
+                ) else {
+                    return result(Self.customNotRegisteredError())
+                }
+                store(handle: handle, contentBuilder: Self.customState)
+                id = handle.id
+            default:
+                // A newer native SDK may know this type even though this wrapper build doesn't.
+                // Fail softly so an unrecognized template can never crash the host app.
+                return result(FlutterError(
+                    code: "live_activity_type_unsupported",
+                    message: "Unsupported Live Activity template: \(type)",
+                    details: nil
+                ))
+            }
+            result(id)
+        } catch {
+            result(FlutterError(code: "live_activity_start_failed", message: error.localizedDescription, details: nil))
+        }
+        #else
+        result(Self.unavailableError())
+        #endif
+    }
+
+    private func update(_ args: [String: Any], result: @escaping FlutterResult) {
+        #if canImport(CioLiveActivities)
+        guard let activityId = args["activityId"] as? String else {
+            return result(FlutterError(code: "live_activity_update_failed", message: "activityId is required", details: nil))
+        }
+        lock.lock()
+        let box = activities[activityId]
+        lock.unlock()
+        // An unknown id means the update did not happen, so it must not report success. Unlike `end`
+        // — where re-ending an already-ended activity is a legitimate no-op — there is nothing
+        // idempotent about an update that never applied. Android *does* perform it (it routes the id
+        // straight to the native SDK), so resolving here would make the same call report success on
+        // both platforms while only one of them did anything.
+        guard let box = box else {
+            Self.logUnknownActivity(activityId, method: "update")
+            return result(FlutterError(
+                code: "live_activity_update_failed",
+                message: "No live activity found for id \(activityId). On iOS only activities started " +
+                    "in this app session can be updated.",
+                details: nil
+            ))
+        }
+        guard let map = args["payload"] as? [String: Any] else {
+            return result(FlutterError(code: "live_activity_update_failed", message: "payload is required", details: nil))
+        }
+        Task {
+            do {
+                try await box.update(map)
+                // FlutterResult must be invoked on the platform (main) thread; the Task
+                // resumes off-main after the await, so hop back before replying.
+                await MainActor.run { result(true) }
+            } catch {
+                await MainActor.run {
+                    result(FlutterError(code: "live_activity_update_failed", message: error.localizedDescription, details: nil))
+                }
+            }
+        }
+        #else
+        result(Self.unavailableError())
+        #endif
+    }
+
+    private func end(_ args: [String: Any], result: @escaping FlutterResult) {
+        #if canImport(CioLiveActivities)
+        guard let activityId = args["activityId"] as? String else {
+            return result(FlutterError(code: "live_activity_end_failed", message: "activityId is required", details: nil))
+        }
+        lock.lock()
+        let box = activities[activityId]
+        lock.unlock()
+        // Unknown/already-ended id is treated as success (idempotent end). See `update` for why an
+        // unknown id is not an error.
+        guard let box = box else {
+            Self.logUnknownActivity(activityId, method: "end")
+            return result(true)
+        }
+        let map = args["payload"] as? [String: Any]
+        Task {
+            // FlutterResult must be invoked on the platform (main) thread; the Task
+            // resumes off-main after the await, so hop back before replying.
+            do {
+                try await box.end(map)
+                // Dropped only once the end succeeded. Removing up front would lose the handle on a
+                // throw, and the retry would then take the unknown-id path above and report success
+                // for an activity still on screen.
+                self.forget(activityId)
+                await MainActor.run { result(true) }
+            } catch {
+                await MainActor.run {
+                    result(FlutterError(code: "live_activity_end_failed", message: error.localizedDescription, details: nil))
+                }
+            }
+        }
+        #else
+        result(Self.unavailableError())
+        #endif
+    }
+
+    // MARK: - Helpers
+
+    #if canImport(CioLiveActivities)
+    @available(iOS 16.2, *)
+    private func store<A: ActivityAttributes>(
+        handle: CIOLiveActivity<A>,
+        contentBuilder: @escaping ([String: Any]) throws -> A.ContentState
+    ) {
+        let box = ActivityBox(
+            // ActivityKit keeps the last content-state on screen when `end` is given none, so a
+            // final payload is what lets the activity show a terminal state rather than freezing
+            // mid-progress.
+            update: { map in await handle.update(try contentBuilder(map)) },
+            end: { map in await handle.end(try map.map(contentBuilder)) }
+        )
+        lock.lock()
+        activities[handle.id] = box
+        lock.unlock()
+    }
+
+    private func forget(_ activityId: String) {
+        lock.lock()
+        activities.removeValue(forKey: activityId)
+        lock.unlock()
+    }
+
+    /// Thrown for a missing required field so the caller sees an error naming it, rather than an
+    /// activity rendering with a blank line. Matches Android, whose `requireString` / `requireInt`
+    /// already throw — the same call must not produce a silent half-rendered card on one platform
+    /// and an error on the other.
+    private struct MissingFieldError: LocalizedError {
+        let field: String
+        var errorDescription: String? { "\(field) is required" }
+    }
+
+    private static func requireString(_ map: [String: Any], _ key: String) throws -> String {
+        guard let value = map[key] as? String else { throw MissingFieldError(field: key) }
+        return value
+    }
+
+    private static func requireInt(_ map: [String: Any], _ key: String) throws -> Int {
+        guard let value = map[key] as? NSNumber else { throw MissingFieldError(field: key) }
+        return value.intValue
+    }
+
+    @available(iOS 16.2, *)
+    private static func segmentsState(from map: [String: Any]) throws -> CIOSegmentsAttributes.ContentState {
+        CIOSegmentsAttributes.ContentState(
+            status: try requireString(map, "status"),
+            substatus: map["substatus"] as? String,
+            segmentsTotal: try requireInt(map, "segmentsTotal"),
+            segmentsComplete: try requireInt(map, "segmentsComplete"),
+            trailingText: map["trailingText"] as? String
+        )
+    }
+
+    @available(iOS 16.2, *)
+    private static func countdownState(from map: [String: Any]) throws -> CIOCountdownTimerAttributes.ContentState {
+        var endTime: EpochSecondsDate?
+        if let seconds = map["endTime"] as? NSNumber {
+            endTime = EpochSecondsDate(Date(timeIntervalSince1970: seconds.doubleValue))
+        }
+        return CIOCountdownTimerAttributes.ContentState(
+            title: try requireString(map, "title"),
+            statusMessage: map["statusMessage"] as? String,
+            endTime: endTime
+        )
+    }
+
+    /// Builds the custom template's content-state from the payload's `data` map.
+    ///
+    /// Values are coerced to strings rather than rejected: a Dart `int`/`double`/`bool` arrives as
+    /// `NSNumber`, and refusing them would make `{'eta': 5}` fail for no reason a caller can see.
+    /// Anything without a sensible text form is dropped instead of stringifying as gibberish.
+    @available(iOS 16.2, *)
+    private static func customState(from map: [String: Any]) throws -> CIOCustomAttributes.ContentState {
+        let raw = map["data"] as? [String: Any] ?? [:]
+        var data: [String: String] = [:]
+        for (key, value) in raw {
+            switch value {
+            case let string as String: data[key] = string
+            case let number as NSNumber: data[key] = number.stringValue
+            default: continue
+            }
+        }
+        return CIOCustomAttributes.ContentState(data: data)
+    }
+    #endif
+
+    private static func unavailableError() -> FlutterError {
+        FlutterError(
+            code: "live_activity_module_unavailable",
+            message: "Live Activities require iOS 16.2 or later.",
+            details: nil
+        )
+    }
+
+    private static func notRegisteredError(_ type: String) -> FlutterError {
+        FlutterError(
+            code: "live_activity_type_not_registered",
+            message: "Live Activity type '\(type)' is not registered. Add it to `liveNotifications.types` " +
+                "in your Customer.io SDK config, and make sure your widget extension renders it.",
+            details: nil
+        )
+    }
+
+    /// The custom template's version of [notRegisteredError]: `type` is only the discriminator, so
+    /// naming it would tell the caller nothing about what to fix.
+    private static func customNotRegisteredError() -> FlutterError {
+        FlutterError(
+            code: "live_activity_type_not_registered",
+            message: "No custom Live Activity type is registered. Set `liveNotifications.customType` " +
+                "in your Customer.io SDK config to your own reverse-DNS identifier, and render " +
+                "CIOCustomAttributes in your Widget Extension.",
+            details: nil
+        )
+    }
+}

--- a/lib/config/customer_io_config.dart
+++ b/lib/config/customer_io_config.dart
@@ -1,6 +1,7 @@
 import '../customer_io_enums.dart';
 import '../customer_io_plugin_version.dart' as plugin_info show version;
 import 'in_app_config.dart';
+import 'live_activities_config.dart';
 import 'location_config.dart';
 import 'push_config.dart';
 
@@ -22,6 +23,7 @@ class CustomerIOConfig {
   final InAppConfig? inAppConfig;
   final PushConfig pushConfig;
   final LocationConfig? locationConfig;
+  final LiveActivitiesConfig? liveNotificationsConfig;
 
   CustomerIOConfig({
     required this.cdpApiKey,
@@ -38,6 +40,7 @@ class CustomerIOConfig {
     this.inAppConfig,
     PushConfig? pushConfig,
     this.locationConfig,
+    this.liveNotificationsConfig,
   }) : pushConfig = pushConfig ?? PushConfig();
 
   Map<String, dynamic> toMap() {
@@ -56,6 +59,7 @@ class CustomerIOConfig {
       'inApp': inAppConfig?.toMap(),
       'push': pushConfig.toMap(),
       'location': locationConfig?.toMap(),
+      'liveNotifications': liveNotificationsConfig?.toMap(),
       'version': version,
       'source': source
     };

--- a/lib/config/live_activities_config.dart
+++ b/lib/config/live_activities_config.dart
@@ -1,0 +1,86 @@
+import '../customer_io_enums.dart';
+
+/// Branding applied to Live Notifications on Android.
+///
+/// This is Android-only; on iOS the Live Activity appearance is defined by the
+/// app's Widget Extension and these values are ignored.
+class LiveActivitiesBranding {
+  /// Company/brand name shown on the notification.
+  final String? companyName;
+
+  /// Accent color as a `#RRGGBB` hex string.
+  final String? accentColorHex;
+
+  /// Name of a bundled drawable resource used as the logo.
+  ///
+  /// Preferred over [logoUrl] when both are set — it renders without a network
+  /// round-trip, so the logo is present on the very first frame.
+  final String? logoResource;
+
+  /// Remote URL for a logo asset.
+  final String? logoUrl;
+
+  /// Name of a drawable resource used as the small icon.
+  final String? smallIconResource;
+
+  LiveActivitiesBranding({
+    this.companyName,
+    this.accentColorHex,
+    this.logoResource,
+    this.logoUrl,
+    this.smallIconResource,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'companyName': companyName,
+      'accentColorHex': accentColorHex,
+      'logoResource': logoResource,
+      'logoUrl': logoUrl,
+      'smallIconResource': smallIconResource,
+    };
+  }
+}
+
+/// Configuration for the Live Activities (iOS) / Live Notifications (Android) module.
+class LiveActivitiesConfig {
+  /// Built-in activity types to enable.
+  ///
+  /// Unrecognized identifiers are ignored, so a newer native template can't
+  /// break an older wrapper build.
+  ///
+  /// Do not list [LiveActivityTemplate.custom] here — it is enabled by [customType],
+  /// and both platforms drop it from this list.
+  final List<LiveActivityTemplate> types;
+
+  /// Your own reverse-DNS identifier for the custom activity type, e.g.
+  /// `'com.myapp.rideshare'`. Setting it enables the custom template on both platforms.
+  ///
+  /// Start one with `LiveActivityPayload.custom(data: {...})`; the SDK reports it under
+  /// this identifier and your campaigns target it by the same name.
+  ///
+  /// Singular by design: iOS resolves an activity's type from its Swift attributes type,
+  /// and every custom activity shares one. A second identifier could not be told apart,
+  /// so one is the limit rather than a silent mis-attribution.
+  ///
+  /// You must also render it yourself — `CIOCustomAttributes` in an iOS Widget Extension,
+  /// and the `createLiveNotification` callback on Android.
+  final String? customType;
+
+  /// Branding for Live Notifications (Android only).
+  final LiveActivitiesBranding? branding;
+
+  LiveActivitiesConfig({
+    this.types = const [],
+    this.customType,
+    this.branding,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'types': types.map((type) => type.rawValue).toList(),
+      'customType': customType,
+      'branding': branding?.toMap(),
+    };
+  }
+}

--- a/lib/customer_io.dart
+++ b/lib/customer_io.dart
@@ -7,9 +7,13 @@ import 'customer_io_config.dart';
 import 'customer_io_enums.dart';
 import 'data_pipelines/customer_io_platform_interface.dart';
 import 'extensions/map_extensions.dart';
+import 'liveActivities/platform_interface.dart';
 import 'location/platform_interface.dart';
 import 'messaging_in_app/platform_interface.dart';
 import 'messaging_push/platform_interface.dart';
+
+export 'liveActivities/live_activity_payload.dart';
+export 'liveActivities/platform_interface.dart';
 
 class CustomerIO {
   static CustomerIO? _instance;
@@ -18,6 +22,7 @@ class CustomerIO {
   final CustomerIOMessagingPushPlatform _pushMessaging;
   final CustomerIOMessagingInAppPlatform _inAppMessaging;
   final CustomerIOLocationPlatform _location;
+  final CustomerIOLiveActivitiesPlatform _liveActivities;
 
   /// Private constructor to enforce singleton pattern
   CustomerIO._({
@@ -25,12 +30,15 @@ class CustomerIO {
     CustomerIOMessagingPushPlatform? pushMessaging,
     CustomerIOMessagingInAppPlatform? inAppMessaging,
     CustomerIOLocationPlatform? location,
+    CustomerIOLiveActivitiesPlatform? liveActivities,
   })  : _platform = platform ?? CustomerIOPlatform.instance,
         _pushMessaging =
             pushMessaging ?? CustomerIOMessagingPushPlatform.instance,
         _inAppMessaging =
             inAppMessaging ?? CustomerIOMessagingInAppPlatform.instance,
-        _location = location ?? CustomerIOLocationPlatform.instance;
+        _location = location ?? CustomerIOLocationPlatform.instance,
+        _liveActivities =
+            liveActivities ?? CustomerIOLiveActivitiesPlatform.instance;
 
   /// Get the singleton instance of CustomerIO
   static CustomerIO get instance {
@@ -50,12 +58,14 @@ class CustomerIO {
     CustomerIOMessagingPushPlatform? pushMessaging,
     CustomerIOMessagingInAppPlatform? inAppMessaging,
     CustomerIOLocationPlatform? location,
+    CustomerIOLiveActivitiesPlatform? liveActivities,
   }) {
     _instance = CustomerIO._(
       platform: platform,
       pushMessaging: pushMessaging,
       inAppMessaging: inAppMessaging,
       location: location,
+      liveActivities: liveActivities,
     );
     return _instance!;
   }
@@ -80,6 +90,12 @@ class CustomerIO {
   /// Access location functionality
   static CustomerIOLocationPlatform get location {
     return _instance?._location ?? CustomerIOLocationPlatform.instance;
+  }
+
+  /// Access Live Activities (iOS) / Live Notifications (Android) functionality
+  static CustomerIOLiveActivitiesPlatform get liveActivities {
+    return _instance?._liveActivities ??
+        CustomerIOLiveActivitiesPlatform.instance;
   }
 
   /// To initialize the plugin

--- a/lib/customer_io_config.dart
+++ b/lib/customer_io_config.dart
@@ -1,4 +1,5 @@
 export 'config/customer_io_config.dart';
 export 'config/in_app_config.dart';
+export 'config/live_activities_config.dart';
 export 'config/location_config.dart';
 export 'config/push_config.dart';

--- a/lib/customer_io_enums.dart
+++ b/lib/customer_io_enums.dart
@@ -41,6 +41,33 @@ enum PushClickBehaviorAndroid {
 /// inApp - to only display in-app messages and not send screen events to destinations.
 enum ScreenView { all, inApp }
 
+/// Built-in Live Activity (iOS) / Live Notification (Android) templates.
+///
+/// The raw values are the reverse-DNS identifiers Customer.io uses everywhere —
+/// the `notificationType` on the wire, Android's `LiveNotificationType`, and
+/// iOS's `CIOSegmentsAttributes.identifier` — so Dart, both native SDKs, and the
+/// backend share one vocabulary. They are also the `type` inside
+/// [LiveActivityPayload] maps.
+enum LiveActivityTemplate {
+  /// Segmented progress template (header, status, substatus, segment counts).
+  segments(rawValue: 'io.customer.livenotifications.segments'),
+
+  /// Countdown timer template (header, title, status message, end time).
+  countdownTimer(rawValue: 'io.customer.livenotifications.countdowntimer'),
+
+  /// Your own activity type, rendered by SwiftUI you write (iOS) and your
+  /// `createLiveNotification` callback (Android).
+  ///
+  /// Unlike the members above this raw value is a marker, not an identifier — the
+  /// activity is named by `LiveActivitiesConfig.customType` and reported under that
+  /// name. It belongs in a payload's type, never in `LiveActivitiesConfig.types`.
+  custom(rawValue: 'custom');
+
+  const LiveActivityTemplate({required this.rawValue});
+
+  final String rawValue;
+}
+
 /// Location tracking mode for the CustomerIO Location module.
 enum LocationTrackingMode {
   /// Location tracking is disabled. All location operations no-op.

--- a/lib/liveActivities/_native_constants.dart
+++ b/lib/liveActivities/_native_constants.dart
@@ -1,0 +1,13 @@
+/// Methods specific to the Live Activities module.
+class NativeMethods {
+  static const String start = "start";
+  static const String update = "update";
+  static const String end = "end";
+}
+
+/// Method parameters specific to the Live Activities module.
+class NativeMethodParams {
+  static const String activityId = "activityId";
+  static const String payload = "payload";
+  static const String url = "url";
+}

--- a/lib/liveActivities/live_activity_payload.dart
+++ b/lib/liveActivities/live_activity_payload.dart
@@ -1,0 +1,147 @@
+import '../customer_io_enums.dart';
+
+/// Payload describing the full desired state of a Live Activity (iOS) /
+/// Live Notification (Android).
+///
+/// ActivityKit replaces the content-state wholesale on every update, so callers
+/// must always pass the complete desired state to both
+/// [CustomerIOLiveActivitiesPlatform.start] and
+/// [CustomerIOLiveActivitiesPlatform.update].
+///
+/// The field names are identical across both platforms and map directly to the
+/// native template attributes.
+abstract class LiveActivityPayload {
+  /// The built-in template this payload targets.
+  final LiveActivityTemplate type;
+
+  const LiveActivityPayload(this.type);
+
+  /// Serializes the payload into a flat map understood by the native handlers.
+  Map<String, dynamic> toMap();
+
+  /// Creates a payload for the [LiveActivityTemplate.segments] template.
+  const factory LiveActivityPayload.segments({
+    required String header,
+    required String status,
+    String? substatus,
+    required int segmentsTotal,
+    required int segmentsComplete,
+    String? trailingText,
+  }) = SegmentsLiveActivityPayload;
+
+  /// Creates a payload for the [LiveActivityTemplate.countdownTimer] template.
+  const factory LiveActivityPayload.countdownTimer({
+    required String header,
+    required String title,
+    String? statusMessage,
+    int? endTime,
+  }) = CountdownTimerLiveActivityPayload;
+
+  /// Creates a payload for your own activity type, named by
+  /// `LiveActivitiesConfig.customType`.
+  const factory LiveActivityPayload.custom({
+    required Map<String, String> data,
+  }) = CustomLiveActivityPayload;
+}
+
+/// Payload for the segmented progress template.
+class SegmentsLiveActivityPayload extends LiveActivityPayload {
+  /// Static, non-changing header shown on the activity (an attribute, not state).
+  final String header;
+
+  /// Primary status line.
+  final String status;
+
+  /// Optional secondary status line.
+  final String? substatus;
+
+  /// Total number of segments.
+  final int segmentsTotal;
+
+  /// Number of segments completed so far.
+  final int segmentsComplete;
+
+  /// Optional trailing text (e.g. an ETA or count).
+  final String? trailingText;
+
+  const SegmentsLiveActivityPayload({
+    required this.header,
+    required this.status,
+    this.substatus,
+    required this.segmentsTotal,
+    required this.segmentsComplete,
+    this.trailingText,
+  }) : super(LiveActivityTemplate.segments);
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'type': type.rawValue,
+      'header': header,
+      'status': status,
+      'substatus': substatus,
+      'segmentsTotal': segmentsTotal,
+      'segmentsComplete': segmentsComplete,
+      'trailingText': trailingText,
+    };
+  }
+}
+
+/// Payload for the countdown timer template.
+class CountdownTimerLiveActivityPayload extends LiveActivityPayload {
+  /// Static, non-changing header shown on the activity (an attribute, not state).
+  final String header;
+
+  /// Primary title line.
+  final String title;
+
+  /// Optional status message.
+  final String? statusMessage;
+
+  /// End time as epoch **seconds**. When null, no countdown is rendered.
+  final int? endTime;
+
+  const CountdownTimerLiveActivityPayload({
+    required this.header,
+    required this.title,
+    this.statusMessage,
+    this.endTime,
+  }) : super(LiveActivityTemplate.countdownTimer);
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'type': type.rawValue,
+      'header': header,
+      'title': title,
+      'statusMessage': statusMessage,
+      'endTime': endTime,
+    };
+  }
+}
+
+/// Payload for your own activity type.
+///
+/// Unlike the built-in templates there is no schema: the SDK owns the iOS attributes
+/// type (`CIOCustomAttributes`) and carries these values through untouched, so you
+/// render them yourself. Requires `LiveActivitiesConfig.customType` to be set.
+class CustomLiveActivityPayload extends LiveActivityPayload {
+  /// The full content-state, re-sent in its entirety on every update — neither
+  /// platform keeps a static/dynamic split for custom types.
+  ///
+  /// Values must be strings. Nested objects and arrays are unsupported and the
+  /// platforms disagree on them (iOS drops them, Android stringifies them), so
+  /// flatten anything structured before sending it.
+  final Map<String, String> data;
+
+  const CustomLiveActivityPayload({required this.data})
+      : super(LiveActivityTemplate.custom);
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'type': type.rawValue,
+      'data': data,
+    };
+  }
+}

--- a/lib/liveActivities/method_channel.dart
+++ b/lib/liveActivities/method_channel.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/services.dart';
+
+import '_native_constants.dart';
+import 'live_activity_payload.dart';
+import 'platform_interface.dart';
+
+/// An implementation of [CustomerIOLiveActivitiesPlatform] that uses method channels.
+class CustomerIOLiveActivitiesMethodChannel
+    extends CustomerIOLiveActivitiesPlatform {
+  final MethodChannel methodChannel =
+      const MethodChannel('customer_io_live_activities');
+
+  @override
+  Future<String> start(LiveActivityPayload payload) async {
+    try {
+      final result = await methodChannel.invokeMethod<String>(
+        NativeMethods.start,
+        {NativeMethodParams.payload: payload.toMap()},
+      );
+      // A null id means the platform reported success without starting anything. Returning '' would
+      // hand back an id that looks usable and only fails later, on an update or end that silently
+      // matches nothing — fail here instead, where the cause is still visible.
+      return result ?? (throw _noActivityId(NativeMethods.start));
+    } on MissingPluginException {
+      throw _notEnabled();
+    }
+  }
+
+  @override
+  Future<void> update(String activityId, LiveActivityPayload payload) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        NativeMethods.update,
+        {
+          NativeMethodParams.activityId: activityId,
+          NativeMethodParams.payload: payload.toMap(),
+        },
+      );
+    } on MissingPluginException {
+      throw _notEnabled();
+    }
+  }
+
+  @override
+  Future<void> end(String activityId, {LiveActivityPayload? payload}) async {
+    try {
+      await methodChannel.invokeMethod<void>(
+        NativeMethods.end,
+        {
+          NativeMethodParams.activityId: activityId,
+          if (payload != null) NativeMethodParams.payload: payload.toMap(),
+        },
+      );
+    } on MissingPluginException {
+      throw _notEnabled();
+    }
+  }
+
+  StateError _noActivityId(String method) => StateError(
+        'Customer.io: Live Activity `$method` returned no activity id. The '
+        'activity was not started, so there is nothing to update or end.',
+      );
+
+  StateError _notEnabled() => StateError(
+        'Customer.io: Live Activities module is not enabled. Enable activity '
+        'types in the SDK config (liveNotifications.types) before using this '
+        'feature.',
+      );
+}

--- a/lib/liveActivities/platform_interface.dart
+++ b/lib/liveActivities/platform_interface.dart
@@ -1,0 +1,48 @@
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import 'live_activity_payload.dart';
+import 'method_channel.dart';
+
+/// The interface that implementations of the Live Activities module must implement.
+///
+/// Live Activities (iOS) / Live Notifications (Android) are exposed here. There is
+/// intentionally no lifecycle event listener/stream, as neither native SDK exposes one.
+abstract class CustomerIOLiveActivitiesPlatform extends PlatformInterface {
+  CustomerIOLiveActivitiesPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static CustomerIOLiveActivitiesPlatform _instance =
+      CustomerIOLiveActivitiesMethodChannel();
+
+  static CustomerIOLiveActivitiesPlatform get instance => _instance;
+
+  static set instance(CustomerIOLiveActivitiesPlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  /// Starts a Live Activity and returns its activity id.
+  ///
+  /// [payload] selects the template: a built-in one, or your own type named by
+  /// `LiveActivitiesConfig.customType` via [LiveActivityPayload.custom].
+  Future<String> start(LiveActivityPayload payload) {
+    throw UnimplementedError('start() has not been implemented.');
+  }
+
+  /// Updates a running Live Activity with the full desired state.
+  ///
+  /// ActivityKit replaces content-state wholesale, so [payload] must contain the
+  /// complete desired state, not a partial diff.
+  ///
+  /// On iOS this fails for an id this app session didn't start: the handle needed to
+  /// update an activity is process-local, so the update genuinely did not happen.
+  Future<void> update(String activityId, LiveActivityPayload payload) {
+    throw UnimplementedError('update() has not been implemented.');
+  }
+
+  /// Ends a running Live Activity. Ending an unknown/already-ended id is a no-op.
+  Future<void> end(String activityId, {LiveActivityPayload? payload}) {
+    throw UnimplementedError('end() has not been implemented.');
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.6.1
+        native_sdk_version: 4.7.0
         firebase_wrapper_version: 1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.5.3
+        native_sdk_version: 4.6.1
         firebase_wrapper_version: 1.0.0

--- a/test/customer_io_config_test.dart
+++ b/test/customer_io_config_test.dart
@@ -1,5 +1,6 @@
 import 'package:customer_io/config/customer_io_config.dart';
 import 'package:customer_io/config/in_app_config.dart';
+import 'package:customer_io/config/live_activities_config.dart';
 import 'package:customer_io/config/push_config.dart';
 import 'package:customer_io/customer_io_enums.dart';
 import 'package:customer_io/customer_io_plugin_version.dart' as plugin_info;
@@ -110,6 +111,7 @@ void main() {
         'inApp': inAppConfig.toMap(),
         'push': pushConfig.toMap(),
         'location': null,
+        'liveNotifications': null,
         'version': config.version,
         'source': config.source,
       };
@@ -168,6 +170,71 @@ void main() {
       final expectedMap = {'siteId': 'testSiteId'};
 
       expect(inAppConfig.toMap(), expectedMap);
+    });
+  });
+
+  group('LiveActivitiesConfig', () {
+    test('should default to empty types and null customType/branding', () {
+      final config = LiveActivitiesConfig();
+
+      expect(config.types, isEmpty);
+      expect(config.customType, isNull);
+      expect(config.branding, isNull);
+
+      final map = config.toMap();
+      expect(map['types'], isEmpty);
+      expect(map['customType'], isNull);
+      expect(map['branding'], isNull);
+    });
+
+    test('should serialize types to their reverse-DNS identifiers', () {
+      final config = LiveActivitiesConfig(
+        types: [
+          LiveActivityTemplate.segments,
+          LiveActivityTemplate.countdownTimer,
+        ],
+        customType: 'com.example.rideshare',
+      );
+
+      final map = config.toMap();
+      expect(map['types'], [
+        'io.customer.livenotifications.segments',
+        'io.customer.livenotifications.countdowntimer',
+      ]);
+      expect(map['customType'], 'com.example.rideshare');
+    });
+
+    test('should serialize branding fields', () {
+      final config = LiveActivitiesConfig(
+        types: [LiveActivityTemplate.segments],
+        branding: LiveActivitiesBranding(
+          companyName: 'Acme',
+          accentColorHex: '#FF0000',
+          logoUrl: 'https://example.com/logo.png',
+          smallIconResource: 'ic_notification',
+        ),
+      );
+
+      final branding = config.toMap()['branding'] as Map;
+      expect(branding['companyName'], 'Acme');
+      expect(branding['accentColorHex'], '#FF0000');
+      expect(branding['logoUrl'], 'https://example.com/logo.png');
+      expect(branding['smallIconResource'], 'ic_notification');
+    });
+
+    test('CustomerIOConfig includes liveNotifications in toMap()', () {
+      final config = CustomerIOConfig(
+        cdpApiKey: 'testApiKey',
+        liveNotificationsConfig: LiveActivitiesConfig(
+          types: [LiveActivityTemplate.countdownTimer],
+        ),
+      );
+
+      final map = config.toMap();
+      expect(map['liveNotifications'], isNotNull);
+      expect((map['liveNotifications'] as Map)['types'], [
+        'io.customer.livenotifications.countdowntimer',
+      ]);
     });
   });
 

--- a/test/liveActivities/method_channel_test.dart
+++ b/test/liveActivities/method_channel_test.dart
@@ -1,0 +1,247 @@
+import 'package:customer_io/customer_io.dart';
+import 'package:customer_io/liveActivities/method_channel.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Verifies the Live Activities method channel invokes the correct native
+/// method names with the expected argument shapes.
+void main() {
+  const MethodChannel channel = MethodChannel('customer_io_live_activities');
+  final Map<String, dynamic> methodInvocations = {};
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    methodInvocations.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      methodInvocations[methodCall.method] = methodCall.arguments;
+      switch (methodCall.method) {
+        case 'start':
+          return 'activity-123';
+        case 'update':
+        case 'end':
+          return null;
+        default:
+          throw MissingPluginException();
+      }
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('start() sends segments payload and returns the activity id', () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    final id = await platform.start(
+      const LiveActivityPayload.segments(
+        header: 'Order',
+        status: 'Preparing',
+        substatus: 'In kitchen',
+        segmentsTotal: 4,
+        segmentsComplete: 1,
+        trailingText: 'ETA 20 min',
+      ),
+    );
+
+    expect(id, 'activity-123');
+    expect(methodInvocations.containsKey('start'), isTrue);
+    final args = methodInvocations['start'] as Map;
+    final payload = args['payload'] as Map;
+    expect(payload['type'], 'io.customer.livenotifications.segments');
+    expect(payload['header'], 'Order');
+    expect(payload['status'], 'Preparing');
+    expect(payload['substatus'], 'In kitchen');
+    expect(payload['segmentsTotal'], 4);
+    expect(payload['segmentsComplete'], 1);
+    expect(payload['trailingText'], 'ETA 20 min');
+  });
+
+  test('start() sends countdownTimer payload with epoch-seconds endTime',
+      () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    await platform.start(
+      const LiveActivityPayload.countdownTimer(
+        header: 'Sale',
+        title: 'Ends soon',
+        statusMessage: 'Hurry',
+        endTime: 1893456000,
+      ),
+    );
+
+    final args = methodInvocations['start'] as Map;
+    final payload = args['payload'] as Map;
+    expect(payload['type'], 'io.customer.livenotifications.countdowntimer');
+    expect(payload['header'], 'Sale');
+    expect(payload['title'], 'Ends soon');
+    expect(payload['statusMessage'], 'Hurry');
+    expect(payload['endTime'], 1893456000);
+  });
+
+  test('update() sends activityId and full payload', () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    await platform.update(
+      'activity-123',
+      const LiveActivityPayload.segments(
+        header: 'Order',
+        status: 'Out for delivery',
+        segmentsTotal: 4,
+        segmentsComplete: 3,
+      ),
+    );
+
+    final args = methodInvocations['update'] as Map;
+    expect(args['activityId'], 'activity-123');
+    final payload = args['payload'] as Map;
+    expect(payload['type'], 'io.customer.livenotifications.segments');
+    expect(payload['status'], 'Out for delivery');
+    expect(payload['segmentsComplete'], 3);
+    expect(payload['substatus'], isNull);
+  });
+
+  test('end() sends the activityId', () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    await platform.end('activity-123');
+
+    final args = methodInvocations['end'] as Map;
+    expect(args['activityId'], 'activity-123');
+  });
+
+  /// The custom template goes through the same `start` as the built-ins. `type` carries the
+  /// discriminator, not the app's identifier — the native side names the activity from the
+  /// configured `customType`, so the payload never repeats it.
+  test('start() sends a custom payload and returns the activity id', () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    final id = await platform.start(
+      const LiveActivityPayload.custom(
+        data: {'driverName': 'Alex', 'status': 'On the way', 'etaMinutes': '5'},
+      ),
+    );
+
+    expect(id, 'activity-123');
+    final args = methodInvocations['start'] as Map;
+    final payload = args['payload'] as Map;
+    expect(payload['type'], 'custom');
+    final data = payload['data'] as Map;
+    expect(data['driverName'], 'Alex');
+    expect(data['status'], 'On the way');
+    expect(data['etaMinutes'], '5');
+  });
+
+  test('update() sends a custom payload for the same activity id', () async {
+    final platform = CustomerIOLiveActivitiesMethodChannel();
+
+    await platform.update(
+      'activity-123',
+      const LiveActivityPayload.custom(data: {'status': 'Arriving now'}),
+    );
+
+    final args = methodInvocations['update'] as Map;
+    expect(args['activityId'], 'activity-123');
+    final payload = args['payload'] as Map;
+    expect(payload['type'], 'custom');
+    expect((payload['data'] as Map)['status'], 'Arriving now');
+  });
+
+  group('resilience', () {
+    /// A newer native SDK can reject a template this wrapper build doesn't know
+    /// about. That must surface as a catchable error, never an uncaught crash.
+    test('start() propagates an unsupported-type native error', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        throw PlatformException(
+          code: 'live_activity_type_unsupported',
+          message: 'Unsupported Live Activity template: io.example.unknown',
+        );
+      });
+      final platform = CustomerIOLiveActivitiesMethodChannel();
+
+      await expectLater(
+        platform.start(
+          const LiveActivityPayload.segments(
+            header: 'Order #123',
+            status: 'Preparing',
+            segmentsTotal: 4,
+            segmentsComplete: 1,
+          ),
+        ),
+        throwsA(
+          isA<PlatformException>().having(
+            (e) => e.code,
+            'code',
+            'live_activity_type_unsupported',
+          ),
+        ),
+      );
+    });
+
+    /// The module may not be registered (type not enabled in the SDK config).
+    /// The native side replies with an error rather than crashing.
+    test('start() propagates a type-not-registered native error', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        throw PlatformException(code: 'live_activity_type_not_registered');
+      });
+      final platform = CustomerIOLiveActivitiesMethodChannel();
+
+      await expectLater(
+        platform.start(
+          const LiveActivityPayload.countdownTimer(
+            header: 'Sale',
+            title: 'Ends soon',
+          ),
+        ),
+        throwsA(isA<PlatformException>()),
+      );
+    });
+
+    /// A missing native side (module not built in) is reported as a clear
+    /// StateError instead of leaking MissingPluginException.
+    test('start() reports a disabled module as a StateError', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        throw MissingPluginException();
+      });
+      final platform = CustomerIOLiveActivitiesMethodChannel();
+
+      await expectLater(
+        platform.start(
+          const LiveActivityPayload.segments(
+            header: 'Order #123',
+            status: 'Preparing',
+            segmentsTotal: 4,
+            segmentsComplete: 1,
+          ),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    /// A null id means nothing was started. Failing here surfaces the cause; returning '' would hand
+    /// back an id that only fails later, on an update or end that silently matches nothing.
+    test('start() throws when native returns a null id', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async => null);
+      final platform = CustomerIOLiveActivitiesMethodChannel();
+
+      expect(
+        () => platform.start(
+          const LiveActivityPayload.segments(
+            header: 'Order #123',
+            status: 'Preparing',
+            segmentsTotal: 4,
+            segmentsComplete: 1,
+          ),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Enable Live Notifications feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-platform surface (push config merge, method channels, optional native modules) with behavioral differences on iOS update vs end; misconfiguration can yield silent no-ops or missed attribution without the documented AppDelegate hook.
> 
> **Overview**
> Adds **Live Activities (iOS)** and **Live Notifications (Android)** to the Flutter plugin so apps can start, update, and end activities from Dart with shared template payloads.
> 
> **Dart API:** `LiveActivitiesConfig` / `liveNotificationsConfig` on `CustomerIOConfig`, `CustomerIO.liveActivities`, and `LiveActivityPayload` for segments, countdown timer, and custom types. Native SDKs bump to **4.7.0** (iOS) and **4.20.0** (Android), with optional opt-in (`liveactivities` pod / `customerio_live_activities_enabled`).
> 
> **Native bridges:** Android routes live notification config through the FCM push module and exposes `customer_io_live_activities`; iOS registers `LiveActivitiesModule` at init and documents `CustomerIOLiveActivities.handleWidgetUrl` for tap attribution. Both platforms align `live_activity_type_not_registered` and validate enabled types before start.
> 
> **Samples & docs:** CocoaPods and SPM sample apps gain Widget extensions, rideshare custom UI, shared `MainApplication` for Android custom notification rendering, and README setup (plist, AppDelegate URL forwarding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7cc9ab2529f72a2945508f51cb772ee2d47096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->