### PR TITLE
feat!: require iOS 15 (MBL-1773)

### DIFF
--- a/ios/customer_io.podspec
+++ b/ios/customer_io.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source      = { :path => '.' }
   s.source_files = 'customer_io/Sources/customer_io/**/*.swift'
   s.dependency 'Flutter'
-  s.platform = :ios, '13.0'
+  s.platform = :ios, '15.0'
 
   # Native SDK dependencies that are required for the Flutter plugin to work.
   s.dependency "CustomerIO/DataPipelines", native_sdk_version

--- a/ios/customer_io_richpush.podspec
+++ b/ios/customer_io_richpush.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.source      = { :path => '.' }
   s.source_files = 'customer_io/Sources/customer_io/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '13.0'
+  s.platform = :ios, '15.0'
 
   # Careful when declaring dependencies here. All dependencies will be included in the App Extension target in Xcode, not the host iOS app.
   # s.dependency "X", "X"

--- a/test/ios_deployment_target_manifest_test.dart
+++ b/test/ios_deployment_target_manifest_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('owned iOS manifests declare the iOS 15 deployment target', () {
+    const expectedManifestMarkers = <String, String>{
+      'ios/customer_io.podspec': "s.platform = :ios, '15.0'",
+      'ios/customer_io/Package.swift': '.iOS("15.0")',
+      'ios/customer_io_richpush.podspec': "s.platform = :ios, '15.0'",
+    };
+
+    final discoveredManifests = Directory('ios')
+        .listSync(recursive: true, followLinks: false)
+        .whereType<File>()
+        .map((file) => file.path.replaceAll('\\', '/'))
+        .where(
+          (path) =>
+              !path.contains('/Flutter/ephemeral/') &&
+              !path.contains('/.build/') &&
+              !path.contains('/.swiftpm/') &&
+              !path.contains('/Pods/') &&
+              !path.contains('/.symlinks/') &&
+              (path.endsWith('/Package.swift') || path.endsWith('.podspec')),
+        )
+        .toSet();
+
+    expect(discoveredManifests, expectedManifestMarkers.keys.toSet());
+
+    for (final entry in expectedManifestMarkers.entries) {
+      expect(
+        File(entry.key).readAsStringSync(),
+        contains(entry.value),
+        reason: 'Expected ${entry.key} to declare the iOS 15 deployment target',
+      );
+    }
+  });
+}


### PR DESCRIPTION
## What changed

- raise both published Flutter CocoaPods artifacts to iOS 15
- retain the existing iOS 15 SwiftPM manifest
- add a focused manifest-policy test covering all published iOS package surfaces

## Validation

- Flutter 3.41.6 focused manifest test passed
- CocoaPods sample simulator build passed
- SwiftPM sample simulator build passed
- podspec and Package.swift declarations were independently parsed
- Fable exact-diff review and independent root verification completed

## Release boundary

This is a breaking iOS package contract and must ship only in the coordinated major release owned by MBL-2235. It does not normalize lower transitive generated Pods targets; MBL-2278 owns that separate consumer-build fix and hosted Xcode 27 proof.

Linear: https://linear.app/customerio/issue/MBL-1773/support-xcode-27-decide-and-validate-the-minimum-ios-deployment-target