### PR TITLE
chore: update Customer.io iOS SDK to 4.7.1

### DIFF
--- a/.github/workflows/auto-update-native-sdks.yml
+++ b/.github/workflows/auto-update-native-sdks.yml
@@ -183,7 +183,10 @@ jobs:
             sed -i "s/native_sdk_version: .*/native_sdk_version: $IOS_VERSION/" pubspec.yaml
             # Keep Package.swift in sync with pubspec.yaml native_sdk_version
             sed -i "s/\.package(url: \"https:\/\/github.com\/customerio\/customerio-ios.git\", exact: \".*\"/.package(url: \"https:\/\/github.com\/customerio\/customerio-ios.git\", exact: \"$IOS_VERSION\"/" ios/customer_io/Package.swift
-            echo "✅ iOS version updated in pubspec.yaml and Package.swift"
+            # Keep both sample apps' Live Activities widget pods in sync with native_sdk_version
+            sed -i "s/pod cio_pod, '.*'/pod cio_pod, '$IOS_VERSION'/" apps/flutter_sample_cocoapods/ios/Podfile
+            sed -i -E "s/^([[:space:]]*)version = [0-9]+\.[0-9]+\.[0-9]+;/\1version = $IOS_VERSION;/" apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
+            echo "✅ iOS version updated in pubspec.yaml, Package.swift, and both sample apps"
           fi
           
           # Update Android version if needed  

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     // Version can be overridden for local/CI verification via -PcioVersion=<version>
     // (e.g. -PcioVersion=local to build against a mavenLocal build). The committed default
     // tracks the intended published release.
-    def cioVersion = rootProject.findProperty("cioVersion") ?: "4.20.0"
+    def cioVersion = rootProject.findProperty("cioVersion") ?: "4.20.1"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/apps/flutter_sample_cocoapods/ios/Podfile
+++ b/apps/flutter_sample_cocoapods/ios/Podfile
@@ -71,7 +71,7 @@ target 'LiveActivityWidget' do
   # A widget extension cannot link the Flutter plugin pod, so it names the rendering pods itself.
   # Keep the version in step with pubspec.yaml's native_sdk_version.
   %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
-    pod cio_pod, '4.7.1'
+    pod cio_pod, '4.7.2'
   end
 end
 

--- a/apps/flutter_sample_cocoapods/ios/Podfile
+++ b/apps/flutter_sample_cocoapods/ios/Podfile
@@ -71,7 +71,7 @@ target 'LiveActivityWidget' do
   # A widget extension cannot link the Flutter plugin pod, so it names the rendering pods itself.
   # Keep the version in step with pubspec.yaml's native_sdk_version.
   %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
-    pod cio_pod, '4.7.0'
+    pod cio_pod, '4.7.1'
   end
 end
 

--- a/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
@@ -955,7 +955,7 @@
 			repositoryURL = "https://github.com/customerio/customerio-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 4.7.0;
+				version = 4.7.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
@@ -955,7 +955,7 @@
 			repositoryURL = "https://github.com/customerio/customerio-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 4.7.1;
+				version = 4.7.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -139,7 +139,7 @@ let package = Package(
     dependencies: [
         // Pinned exactly, matching `native_sdk_version` in pubspec.yaml and the podspec, so one
         // plugin version always resolves one native SDK across every package manager.
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.7.1"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.7.2"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -139,7 +139,7 @@ let package = Package(
     dependencies: [
         // Pinned exactly, matching `native_sdk_version` in pubspec.yaml and the podspec, so one
         // plugin version always resolves one native SDK across every package manager.
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.7.0"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.7.1"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.7.1
+        native_sdk_version: 4.7.2
         firebase_wrapper_version: 1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.7.0
+        native_sdk_version: 4.7.1
         firebase_wrapper_version: 1.0.0


### PR DESCRIPTION
Bumps the pinned native iOS SDK from 4.7.0 to 4.7.1 across every place a version is declared, so CocoaPods and SPM resolve the same native SDK.

- `pubspec.yaml` `native_sdk_version` (drives both podspecs)
- `ios/customer_io/Package.swift` (SPM)
- `apps/flutter_sample_cocoapods/ios/Podfile` (sample, CocoaPods variant)
- `apps/flutter_sample_spm/ios/Runner.xcodeproj` (sample, SPM variant)

The two sample-app pins belong to the Live Activities widget extension, which cannot link the plugin pod and so names the rendering pods itself. They were added after `auto-update-native-sdks.yml` was written, so the automation never moved them — this PR also teaches that workflow about both.

Android stays at 4.20.0, already the latest release.

> [!NOTE]
> The umbrella `CustomerIO` pod is still publishing 4.7.1 to CocoaPods trunk (the 4.7.1 deploy tagged the release but its CocoaPods job failed part-way; all 12 sub-pods are at 4.7.1, the umbrella spec is not yet). CocoaPods checks will fail until it lands, then need a re-run. SPM is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and CI workflow changes only; no runtime logic or security-sensitive code paths.
> 
> **Overview**
> **Bumps pinned native Customer.io SDK versions** so CocoaPods, SPM, Gradle, and the sample apps resolve the same releases.
> 
> **iOS (4.7.0 → 4.7.2):** Updates `native_sdk_version` in `pubspec.yaml`, the exact pin in `ios/customer_io/Package.swift`, Live Activities pods in `apps/flutter_sample_cocoapods/ios/Podfile`, and the SPM exact version in `apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj`.
> 
> **Android (4.20.0 → 4.20.1):** Updates the default `cioVersion` in `android/build.gradle`.
> 
> **Automation:** Extends `auto-update-native-sdks.yml` so future iOS bumps also rewrite the CocoaPods Live Activity widget pod versions and the SPM sample’s `version = …` line—paths that were missing from the workflow before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bd7c94c0fee9eb9a877e389ce8d4d5d4162dd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->