### PR TITLE
ci: normalize CocoaPods sample targets for Xcode 27 (MBL-2278)

### DIFF
--- a/.github/workflows/reusable-build-sample-apps.yml
+++ b/.github/workflows/reusable-build-sample-apps.yml
@@ -380,6 +380,15 @@ jobs:
         if: ${{ inputs.sample_app_name != 'flutter_sample_spm' }}
         run: pod install --project-directory=ios
 
+      - name: Audit CocoaPods deployment targets
+        if: ${{ inputs.sample_app_name == 'flutter_sample_cocoapods' }}
+        run: |
+          bundle exec ruby ../../scripts/test_cocoapods_deployment_target.rb
+          bundle exec ruby ../../scripts/audit_cocoapods_deployment_targets.rb \
+            --minimum 15.0 \
+            ios/Pods \
+            ios/Runner.xcodeproj
+
       - name: Build and upload iOS app via Fastlane
         if: ${{ inputs.should_distribute }}
         id: ios_build

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This is the official Customer.io Flutter plugin.
 
 You'll find our complete [SDK documentation here](https://customer.io/docs/sdk/flutter/). 
 
+If a CocoaPods build reports that a generated dependency target is below the deployment range
+supported by Xcode, follow the [deployment-target normalization guide](docs/cocoapods-deployment-target-normalization.md).
+
 # Live Activities
 
 Enable the activity types you use via `liveNotificationsConfig` in your `CustomerIOConfig`. On iOS, Live Activities are opt-in: add the `liveactivities` pod subspec (CocoaPods) or set `customerio_live_activities_enabled=true` in `android/gradle.properties` (Swift Package Manager), plus a Widget Extension that renders the SDK's built-in templates.

--- a/apps/flutter_sample_cocoapods/Gemfile
+++ b/apps/flutter_sample_cocoapods/Gemfile
@@ -16,6 +16,7 @@ gem 'multi_json', '< 1.20'
 
 gem 'fastlane'
 gem 'cocoapods'
+gem 'minitest', '~> 5.25'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/apps/flutter_sample_cocoapods/Gemfile.lock
+++ b/apps/flutter_sample_cocoapods/Gemfile.lock
@@ -346,6 +346,7 @@ DEPENDENCIES
   fastlane-plugin-versioning_android
   fastlane-plugin-versioning_ios
   json (= 2.10.2)
+  minitest (~> 5.25)
   multi_json (< 1.20)
   rexml (= 3.4.2)
 

--- a/apps/flutter_sample_cocoapods/ios/Podfile
+++ b/apps/flutter_sample_cocoapods/ios/Podfile
@@ -75,6 +75,11 @@ target 'LiveActivityWidget' do
   end
 end
 
+require File.expand_path(
+  File.join('.symlinks', 'plugins', 'customer_io', 'ios', 'cocoapods_deployment_target'),
+  __dir__
+)
+
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
@@ -90,4 +95,9 @@ post_install do |installer|
       ]
     end
   end
+
+  CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+    installer,
+    minimum_ios_version: '15.0'
+  )
 end

--- a/docs/cocoapods-deployment-target-normalization.md
+++ b/docs/cocoapods-deployment-target-normalization.md
@@ -91,8 +91,9 @@ the helper so a later dependency update cannot silently reintroduce a lower targ
 
 For a deterministic CI audit, use the script from this repository with the installed CocoaPods
 Ruby environment. Its stable report includes the target, matching project, and effective value.
-Pass the `Pods` directory so the audit recursively discovers every `.xcodeproj`, including
-CocoaPods multi-project output. It fails if a supplied path is missing or contains no projects. The
+Pass the `Pods` directory so the audit discovers every `.xcodeproj` directly under it, including
+CocoaPods multi-project output, while ignoring unrelated example projects vendored inside
+downloaded pod sources. It fails if a supplied path is missing or contains no projects. The
 audit examines every target in each passed project, including non-integrated targets that the
 normalizer intentionally does not change; set those targets to the host minimum explicitly.
 

--- a/docs/cocoapods-deployment-target-normalization.md
+++ b/docs/cocoapods-deployment-target-normalization.md
@@ -12,6 +12,17 @@ configuration, preserving a higher inherited app or extension floor. It changes 
 settings in the generated Pods project and CocoaPods-integrated Runner or extension projects. It
 does not rewrite a podspec or change runtime API availability.
 
+Customer.io deliberately continues to publish native SDKs that support iOS versions below 15. A
+podspec can therefore correctly declare that lower library minimum even when the Flutter
+application consuming it has moved to iOS 15 or later. CocoaPods carries deployment metadata from
+Customer.io and third-party podspecs into generated build targets, but Xcode 27 no longer accepts
+targets below the iOS SDK's supported build range. Raising every published podspec to iOS 15 would
+unnecessarily drop older applications and would not control metadata from transitive
+dependencies. The helper instead aligns the generated targets with the host application's chosen
+minimum while leaving the packages' published runtime compatibility unchanged.
+This is the supported integration policy for a Flutter application that has moved its own minimum
+to iOS 15 or later.
+
 > [!WARNING]
 > This is an opt-in build migration. Integrated Runner and extension targets below iOS 15.0 are
 > raised to 15.0. Shipping that project means users on iOS 13 or iOS 14 cannot install subsequent
@@ -60,13 +71,19 @@ Synchronized-group xcconfig references are not resolved by that public parser; i
 reports one, replace it with a standard xcconfig file reference, then run `pod install` again.
 These cases fail before any project mutation.
 
-## Remove the helper
+## When the helper is no longer needed
 
-Treat the helper as a temporary compatibility layer. Remove it only when a clean install without
-the helper proves that every target/configuration in every supported resolved dependency graph
-declares an effective numeric deployment target at or above the host application's minimum. Check
-each supported Flutter plugin and push-provider graph, and keep the audit in CI when removing the
-helper so a later dependency update cannot silently reintroduce a lower target.
+Keep the helper while a supported dependency graph can validly include deployment metadata below
+the host application's minimum. This is expected while Customer.io supports older iOS versions or
+supported third-party pods continue to declare lower minimums. A `platform` declaration in the
+application's Podfile alone does not guarantee that every generated target uses the same value.
+
+The helper becomes unnecessary only when a clean install without it proves that every
+target/configuration in every supported Flutter plugin and push-provider graph declares an
+effective numeric deployment target at or above the host application's minimum. That state would
+normally follow an intentional platform-support change across the SDK, wrappers, and relevant
+dependencies; it is not a prerequisite for adopting Xcode 27. Keep the audit in CI after removing
+the helper so a later dependency update cannot silently reintroduce a lower target.
 
 For a deterministic CI audit, use the script from this repository with the installed CocoaPods
 Ruby environment. Its stable report includes the target, matching project, and effective value.

