### PR TITLE
ci: move iOS sample-app build to macos-26 and fix the ignored Xcode pin

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -9,9 +9,6 @@ concurrency: # cancel previous workflow run if one exists.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  XCODE_VERSION: "26.2"
-
 jobs:
   update-pr-comment:
     if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/reusable-build-sample-apps.yml
+++ b/.github/workflows/reusable-build-sample-apps.yml
@@ -227,7 +227,7 @@ jobs:
     defaults:
       run:
         working-directory: apps/${{ inputs.sample_app_name }}
-    runs-on: macos-15
+    runs-on: macos-26
     outputs:
       APP_VERSION_NAME: ${{ steps.set_output.outputs.APP_VERSION_NAME }}
       APP_VERSION_CODE: ${{ steps.set_output.outputs.APP_VERSION_CODE }}
@@ -360,10 +360,12 @@ jobs:
       - name: Install Flutter dependencies for app
         run: flutter pub get
 
+      # No xcode-version here on purpose: the action pins the fleet-wide default
+      # (26.6). This previously passed ${{ env.XCODE_VERSION }}, which was defined
+      # only in the calling workflow — env does not cross a workflow_call boundary,
+      # so it arrived empty and setup-xcode silently resolved `latest` instead.
       - name: Setup iOS environment for sample app
-        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
-        with:
-          xcode-version: ${{ env.XCODE_VERSION }}
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
 
       - name: Cache CocoaPods downloaded dependencies for faster builds in the future
         if: ${{ inputs.sample_app_name != 'flutter_sample_spm' }}

--- a/.github/workflows/reusable-build-sample-apps.yml
+++ b/.github/workflows/reusable-build-sample-apps.yml
@@ -365,7 +365,7 @@ jobs:
       # only in the calling workflow — env does not cross a workflow_call boundary,
       # so it arrived empty and setup-xcode silently resolved `latest` instead.
       - name: Setup iOS environment for sample app
-        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
 
       - name: Cache CocoaPods downloaded dependencies for faster builds in the future
         if: ${{ inputs.sample_app_name != 'flutter_sample_spm' }}


### PR DESCRIPTION
> ✅ **Unblocked.** [mobile-ci-tools#13](https://github.com/customerio/mobile-ci-tools/pull/13) is merged and the `setup-ios` ref here now points at `@main`, so nothing depends on the transitional `macos-26` branch.

[MBL-2224: Migrate iOS CI to `macos-26` + Xcode 26.6, and stop downloading simulator runtimes we already have](https://linear.app/customerio/issue/MBL-2224/migrate-ios-ci-to-macos-26-xcode-266-and-stop-downloading-simulator)

---

This repo carries the fleet's largest share of a fleet-wide waste: roughly 212 minutes of macOS runner time a week downloading a simulator runtime that is not on the image and that these jobs never use, since they build device archives.

It also pinned an Xcode version that never took effect, because the value was defined in the calling workflow and does not cross a reusable-workflow boundary. The pin silently resolved to "whatever is latest" instead, which is what caused the download in the first place.

Moves the macOS runner from 15 to 26, and makes the Xcode version an explicit, actually-applied pin.