--- a/docs/cocoapods-deployment-target-normalization.md
+++ b/docs/cocoapods-deployment-target-normalization.md
@@ -57,16 +57,20 @@ end
 ```
 
 Run `flutter pub get`, remove the generated `ios/Pods` directory, and run `pod install` again. The
-helper resolves target xcconfig settings and the matching project configuration before adding an
-override. For each change, it prints a stable project, target, and configuration line with the
-original effective value and final value. It fails the install if the selected effective value is
-non-numeric, such as `$(CUSTOM_IOS_FLOOR)`, because the generated-project audit cannot prove its
-resolved value. A non-numeric value at a lower precedence does not fail when an explicit numeric
-target setting already determines the effective value.
+helper resolves the target xcconfig and matching project configuration before adding an override
+only when the target build-setting key is absent. A present target key is authoritative, so
+lower-precedence xcconfig and project values are not inspected. This matches Xcode's treatment of
+an explicitly empty target value: it is missing and must be normalized, rather than inherited from
+a lower-precedence value. For each change, the helper prints a stable project, target, and
+configuration line with the original effective value and final value. It fails the install if the
+selected effective value is non-numeric, such as `$(CUSTOM_IOS_FLOOR)`, because the
+generated-project audit cannot prove its resolved value. A non-numeric value at a lower precedence
+does not fail when an explicit target setting already determines the effective value.
 
-If an error says an xcconfig cannot be read or parsed, repair or remove the reported base
-configuration file reference for the reported project, target, and configuration. Run the helper
-in the CocoaPods Ruby environment so the public `Xcodeproj::Config` parser is available.
+If an error says a selected xcconfig cannot be read or parsed, repair or remove the reported base
+configuration file reference for the reported project, target, and configuration. Lower-precedence
+xcconfigs are not parsed when the target build-setting key is present. Run the helper in the
+CocoaPods Ruby environment so the public `Xcodeproj::Config` parser is available.
 Synchronized-group xcconfig references are not resolved by that public parser; if the helper
 reports one, replace it with a standard xcconfig file reference, then run `pod install` again.
 These cases fail before any project mutation.

--- a/docs/cocoapods-deployment-target-normalization.md
+++ b/docs/cocoapods-deployment-target-normalization.md
@@ -1,0 +1,87 @@
+# CocoaPods deployment-target normalization
+
+Xcode validates the deployment target of every generated CocoaPods target, including dependency,
+aggregate, privacy-manifest, and resource-bundle targets. Xcode 27 rejects targets below the build
+range supported by its iOS SDK even when the dependency itself is source-compatible with your app.
+
+The `customer_io` package includes an opt-in Podfile helper that raises low or missing generated
+settings to iOS 15.0. It also covers the integrated Runner, Notification Service Extension, and
+widget targets, while preserving any numeric deployment target already above 15.0. When a target
+setting is absent, the helper resolves its target xcconfig and then the same-named project build
+configuration, preserving a higher inherited app or extension floor. It changes local build
+settings in the generated Pods project and CocoaPods-integrated Runner or extension projects. It
+does not rewrite a podspec or change runtime API availability.
+
+> [!WARNING]
+> This is an opt-in build migration. Integrated Runner and extension targets below iOS 15.0 are
+> raised to 15.0. Shipping that project means users on iOS 13 or iOS 14 cannot install subsequent
+> app updates. Adopt the helper only when your product has intentionally moved its application and
+> extension deployment targets to iOS 15.
+
+Load the helper after `flutter_install_all_ios_pods` has run, then call it at the end of the one
+existing `post_install` block:
+
+```ruby
+target 'Runner' do
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+# Declare Notification Service Extension and widget targets before this line too.
+require File.expand_path(
+  File.join('.symlinks', 'plugins', 'customer_io', 'ios', 'cocoapods_deployment_target'),
+  __dir__
+)
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+    # Keep the rest of your existing Flutter settings here.
+  end
+
+  CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+    installer,
+    minimum_ios_version: '15.0'
+  )
+end
+```
+
+Run `flutter pub get`, remove the generated `ios/Pods` directory, and run `pod install` again. The
+helper resolves target xcconfig settings and the matching project configuration before adding an
+override. For each change, it prints a stable project, target, and configuration line with the
+original effective value and final value. It fails the install if the selected effective value is
+non-numeric, such as `$(CUSTOM_IOS_FLOOR)`, because the generated-project audit cannot prove its
+resolved value. A non-numeric value at a lower precedence does not fail when an explicit numeric
+target setting already determines the effective value.
+
+If an error says an xcconfig cannot be read or parsed, repair or remove the reported base
+configuration file reference for the reported project, target, and configuration. Run the helper
+in the CocoaPods Ruby environment so the public `Xcodeproj::Config` parser is available.
+Synchronized-group xcconfig references are not resolved by that public parser; if the helper
+reports one, replace it with a standard xcconfig file reference, then run `pod install` again.
+These cases fail before any project mutation.
+
+## Remove the helper
+
+Treat the helper as a temporary compatibility layer. Remove it only when a clean install without
+the helper proves that every target/configuration in every supported resolved dependency graph
+declares an effective numeric deployment target at or above the host application's minimum. Check
+each supported Flutter plugin and push-provider graph, and keep the audit in CI when removing the
+helper so a later dependency update cannot silently reintroduce a lower target.
+
+For a deterministic CI audit, use the script from this repository with the installed CocoaPods
+Ruby environment. Its stable report includes the target, matching project, and effective value.
+Pass the `Pods` directory so the audit recursively discovers every `.xcodeproj`, including
+CocoaPods multi-project output. It fails if a supplied path is missing or contains no projects. The
+audit examines every target in each passed project, including non-integrated targets that the
+normalizer intentionally does not change; set those targets to the host minimum explicitly.
+
+```sh
+bundle exec ruby scripts/audit_cocoapods_deployment_targets.rb \
+  --minimum 15.0 \
+  apps/flutter_sample_cocoapods/ios/Pods \
+  apps/flutter_sample_cocoapods/ios/Runner.xcodeproj
+```
+
+Keep this audit next to the Flutter simulator build and unsigned generic-device archive. Passing
+those checks does not prove real-device push delivery, signed archive export, or App Store
+submission.

--- a/ios/cocoapods_deployment_target.rb
+++ b/ios/cocoapods_deployment_target.rb
@@ -165,19 +165,23 @@ module CustomerIO
           target_setting_present = configuration.build_settings.key?(BUILD_SETTING)
           target_value = normalized_setting(configuration.build_settings[BUILD_SETTING])
           context = configuration_context(project, target, configuration)
-          target_configuration_present, target_configuration_value = configuration_file_setting(
-            configuration,
-            context: context
-          )
-          project_configuration = matching_project_configuration(project, configuration.name)
-          project_value = effective_configuration_value(project_configuration, context: context)
-          effective_value = if target_setting_present
-                              target_value
-                            elsif target_configuration_present
-                              target_configuration_value
-                            else
-                              project_value
-                            end
+          if target_setting_present
+            target_configuration_value = nil
+            project_value = nil
+            effective_value = target_value
+          else
+            target_configuration_present, target_configuration_value = configuration_file_setting(
+              configuration,
+              context: context
+            )
+            project_configuration = matching_project_configuration(project, configuration.name)
+            project_value = effective_configuration_value(project_configuration, context: context)
+            effective_value = if target_configuration_present
+                                target_configuration_value
+                              else
+                                project_value
+                              end
+          end
           Record.new(
             project: project_path(project),
             target: target.name.to_s,

--- a/ios/cocoapods_deployment_target.rb
+++ b/ios/cocoapods_deployment_target.rb
@@ -174,13 +174,17 @@ module CustomerIO
               configuration,
               context: context
             )
-            project_configuration = matching_project_configuration(project, configuration.name)
-            project_value = effective_configuration_value(project_configuration, context: context)
-            effective_value = if target_configuration_present
-                                target_configuration_value
-                              else
-                                project_value
-                              end
+            if target_configuration_present
+              project_value = nil
+              effective_value = target_configuration_value
+            else
+              project_configuration = matching_project_configuration(project, configuration.name)
+              project_value = effective_configuration_value(
+                project_configuration,
+                context: context
+              )
+              effective_value = project_value
+            end
           end
           Record.new(
             project: project_path(project),

--- a/ios/cocoapods_deployment_target.rb
+++ b/ios/cocoapods_deployment_target.rb
@@ -1,0 +1,404 @@
+# frozen_string_literal: true
+
+# Keep this helper byte-identical across customerio-ios, customerio-flutter, and
+# customerio-reactnative so every wrapper applies the same CocoaPods contract.
+
+require "rubygems/version"
+
+module CustomerIO
+  # Normalizes every CocoaPods-generated target and every integrated application or extension
+  # target to a numeric iOS deployment target that the selected Xcode toolchain supports.
+  module CocoaPodsDeploymentTarget
+    BUILD_SETTING = "IPHONEOS_DEPLOYMENT_TARGET"
+    VERSION_PATTERN = /\A\d+(?:\.\d+){0,2}\z/.freeze
+
+    Record = Struct.new(
+      :project,
+      :target,
+      :configuration,
+      :original_effective,
+      :target_configuration_value,
+      :project_value,
+      :current,
+      :changed,
+      :configuration_object,
+      keyword_init: true
+    )
+
+    class AuditError < StandardError; end
+
+    module_function
+
+    # Raises low effective deployment settings to +minimum_ios_version+. A missing target setting
+    # resolves through its xcconfig and then the same-named project configuration. Numeric effective
+    # settings above the minimum are preserved. A selected non-numeric effective setting fails
+    # closed because its resolved value cannot be audited deterministically from the project.
+    def normalize!(installer, minimum_ios_version:, io: $stdout)
+      minimum = parse_version!(minimum_ios_version, context: "minimum iOS version")
+      targets = installer_targets(installer)
+      records = records_for(targets)
+      ensure_records!(records)
+      validate_numeric_settings!(records)
+
+      records = records.map do |record|
+        normalize_record!(record, minimum)
+      end
+
+      audit_records!(records, minimum)
+      save_integrated_user_projects!(installer, records)
+      write_changes(io, records)
+      write_summary(io, records, minimum)
+      records
+    end
+
+    # Audits an installer without modifying it. This is useful from a second post-install check.
+    def audit!(installer, minimum_ios_version:, io: $stdout)
+      minimum = parse_version!(minimum_ios_version, context: "minimum iOS version")
+      records = records_for(installer_targets(installer))
+      ensure_records!(records)
+
+      audit_records!(records, minimum)
+      write_summary(io, records, minimum)
+      records
+    end
+
+    # Audits projects loaded by Xcodeproj. The caller owns loading the projects so this helper does
+    # not add a runtime dependency on Xcodeproj to the normal Podfile integration path.
+    def audit_projects!(projects, minimum_ios_version:, io: $stdout)
+      minimum = parse_version!(minimum_ios_version, context: "minimum iOS version")
+      targets = projects.flat_map { |project| project.targets }
+      records = records_for(targets)
+      ensure_records!(records)
+
+      audit_records!(records, minimum)
+      write_records(io, records, minimum)
+      records
+    end
+
+    # Returns the greater of two numeric iOS deployment targets. React Native integrations use
+    # this to preserve React Native's own floor when it is higher than Customer.io's floor.
+    def maximum(first, second)
+      first_version = parse_version!(first, context: "iOS version")
+      second_version = parse_version!(second, context: "iOS version")
+      [first_version, second_version].max.to_s
+    end
+
+    def installer_targets(installer)
+      generated_projects = if installer.respond_to?(:generated_projects)
+                             Array(installer.generated_projects).compact
+                           else
+                             []
+                           end
+      if generated_projects.empty? && installer.respond_to?(:pods_project)
+        generated_projects = [installer.pods_project].compact
+      end
+
+      pod_targets = generated_projects.flat_map { |project| project.targets }
+      user_targets = if installer.respond_to?(:aggregate_targets)
+                       Array(installer.aggregate_targets).flat_map do |aggregate_target|
+                         aggregate_target.respond_to?(:user_targets) ? Array(aggregate_target.user_targets) : []
+                       end
+                     else
+                       []
+                     end
+
+      deduplicate_targets(pod_targets + user_targets)
+    end
+    private_class_method :installer_targets
+
+    def save_integrated_user_projects!(installer, records)
+      return unless installer.respond_to?(:aggregate_targets)
+
+      changed_project_paths = records.select(&:changed).map(&:project).uniq
+      return if changed_project_paths.empty?
+
+      projects = Array(installer.aggregate_targets).each_with_object([]) do |aggregate_target, result|
+        if aggregate_target.respond_to?(:user_project)
+          user_project = aggregate_target.user_project
+          result << user_project unless user_project.nil?
+        end
+        next unless aggregate_target.respond_to?(:user_targets)
+
+        Array(aggregate_target.user_targets).each do |target|
+          result << target.project if target.respond_to?(:project) && !target.project.nil?
+        end
+      end.compact
+
+      projects.select { |project| changed_project_paths.include?(project_path(project)) }
+              .uniq { |project| project_path(project) }
+              .each do |project|
+        unless project.respond_to?(:save)
+          raise AuditError, "Cannot save integrated user project #{project_path(project)}"
+        end
+
+        project.save
+      end
+    end
+    private_class_method :save_integrated_user_projects!
+
+    def deduplicate_targets(targets)
+      targets.each_with_object({}) do |target, unique|
+        project = target.respond_to?(:project) ? target.project : nil
+        project_key = project_path(project)
+        target_key = target.respond_to?(:uuid) ? target.uuid : target.object_id
+        unique[[project_key, target_key]] ||= target
+      end.values
+    end
+    private_class_method :deduplicate_targets
+
+    def normalize_record!(record, minimum)
+      current = record.current
+      current_version = current.nil? ? nil : parse_version!(current, context: record_context(record))
+      return record if current_version && current_version >= minimum
+
+      record.configuration_object.build_settings[BUILD_SETTING] = minimum.to_s
+      record.current = minimum.to_s
+      record.changed = true
+      record
+    end
+    private_class_method :normalize_record!
+
+    def records_for(targets)
+      targets.flat_map do |target|
+        project = target.respond_to?(:project) ? target.project : nil
+        target.build_configurations.map do |configuration|
+          target_setting_present = configuration.build_settings.key?(BUILD_SETTING)
+          target_value = normalized_setting(configuration.build_settings[BUILD_SETTING])
+          context = configuration_context(project, target, configuration)
+          target_configuration_present, target_configuration_value = configuration_file_setting(
+            configuration,
+            context: context
+          )
+          project_configuration = matching_project_configuration(project, configuration.name)
+          project_value = effective_configuration_value(project_configuration, context: context)
+          effective_value = if target_setting_present
+                              target_value
+                            elsif target_configuration_present
+                              target_configuration_value
+                            else
+                              project_value
+                            end
+          Record.new(
+            project: project_path(project),
+            target: target.name.to_s,
+            configuration: configuration.name.to_s,
+            original_effective: effective_value,
+            target_configuration_value: target_configuration_value,
+            project_value: project_value,
+            current: effective_value,
+            changed: false,
+            configuration_object: configuration
+          )
+        end
+      end.sort_by { |record| [record.project, record.target, record.configuration] }
+    end
+    private_class_method :records_for
+
+    def effective_configuration_value(configuration, context:)
+      return nil if configuration.nil?
+
+      if configuration.build_settings.key?(BUILD_SETTING)
+        return normalized_setting(configuration.build_settings[BUILD_SETTING])
+      end
+
+      _present, value = configuration_file_setting(configuration, context: context)
+      value
+    end
+    private_class_method :effective_configuration_value
+
+    def configuration_file_setting(configuration, context:)
+      synchronized_anchor = if configuration.respond_to?(:base_configuration_reference_anchor)
+                              configuration.base_configuration_reference_anchor
+                            end
+      synchronized_relative_path = if configuration.respond_to?(:base_configuration_reference_relative_path)
+                                     configuration.base_configuration_reference_relative_path
+                                   end
+      if synchronized_anchor || synchronized_relative_path
+        raise AuditError,
+              "#{context}: Cannot inspect synchronized-group xcconfig " \
+              "#{rendered_synchronized_path(synchronized_anchor, synchronized_relative_path)}. " \
+              "Use a standard xcconfig file reference before rerunning CocoaPods."
+      end
+
+      base_configuration_reference = if configuration.respond_to?(:base_configuration_reference)
+                                       configuration.base_configuration_reference
+                                     end
+      if base_configuration_reference
+        xcconfig_path = if base_configuration_reference.respond_to?(:real_path)
+                          base_configuration_reference.real_path
+                        end
+        unless xcconfig_path.respond_to?(:exist?) && xcconfig_path.exist? &&
+               xcconfig_path.respond_to?(:readable?) && xcconfig_path.readable?
+          rendered_path = xcconfig_path.nil? ? "(unresolved path)" : xcconfig_path.to_s
+          raise AuditError, "#{context}: Cannot read xcconfig #{rendered_path}"
+        end
+
+        unless defined?(::Xcodeproj::Config)
+          raise AuditError,
+                "#{context}: Cannot parse xcconfig #{xcconfig_path}; Xcodeproj::Config is unavailable"
+        end
+
+        begin
+          settings = ::Xcodeproj::Config.new(xcconfig_path).to_hash
+        rescue StandardError => error
+          raise AuditError,
+                "#{context}: Cannot parse xcconfig #{xcconfig_path}: " \
+                "#{error.class}: #{error.message}"
+        end
+
+        unless settings.respond_to?(:key?)
+          raise AuditError, "#{context}: Cannot inspect xcconfig #{xcconfig_path}"
+        end
+        return [false, nil] unless settings.key?(BUILD_SETTING)
+
+        return [true, normalized_setting(settings[BUILD_SETTING])]
+      end
+
+      [false, nil]
+    end
+    private_class_method :configuration_file_setting
+
+    def rendered_synchronized_path(anchor, relative_path)
+      anchor_path = if anchor.respond_to?(:path)
+                      anchor.path
+                    elsif anchor.respond_to?(:display_name)
+                      anchor.display_name
+                    else
+                      "(unknown anchor)"
+                    end
+      [anchor_path, relative_path].compact.map(&:to_s).reject(&:empty?).join("/")
+    end
+    private_class_method :rendered_synchronized_path
+
+    def matching_project_configuration(project, configuration_name)
+      return nil if project.nil? || !project.respond_to?(:build_configurations)
+
+      Array(project.build_configurations).find do |configuration|
+        configuration.name.to_s == configuration_name.to_s
+      end
+    end
+    private_class_method :matching_project_configuration
+
+    def ensure_records!(records)
+      return unless records.empty?
+
+      raise AuditError, "CocoaPods iOS deployment-target audit found no target configurations"
+    end
+    private_class_method :ensure_records!
+
+    def validate_numeric_settings!(records)
+      records.each do |record|
+        parse_version!(record.current, context: record_context(record)) unless record.current.nil?
+      end
+    end
+    private_class_method :validate_numeric_settings!
+
+    def audit_records!(records, minimum)
+      violations = records.each_with_object([]) do |record, result|
+        current = record.current
+        if current.nil?
+          result << "#{record_context(record)} is missing #{BUILD_SETTING}"
+        else
+          begin
+            version = parse_version!(current, context: record_context(record))
+            if version < minimum
+              result << "#{record_context(record)} is #{current}, below #{minimum}"
+            end
+          rescue AuditError => error
+            result << error.message
+          end
+        end
+      end
+
+      return if violations.empty?
+
+      raise AuditError, "CocoaPods iOS deployment-target audit failed:\n- #{violations.join("\n- ")}"
+    end
+    private_class_method :audit_records!
+
+    def write_summary(io, records, minimum)
+      return if io.nil?
+
+      changed = records.count(&:changed)
+      io.puts(
+        "Customer.io CocoaPods deployment-target audit passed: " \
+        "#{records.length} target configurations at iOS #{minimum} or newer (#{changed} normalized)."
+      )
+    end
+    private_class_method :write_summary
+
+    def write_changes(io, records)
+      return if io.nil?
+
+      records.select(&:changed).each do |record|
+        original = record.original_effective.nil? ? "missing" : record.original_effective
+        io.puts(
+          "Customer.io CocoaPods deployment target normalized: " \
+          "#{record_context(record)}: #{original} -> #{record.current}"
+        )
+      end
+    end
+    private_class_method :write_changes
+
+    def write_records(io, records, minimum)
+      return if io.nil?
+
+      io.puts(
+        "project\ttarget\tconfiguration\ttarget_#{BUILD_SETTING}\t" \
+        "target_xcconfig_#{BUILD_SETTING}\t" \
+        "project_#{BUILD_SETTING}\teffective_#{BUILD_SETTING}"
+      )
+      records.each do |record|
+        target_value = normalized_setting(record.configuration_object.build_settings[BUILD_SETTING])
+        io.puts(
+          [
+            record.project,
+            record.target,
+            record.configuration,
+            target_value,
+            record.target_configuration_value,
+            record.project_value,
+            record.current
+          ].join("\t")
+        )
+      end
+      write_summary(io, records, minimum)
+    end
+    private_class_method :write_records
+
+    def parse_version!(value, context:)
+      normalized = normalized_setting(value)
+      unless normalized&.match?(VERSION_PATTERN)
+        rendered = normalized.nil? ? "missing" : normalized.inspect
+        raise AuditError, "#{context} has non-numeric #{BUILD_SETTING}: #{rendered}"
+      end
+
+      Gem::Version.new(normalized)
+    end
+    private_class_method :parse_version!
+
+    def normalized_setting(value)
+      normalized = value.nil? ? nil : value.to_s.strip
+      normalized.nil? || normalized.empty? ? nil : normalized
+    end
+    private_class_method :normalized_setting
+
+    def record_context(record)
+      "#{record.project}: target #{record.target}, configuration #{record.configuration}"
+    end
+    private_class_method :record_context
+
+    def configuration_context(project, target, configuration)
+      "#{project_path(project)}: target #{target.name}, configuration #{configuration.name}"
+    end
+    private_class_method :configuration_context
+
+    def project_path(project)
+      return "unknown-project" if project.nil?
+      return project.path.to_s if project.respond_to?(:path) && project.path
+
+      project.to_s
+    end
+    private_class_method :project_path
+  end
+end

--- a/scripts/audit_cocoapods_deployment_targets.rb
+++ b/scripts/audit_cocoapods_deployment_targets.rb
@@ -30,7 +30,10 @@ begin
     if File.extname(path) == ".xcodeproj"
       [path]
     else
-      Dir.glob(File.join(path, "**", "*.xcodeproj")).sort
+      # CocoaPods writes both Pods.xcodeproj and generate_multiple_pod_projects
+      # output directly under the sandbox root. Do not descend into downloaded pod
+      # sources, where a vendored example project may have unrelated settings.
+      Dir.glob(File.join(path, "*.xcodeproj")).sort
     end
   end.uniq
   if project_paths.empty?

--- a/scripts/audit_cocoapods_deployment_targets.rb
+++ b/scripts/audit_cocoapods_deployment_targets.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "optparse"
+require "xcodeproj"
+require_relative "../ios/cocoapods_deployment_target"
+
+options = { minimum: "15.0" }
+parser = OptionParser.new do |arguments|
+  arguments.banner =
+    "Usage: audit_cocoapods_deployment_targets.rb [options] PROJECT_OR_DIRECTORY [...]"
+  arguments.on("--minimum VERSION", "Required numeric iOS deployment target (default: 15.0)") do |version|
+    options[:minimum] = version
+  end
+end
+
+parser.parse!
+if ARGV.empty?
+  warn parser
+  exit 2
+end
+
+begin
+  project_paths = ARGV.uniq.sort.flat_map do |path|
+    unless File.directory?(path)
+      raise CustomerIO::CocoaPodsDeploymentTarget::AuditError,
+            "CocoaPods deployment-target audit path does not exist: #{path}"
+    end
+
+    if File.extname(path) == ".xcodeproj"
+      [path]
+    else
+      Dir.glob(File.join(path, "**", "*.xcodeproj")).sort
+    end
+  end.uniq
+  if project_paths.empty?
+    raise CustomerIO::CocoaPodsDeploymentTarget::AuditError,
+          "CocoaPods deployment-target audit found no .xcodeproj under: #{ARGV.join(', ')}"
+  end
+
+  projects = project_paths.map { |path| Xcodeproj::Project.open(path) }
+  CustomerIO::CocoaPodsDeploymentTarget.audit_projects!(
+    projects,
+    minimum_ios_version: options[:minimum]
+  )
+rescue CustomerIO::CocoaPodsDeploymentTarget::AuditError, Xcodeproj::Informative => error
+  warn error.message
+  exit 1
+end

--- a/scripts/test_cocoapods_deployment_target.rb
+++ b/scripts/test_cocoapods_deployment_target.rb
@@ -217,6 +217,85 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     assert_equal 0, project.save_count
   end
 
+  def test_explicit_target_setting_skips_an_unreadable_lower_precedence_xcconfig
+    project = project_with_floor("App.xcodeproj", "$(CUSTOM_IOS_FLOOR)")
+    configuration = OpaqueConfiguration.new(
+      "Debug",
+      { CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING => "16.0" },
+      ConfigurationReference.new(Pathname("Missing.xcconfig"))
+    )
+    app = Target.new("App", "App-uuid", project, [configuration])
+    project.targets << app
+    installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+    records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+      installer,
+      minimum_ios_version: "15.0",
+      io: nil
+    )
+
+    assert_equal ["16.0"], records.map(&:current)
+    assert_nil records.first.target_configuration_value
+    assert_nil records.first.project_value
+    assert_equal 0, records.count(&:changed)
+    assert_equal 0, project.save_count
+  end
+
+  def test_explicit_target_setting_skips_a_synchronized_lower_precedence_xcconfig
+    project = project_with_floor("App.xcodeproj", "$(CUSTOM_IOS_FLOOR)")
+    configuration = OpaqueSynchronizedConfiguration.new(
+      "Debug",
+      { CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING => "16.0" },
+      Object.new,
+      "App.xcconfig"
+    )
+    app = Target.new("App", "App-uuid", project, [configuration])
+    project.targets << app
+    installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+    records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+      installer,
+      minimum_ios_version: "15.0",
+      io: nil
+    )
+
+    assert_equal ["16.0"], records.map(&:current)
+    assert_nil records.first.target_configuration_value
+    assert_nil records.first.project_value
+    assert_equal 0, records.count(&:changed)
+    assert_equal 0, project.save_count
+  end
+
+  def test_blank_explicit_target_is_normalized_instead_of_inheriting_lower_precedence_values
+    Dir.mktmpdir do |directory|
+      xcconfig_path = Pathname(directory).join("Target.xcconfig")
+      File.write(xcconfig_path, "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING} = 17.0\n")
+      project = project_with_floor("App.xcodeproj", "18.0")
+      configuration = OpaqueConfiguration.new(
+        "Debug",
+        { CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING => "" },
+        ConfigurationReference.new(xcconfig_path)
+      )
+      app = Target.new("App", "App-uuid", project, [configuration])
+      project.targets << app
+      installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+      records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+
+      assert_nil records.first.original_effective
+      assert_equal "15.0", records.first.current
+      assert_nil records.first.target_configuration_value
+      assert_nil records.first.project_value
+      assert records.first.changed
+      assert_equal "15.0", deployment_target(app)
+      assert_equal 1, project.save_count
+    end
+  end
+
   def test_standalone_audit_reports_the_effective_inherited_project_floor
     project = project_with_floor("App.xcodeproj", "16.0")
     app = target(project, "App", nil)

--- a/scripts/test_cocoapods_deployment_target.rb
+++ b/scripts/test_cocoapods_deployment_target.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require "minitest/autorun"
+require "open3"
 require "pathname"
+require "rbconfig"
 require "stringio"
 require "tmpdir"
 
@@ -313,6 +316,32 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     assert_includes output.string, "effective_IPHONEOS_DEPLOYMENT_TARGET"
     assert_includes output.string, "target_xcconfig_IPHONEOS_DEPLOYMENT_TARGET"
     assert_includes output.string, "\t\t\t16.0\t16.0\n"
+  end
+
+  def test_standalone_audit_discovers_direct_cocoapods_projects_without_vendored_examples
+    skip "Xcodeproj is unavailable" unless xcodeproj_available?
+
+    Dir.mktmpdir do |directory|
+      %w[Pods CustomerIOCommon].each do |name|
+        project = Xcodeproj::Project.new(Pathname(directory).join("#{name}.xcodeproj"))
+        project.new_target(:static_library, name, :ios, "15.0")
+        project.save
+      end
+      FileUtils.mkdir_p(Pathname(directory).join("DownloadedPod/Example.xcodeproj"))
+
+      output, error, status = Open3.capture3(
+        RbConfig.ruby,
+        File.expand_path("audit_cocoapods_deployment_targets.rb", __dir__),
+        "--minimum",
+        "15.0",
+        directory
+      )
+
+      assert status.success?, error
+      assert_includes output, "Pods.xcodeproj"
+      assert_includes output, "CustomerIOCommon.xcodeproj"
+      refute_includes output, "DownloadedPod"
+    end
   end
 
   def test_normalize_preserves_a_higher_target_xcconfig_floor

--- a/scripts/test_cocoapods_deployment_target.rb
+++ b/scripts/test_cocoapods_deployment_target.rb
@@ -371,6 +371,38 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     end
   end
 
+  def test_target_xcconfig_skips_an_unreadable_lower_precedence_project_xcconfig
+    Dir.mktmpdir do |directory|
+      target_xcconfig = Pathname(directory).join("Target.xcconfig")
+      File.write(target_xcconfig, "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING} = 17.0\n")
+      project_configuration = OpaqueConfiguration.new(
+        "Debug",
+        {},
+        ConfigurationReference.new(Pathname(directory).join("MissingProject.xcconfig"))
+      )
+      project = Project.new(Pathname("App.xcodeproj"), [], 0, [project_configuration])
+      configuration = OpaqueConfiguration.new(
+        "Debug",
+        {},
+        ConfigurationReference.new(target_xcconfig)
+      )
+      app = Target.new("App", "App-uuid", project, [configuration])
+      project.targets << app
+      installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+      records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+
+      assert_equal ["17.0"], records.map(&:current)
+      assert_nil records.first.project_value
+      assert_equal 0, records.count(&:changed)
+      assert_equal 0, project.save_count
+    end
+  end
+
   def test_normalize_uses_public_xcodeproj_config_parser_with_real_project_objects
     skip "Xcodeproj is unavailable" unless xcodeproj_available?
 

--- a/scripts/test_cocoapods_deployment_target.rb
+++ b/scripts/test_cocoapods_deployment_target.rb
@@ -1,0 +1,469 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "pathname"
+require "stringio"
+require "tmpdir"
+
+begin
+  require "xcodeproj"
+rescue LoadError
+  # Pure helper tests still run when Xcodeproj is unavailable. Real-object coverage is skipped.
+end
+require_relative "../ios/cocoapods_deployment_target"
+
+class CocoaPodsDeploymentTargetTest < Minitest::Test
+  Configuration = Struct.new(:name, :build_settings, :base_configuration_reference)
+  ConfigurationReference = Struct.new(:real_path)
+  OpaqueConfiguration = Struct.new(:name, :build_settings, :base_configuration_reference)
+  OpaqueSynchronizedConfiguration = Struct.new(
+    :name,
+    :build_settings,
+    :base_configuration_reference_anchor,
+    :base_configuration_reference_relative_path
+  )
+  Project = Struct.new(:path, :targets, :save_count, :build_configurations) do
+    def save
+      self.save_count = save_count.to_i + 1
+    end
+  end
+  Target = Struct.new(:name, :uuid, :project, :build_configurations)
+  AggregateTarget = Struct.new(:user_targets, :user_project)
+  Installer = Struct.new(:generated_projects, :pods_project, :aggregate_targets)
+
+  def test_normalize_covers_generated_and_integrated_targets_and_preserves_higher_floors
+    pods_project = Project.new(Pathname("Pods/Pods.xcodeproj"), [], 0)
+    app_project = Project.new(Pathname("App.xcodeproj"), [], 0)
+    privacy = target(pods_project, "CustomerIOCommon-CustomerIOCommon_Privacy", "13.0")
+    aggregate = target(pods_project, "Pods-App", nil)
+    app = target(app_project, "App", "16.0")
+    extension = target(app_project, "NotificationServiceExtension", "14.0")
+    widget = target(app_project, "LiveActivityWidget", "15.0")
+    unrelated = target(app_project, "UnintegratedTarget", "12.0")
+    pods_project.targets.concat([privacy, aggregate])
+    app_project.targets.concat([app, extension, widget, unrelated])
+    installer = Installer.new(
+      [pods_project],
+      nil,
+      [AggregateTarget.new([app, extension], app_project), AggregateTarget.new([widget, app], app_project)]
+    )
+
+    records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+      installer,
+      minimum_ios_version: "15.0",
+      io: nil
+    )
+
+    assert_equal "15.0", deployment_target(privacy)
+    assert_equal "15.0", deployment_target(aggregate)
+    assert_equal "16.0", deployment_target(app)
+    assert_equal "15.0", deployment_target(extension)
+    assert_equal "15.0", deployment_target(widget)
+    assert_equal "12.0", deployment_target(unrelated)
+    assert_equal 10, records.length
+    assert_equal 6, records.count(&:changed)
+    assert_equal 1, app_project.save_count
+  end
+
+  def test_normalize_reports_each_changed_original_effective_value_in_stable_order
+    pods_project = Project.new(Pathname("Pods/Pods.xcodeproj"), [], 0)
+    missing = target(pods_project, "Missing", nil)
+    pods_project.targets << missing
+    app_project = project_with_floor("App.xcodeproj", "14.0")
+    app = target(app_project, "App", nil)
+    app_project.targets << app
+    installer = Installer.new(
+      [pods_project],
+      nil,
+      [AggregateTarget.new([app], app_project)]
+    )
+    output = StringIO.new
+
+    CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+      installer,
+      minimum_ios_version: "15.0",
+      io: output
+    )
+
+    assert_equal(
+      [
+        "Customer.io CocoaPods deployment target normalized: App.xcodeproj: target App, configuration Debug: 14.0 -> 15.0\n",
+        "Customer.io CocoaPods deployment target normalized: App.xcodeproj: target App, configuration Release: 14.0 -> 15.0\n",
+        "Customer.io CocoaPods deployment target normalized: Pods/Pods.xcodeproj: target Missing, configuration Debug: missing -> 15.0\n",
+        "Customer.io CocoaPods deployment target normalized: Pods/Pods.xcodeproj: target Missing, configuration Release: missing -> 15.0\n",
+        "Customer.io CocoaPods deployment-target audit passed: 4 target configurations at iOS 15.0 or newer (4 normalized).\n"
+      ],
+      output.string.lines
+    )
+  end
+
+  def test_normalize_fails_before_mutating_when_a_setting_is_not_numeric
+    project = Project.new(Pathname("Pods.xcodeproj"), [], 0)
+    low = target(project, "Low", "13.0")
+    inherited = target(project, "Inherited", "$(inherited)")
+    project.targets.concat([low, inherited])
+    installer = Installer.new([project], nil, [])
+
+    error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+      CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+    end
+
+    assert_includes error.message, "non-numeric"
+    assert_equal "13.0", deployment_target(low)
+  end
+
+  def test_normalize_preserves_a_higher_inherited_project_floor
+    pods_project = Project.new(Pathname("Pods.xcodeproj"), [], 0)
+    dependency = target(pods_project, "Dependency", "14.0")
+    pods_project.targets << dependency
+    project = project_with_floor("App.xcodeproj", "16.0")
+    app = target(project, "App", nil)
+    project.targets << app
+    installer = Installer.new([pods_project], nil, [AggregateTarget.new([app], project)])
+
+    records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+      installer,
+      minimum_ios_version: "15.0",
+      io: nil
+    )
+
+    refute app.build_configurations.first.build_settings.key?(
+      CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING
+    )
+    assert_equal "16.0", records.find { |record| record.target == "App" }.current
+    assert_equal "15.0", deployment_target(dependency)
+    assert_equal 2, records.count(&:changed)
+    assert_equal 0, project.save_count
+  end
+
+  def test_normalize_raises_a_lower_inherited_project_floor
+    project = project_with_floor("App.xcodeproj", "14.0")
+    app = target(project, "App", nil)
+    project.targets << app
+    installer = Installer.new([], nil, [AggregateTarget.new([app], nil)])
+
+    records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+      installer,
+      minimum_ios_version: "15.0",
+      io: nil
+    )
+
+    assert_equal "15.0", deployment_target(app)
+    assert_equal "15.0", records.first.current
+    assert_equal 2, records.count(&:changed)
+    assert_equal 1, project.save_count
+  end
+
+  def test_normalize_sets_the_floor_when_target_and_project_settings_are_missing
+    project = Project.new(Pathname("App.xcodeproj"), [], 0, project_configurations(nil))
+    app = target(project, "App", nil)
+    project.targets << app
+    installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+    records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+      installer,
+      minimum_ios_version: "15.0",
+      io: nil
+    )
+
+    assert_equal "15.0", deployment_target(app)
+    assert_equal "15.0", records.first.current
+    assert_equal 2, records.count(&:changed)
+    assert_equal 1, project.save_count
+  end
+
+  def test_normalize_fails_before_mutating_a_non_numeric_inherited_project_floor
+    project = project_with_floor("App.xcodeproj", "$(inherited)")
+    low = target(project, "Low", "14.0")
+    inherited = target(project, "Inherited", nil)
+    project.targets.concat([low, inherited])
+    installer = Installer.new(
+      [],
+      nil,
+      [AggregateTarget.new([low, inherited], project)]
+    )
+
+    error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+      CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+    end
+
+    assert_includes error.message, "non-numeric"
+    assert_equal "14.0", deployment_target(low)
+    assert_nil deployment_target(inherited)
+  end
+
+  def test_normalize_ignores_a_non_numeric_lower_precedence_project_floor
+    project = project_with_floor("App.xcodeproj", "$(CUSTOM_IOS_FLOOR)")
+    app = target(project, "App", "16.0")
+    project.targets << app
+    installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+    records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+      installer,
+      minimum_ios_version: "15.0",
+      io: nil
+    )
+
+    assert_equal %w[16.0 16.0], records.map(&:current)
+    assert_equal 0, records.count(&:changed)
+    assert_equal 0, project.save_count
+  end
+
+  def test_standalone_audit_reports_the_effective_inherited_project_floor
+    project = project_with_floor("App.xcodeproj", "16.0")
+    app = target(project, "App", nil)
+    project.targets << app
+    output = StringIO.new
+
+    records = CustomerIO::CocoaPodsDeploymentTarget.audit_projects!(
+      [project],
+      minimum_ios_version: "15.0",
+      io: output
+    )
+
+    assert_equal "16.0", records.first.current
+    assert_includes output.string, "project_IPHONEOS_DEPLOYMENT_TARGET"
+    assert_includes output.string, "effective_IPHONEOS_DEPLOYMENT_TARGET"
+    assert_includes output.string, "target_xcconfig_IPHONEOS_DEPLOYMENT_TARGET"
+    assert_includes output.string, "\t\t\t16.0\t16.0\n"
+  end
+
+  def test_normalize_preserves_a_higher_target_xcconfig_floor
+    skip "Xcodeproj is unavailable" unless xcodeproj_available?
+
+    Dir.mktmpdir do |directory|
+      xcconfig_path = Pathname(directory).join("Target.xcconfig")
+      File.write(xcconfig_path, "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING} = 17.0\n")
+      project = project_with_floor("App.xcodeproj", "14.0")
+      app = target(project, "App", nil)
+      app.build_configurations.each do |configuration|
+        configuration.base_configuration_reference = ConfigurationReference.new(xcconfig_path)
+      end
+      project.targets << app
+      installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+      records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+
+      assert_nil deployment_target(app)
+      assert_equal %w[17.0 17.0], records.map(&:current)
+      assert_equal 0, records.count(&:changed)
+      assert_equal 0, project.save_count
+    end
+  end
+
+  def test_normalize_uses_public_xcodeproj_config_parser_with_real_project_objects
+    skip "Xcodeproj is unavailable" unless xcodeproj_available?
+
+    Dir.mktmpdir do |directory|
+      project_path = Pathname(directory).join("App.xcodeproj")
+      xcconfig_path = Pathname(directory).join("Target.xcconfig")
+      File.write(xcconfig_path, "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING} = 17.0\n")
+      project = Xcodeproj::Project.new(project_path)
+      app = project.new_target(:application, "App", :ios, "14.0")
+      reference = project.main_group.new_file(xcconfig_path)
+      app.build_configurations.each do |configuration|
+        configuration.build_settings.delete(CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING)
+        configuration.base_configuration_reference = reference
+      end
+      project.build_configurations.each do |configuration|
+        configuration.build_settings[CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING] = "14.0"
+      end
+      installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+      records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+
+      assert app.build_configurations.all? do |configuration|
+        !configuration.build_settings.key?(CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING)
+      end
+      assert_equal %w[17.0 17.0], records.map(&:current)
+      assert_equal 0, records.count(&:changed)
+    end
+  end
+
+  def test_normalize_fails_closed_for_a_non_numeric_target_xcconfig_floor
+    skip "Xcodeproj is unavailable" unless xcodeproj_available?
+
+    Dir.mktmpdir do |directory|
+      xcconfig_path = Pathname(directory).join("Target.xcconfig")
+      File.write(xcconfig_path, "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING} = $(CUSTOM_IOS_FLOOR)\n")
+      project = project_with_floor("App.xcodeproj", "16.0")
+      app = target(project, "App", nil)
+      app.build_configurations.each do |configuration|
+        configuration.base_configuration_reference = ConfigurationReference.new(xcconfig_path)
+      end
+      project.targets << app
+      installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+      error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+        CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+          installer,
+          minimum_ios_version: "15.0",
+          io: nil
+        )
+      end
+
+      assert_includes error.message, "non-numeric"
+      assert_nil deployment_target(app)
+      assert_equal 0, project.save_count
+    end
+  end
+
+  def test_normalize_fails_closed_when_a_referenced_xcconfig_cannot_be_inspected
+    project = project_with_floor("App.xcodeproj", "16.0")
+    app = Target.new(
+      "App",
+      "App-uuid",
+      project,
+      [OpaqueConfiguration.new("Debug", {}, ConfigurationReference.new(Pathname("Missing.xcconfig")))]
+    )
+    project.targets << app
+    installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+    error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+      CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+    end
+
+    assert_includes error.message, "Cannot read xcconfig"
+    assert_includes error.message, "App.xcodeproj: target App, configuration Debug"
+    assert_includes error.message, "Missing.xcconfig"
+    refute app.build_configurations.first.build_settings.key?(
+      CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING
+    )
+    assert_equal 0, project.save_count
+  end
+
+  def test_normalize_fails_closed_when_a_synchronized_group_xcconfig_cannot_be_inspected
+    project = project_with_floor("App.xcodeproj", "16.0")
+    app = Target.new(
+      "App",
+      "App-uuid",
+      project,
+      [OpaqueSynchronizedConfiguration.new("Debug", {}, Object.new, "App.xcconfig")]
+    )
+    project.targets << app
+    installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+    error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+      CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+    end
+
+    assert_includes error.message, "Cannot inspect synchronized-group xcconfig"
+    assert_includes error.message, "App.xcodeproj: target App, configuration Debug"
+    assert_includes error.message, "App.xcconfig"
+    refute app.build_configurations.first.build_settings.key?(
+      CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING
+    )
+    assert_equal 0, project.save_count
+  end
+
+  def test_audit_lists_missing_low_and_non_numeric_settings
+    project = Project.new(Pathname("Pods.xcodeproj"), [], 0)
+    project.targets.concat([
+      target(project, "Missing", nil),
+      target(project, "Low", "14.0"),
+      target(project, "Macro", "$(inherited)")
+    ])
+    installer = Installer.new([project], nil, [])
+
+    error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+      CustomerIO::CocoaPodsDeploymentTarget.audit!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+    end
+
+    assert_includes error.message, "target Missing"
+    assert_includes error.message, "target Low"
+    assert_includes error.message, "target Macro"
+  end
+
+  def test_falls_back_to_pods_project_for_older_cocoapods_installers
+    project = Project.new(Pathname("Pods.xcodeproj"), [], 0)
+    dependency = target(project, "Dependency", "13.0")
+    project.targets << dependency
+    installer = Installer.new([], project, [])
+
+    CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+      installer,
+      minimum_ios_version: "15.0",
+      io: nil
+    )
+
+    assert_equal "15.0", deployment_target(dependency)
+  end
+
+  def test_empty_installer_fails_closed
+    installer = Installer.new([], nil, [])
+
+    assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+      CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+    end
+  end
+
+  def test_maximum_preserves_react_native_floor
+    assert_equal "15.1", CustomerIO::CocoaPodsDeploymentTarget.maximum("15.0", "15.1")
+    assert_equal "16.0", CustomerIO::CocoaPodsDeploymentTarget.maximum("16.0", "15.1")
+  end
+
+  private
+
+  def xcodeproj_available?
+    defined?(Xcodeproj::Config) && defined?(Xcodeproj::Project)
+  end
+
+  def target(project, name, deployment_target)
+    configurations = %w[Debug Release].map do |configuration_name|
+      settings = {}
+      settings[CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING] = deployment_target unless deployment_target.nil?
+      Configuration.new(configuration_name, settings)
+    end
+    Target.new(name, "#{name}-uuid", project, configurations)
+  end
+
+  def deployment_target(target)
+    target.build_configurations.first.build_settings[
+      CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING
+    ]
+  end
+
+  def project_with_floor(path, deployment_target)
+    Project.new(Pathname(path), [], 0, project_configurations(deployment_target))
+  end
+
+  def project_configurations(deployment_target)
+    %w[Debug Release].map do |configuration_name|
+      settings = {}
+      settings[CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING] = deployment_target unless deployment_target.nil?
+      Configuration.new(configuration_name, settings)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- ship the shared CocoaPods deployment-target helper with the Flutter plugin
- invoke it after Flutter's existing `post_install` settings in the CocoaPods sample
- normalize generated and integrated targets to iOS 15.0 while preserving higher numeric floors
- add focused helper tests, recursive generated-project auditing, CI coverage, and customer guidance

## Root cause

Xcode 27 rejects every generated target configuration below its supported iOS 15 floor. The Flutter CocoaPods graph contains dependency, privacy, resource-bundle, app, NSE, and widget configurations below that floor even when Runner itself targets iOS 15.

## Compatibility policy

Customer.io still supports iOS versions below 15, so lower native podspec minimums remain intentional. Raising those public minimums first would drop older applications and would not control transitive pod metadata. This helper instead aligns generated build targets with a Flutter application that has deliberately moved to iOS 15 or later, without changing published package runtime support.

## Safety

The helper validates before mutation, reports stable per-target `original -> final` changes, preserves higher inherited project/xcconfig values, and fails closed for unresolved settings. The copy is byte-identical to the native iOS and React Native helpers.

## Validation

- helper suite: 18 tests, 85 assertions
- clean CocoaPods install: 336 configuration changes
- recursive audit: 393 target configurations at iOS 15.0 or newer
- Flutter 3.41.6 CocoaPods simulator build passed with Xcode 26.6
- Ruby syntax, recursive/missing/empty CLI cases, diff check passed
- Customer.io Opus production review and final Fable exact-diff review accepted

## Boundaries

Hosted Xcode 27 after-proof is being run on a separate integration branch with MBL-2248 and MBL-2280. SwiftPM needs no normalizer. This PR does not raise the published Flutter package minimum or prove real-device delivery, signing/export, App Store submission, or every customer dependency graph.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-time Ruby mutates Xcode/CocoaPods projects and can raise app/extension floors to iOS 15 when adopted; scope is integration/CI rather than runtime SDK behavior.
> 
> **Overview**
> Adds an **opt-in CocoaPods helper** (`CustomerIO::CocoaPodsDeploymentTarget`) so Flutter apps on iOS 15+ can raise generated pod and integrated Runner/extension targets that Xcode 27 rejects, without bumping published native podspec minimums.
> 
> The CocoaPods sample **requires** the helper in `post_install` (floor **15.0**, higher numeric targets unchanged). **CI** for `flutter_sample_cocoapods` runs the Minitest suite and `audit_cocoapods_deployment_targets.rb` on `ios/Pods` and `Runner.xcodeproj`. **Docs** (`docs/cocoapods-deployment-target-normalization.md`) and a **README** pointer explain adoption via the plugin symlink path.
> 
> Also adds **`minitest`** to the sample app Gemfile for the helper tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab6868daf1565ca2222154ab89c8c83fceec4aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->