### PR TITLE
ci: reject conditional CocoaPods deployment targets (MBL-2278)

### DIFF
--- a/docs/cocoapods-deployment-target-normalization.md
+++ b/docs/cocoapods-deployment-target-normalization.md
@@ -72,6 +72,8 @@ Xcode can choose a qualified key over an unconditional value, so adding a numeri
 not prove the effective floor and could lower a higher conditional project setting. Replace the
 selected conditional matrix with one numeric, unconditional deployment target before rerunning the
 helper.
+For a generated Pods target, make that correction in the Podfile or dependency podspec rather than
+editing `Pods.xcodeproj`, which CocoaPods regenerates.
 
 If an error says a selected xcconfig cannot be read or parsed, repair or remove the reported base
 configuration file reference for the reported project, target, and configuration. Lower-precedence

--- a/docs/cocoapods-deployment-target-normalization.md
+++ b/docs/cocoapods-deployment-target-normalization.md
@@ -66,6 +66,12 @@ configuration line with the original effective value and final value. It fails t
 selected effective value is non-numeric, such as `$(CUSTOM_IOS_FLOOR)`, because the
 generated-project audit cannot prove its resolved value. A non-numeric value at a lower precedence
 does not fail when an explicit target setting already determines the effective value.
+SDK-, architecture-, or configuration-qualified keys such as
+`IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos*]` also fail before mutation at the selected precedence.
+Xcode can choose a qualified key over an unconditional value, so adding a numeric override would
+not prove the effective floor and could lower a higher conditional project setting. Replace the
+selected conditional matrix with one numeric, unconditional deployment target before rerunning the
+helper.
 
 If an error says a selected xcconfig cannot be read or parsed, repair or remove the reported base
 configuration file reference for the reported project, target, and configuration. Lower-precedence

--- a/docs/cocoapods-deployment-target-normalization.md
+++ b/docs/cocoapods-deployment-target-normalization.md
@@ -102,7 +102,9 @@ Ruby environment. Its stable report includes the target, matching project, and e
 Pass the `Pods` directory so the audit discovers every `.xcodeproj` directly under it, including
 CocoaPods multi-project output, while ignoring unrelated example projects vendored inside
 downloaded pod sources. It fails if a supplied path is missing or contains no projects. The
-audit examines every target in each passed project, including non-integrated targets that the
+audit fails before printing the table when a selected precedence contains a qualified
+deployment-target key because it cannot determine one effective value for that configuration. It
+examines every target in each passed project, including non-integrated targets that the
 normalizer intentionally does not change; set those targets to the host minimum explicitly.
 
 ```sh

--- a/ios/cocoapods_deployment_target.rb
+++ b/ios/cocoapods_deployment_target.rb
@@ -181,7 +181,7 @@ module CustomerIO
               project_configuration = matching_project_configuration(project, configuration.name)
               project_value = effective_configuration_value(
                 project_configuration,
-                context: context
+                context: "#{context}, project build configuration #{configuration.name}"
               )
               effective_value = project_value
             end

--- a/ios/cocoapods_deployment_target.rb
+++ b/ios/cocoapods_deployment_target.rb
@@ -274,8 +274,9 @@ module CustomerIO
     private_class_method :configuration_file_setting
 
     def validate_no_conditional_settings!(settings, context:)
+      conditional_setting_pattern = /\A#{Regexp.escape(BUILD_SETTING)}[[:space:]]*\[/
       conditional_keys = settings.keys.map(&:to_s).select do |key|
-        key.start_with?("#{BUILD_SETTING}[")
+        key.match?(conditional_setting_pattern)
       end.sort
       return if conditional_keys.empty?
 

--- a/ios/cocoapods_deployment_target.rb
+++ b/ios/cocoapods_deployment_target.rb
@@ -282,7 +282,8 @@ module CustomerIO
       raise AuditError,
             "#{context} has conditional #{BUILD_SETTING} settings that cannot be audited deterministically: " \
             "#{conditional_keys.join(', ')}. Replace them with one numeric, unconditional #{BUILD_SETTING} " \
-            "before running this helper."
+            "before running this helper. For a generated Pods target, change the Podfile or dependency " \
+            "podspec rather than Pods.xcodeproj."
     end
     private_class_method :validate_no_conditional_settings!
 

--- a/ios/cocoapods_deployment_target.rb
+++ b/ios/cocoapods_deployment_target.rb
@@ -162,9 +162,10 @@ module CustomerIO
       targets.flat_map do |target|
         project = target.respond_to?(:project) ? target.project : nil
         target.build_configurations.map do |configuration|
+          context = configuration_context(project, target, configuration)
+          validate_no_conditional_settings!(configuration.build_settings, context: context)
           target_setting_present = configuration.build_settings.key?(BUILD_SETTING)
           target_value = normalized_setting(configuration.build_settings[BUILD_SETTING])
-          context = configuration_context(project, target, configuration)
           if target_setting_present
             target_configuration_value = nil
             project_value = nil
@@ -204,6 +205,8 @@ module CustomerIO
 
     def effective_configuration_value(configuration, context:)
       return nil if configuration.nil?
+
+      validate_no_conditional_settings!(configuration.build_settings, context: context)
 
       if configuration.build_settings.key?(BUILD_SETTING)
         return normalized_setting(configuration.build_settings[BUILD_SETTING])
@@ -257,6 +260,10 @@ module CustomerIO
         unless settings.respond_to?(:key?)
           raise AuditError, "#{context}: Cannot inspect xcconfig #{xcconfig_path}"
         end
+        validate_no_conditional_settings!(
+          settings,
+          context: "#{context}, xcconfig #{xcconfig_path}"
+        )
         return [false, nil] unless settings.key?(BUILD_SETTING)
 
         return [true, normalized_setting(settings[BUILD_SETTING])]
@@ -265,6 +272,19 @@ module CustomerIO
       [false, nil]
     end
     private_class_method :configuration_file_setting
+
+    def validate_no_conditional_settings!(settings, context:)
+      conditional_keys = settings.keys.map(&:to_s).select do |key|
+        key.start_with?("#{BUILD_SETTING}[")
+      end.sort
+      return if conditional_keys.empty?
+
+      raise AuditError,
+            "#{context} has conditional #{BUILD_SETTING} settings that cannot be audited deterministically: " \
+            "#{conditional_keys.join(', ')}. Replace them with one numeric, unconditional #{BUILD_SETTING} " \
+            "before running this helper."
+    end
+    private_class_method :validate_no_conditional_settings!
 
     def rendered_synchronized_path(anchor, relative_path)
       anchor_path = if anchor.respond_to?(:path)

--- a/ios/cocoapods_deployment_target.rb
+++ b/ios/cocoapods_deployment_target.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Keep this helper byte-identical across customerio-ios, customerio-flutter, and
-# customerio-reactnative so every wrapper applies the same CocoaPods contract.
+# This packaged copy is owned by customerio-flutter and covered by its local test suite.
 
 require "rubygems/version"
 

--- a/scripts/test_cocoapods_deployment_target.rb
+++ b/scripts/test_cocoapods_deployment_target.rb
@@ -119,6 +119,56 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     assert_equal "13.0", deployment_target(low)
   end
 
+  def test_normalize_fails_before_mutating_a_conditional_target_setting
+    project = Project.new(Pathname("Pods.xcodeproj"), [], 0)
+    low = target(project, "Low", "13.0")
+    conditional = target(project, "Conditional", nil)
+    conditional.build_configurations.first.build_settings[
+      "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}[sdk=iphoneos*]"
+    ] = "13.0"
+    project.targets.concat([low, conditional])
+    installer = Installer.new([project], nil, [])
+
+    error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+      CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+    end
+
+    assert_includes error.message, "conditional IPHONEOS_DEPLOYMENT_TARGET"
+    assert_includes error.message, "[sdk=iphoneos*]"
+    assert_equal "13.0", deployment_target(low)
+    refute conditional.build_configurations.first.build_settings.key?(
+      CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING
+    )
+  end
+
+  def test_normalize_fails_before_target_override_can_lower_a_conditional_project_floor
+    project = Project.new(Pathname("App.xcodeproj"), [], 0, project_configurations(nil))
+    project.build_configurations.first.build_settings[
+      "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}[sdk=iphoneos*]"
+    ] = "17.0"
+    app = target(project, "App", nil)
+    project.targets << app
+    installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+    error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+      CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+    end
+
+    assert_includes error.message, "conditional IPHONEOS_DEPLOYMENT_TARGET"
+    refute app.build_configurations.first.build_settings.key?(
+      CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING
+    )
+    assert_equal 0, project.save_count
+  end
+
   def test_normalize_preserves_a_higher_inherited_project_floor
     pods_project = Project.new(Pathname("Pods.xcodeproj"), [], 0)
     dependency = target(pods_project, "Dependency", "14.0")
@@ -457,6 +507,38 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
       end
 
       assert_includes error.message, "non-numeric"
+      assert_nil deployment_target(app)
+      assert_equal 0, project.save_count
+    end
+  end
+
+  def test_normalize_fails_closed_for_a_conditional_target_xcconfig_floor
+    skip "Xcodeproj is unavailable" unless xcodeproj_available?
+
+    Dir.mktmpdir do |directory|
+      xcconfig_path = Pathname(directory).join("Target.xcconfig")
+      File.write(
+        xcconfig_path,
+        "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}[sdk=iphoneos*] = 13.0\n"
+      )
+      project = project_with_floor("App.xcodeproj", "16.0")
+      app = target(project, "App", nil)
+      app.build_configurations.each do |configuration|
+        configuration.base_configuration_reference = ConfigurationReference.new(xcconfig_path)
+      end
+      project.targets << app
+      installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+      error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+        CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+          installer,
+          minimum_ios_version: "15.0",
+          io: nil
+        )
+      end
+
+      assert_includes error.message, "conditional IPHONEOS_DEPLOYMENT_TARGET"
+      assert_includes error.message, xcconfig_path.to_s
       assert_nil deployment_target(app)
       assert_equal 0, project.save_count
     end

--- a/scripts/test_cocoapods_deployment_target.rb
+++ b/scripts/test_cocoapods_deployment_target.rb
@@ -438,6 +438,27 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     assert_includes output.string, "\t\t\t16.0\t16.0\n"
   end
 
+  def test_standalone_audit_fails_before_output_for_a_conditional_setting
+    project = Project.new(Pathname("Pods.xcodeproj"), [], 0)
+    conditional = target(project, "Conditional", "16.0")
+    conditional.build_configurations.first.build_settings[
+      "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}[sdk=iphoneos*]"
+    ] = "17.0"
+    project.targets << conditional
+    output = StringIO.new
+
+    error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+      CustomerIO::CocoaPodsDeploymentTarget.audit_projects!(
+        [project],
+        minimum_ios_version: "15.0",
+        io: output
+      )
+    end
+
+    assert_includes error.message, "conditional IPHONEOS_DEPLOYMENT_TARGET"
+    assert_empty output.string
+  end
+
   def test_standalone_audit_discovers_direct_cocoapods_projects_without_vendored_examples
     skip "Xcodeproj is unavailable" unless xcodeproj_available?
 

--- a/scripts/test_cocoapods_deployment_target.rb
+++ b/scripts/test_cocoapods_deployment_target.rb
@@ -145,6 +145,30 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     )
   end
 
+  def test_normalize_fails_before_mutating_whitespace_qualified_target_settings
+    [" ", "\t"].each do |separator|
+      project = Project.new(Pathname("Pods.xcodeproj"), [], 0)
+      conditional = target(project, "Conditional", nil)
+      conditional.build_configurations.first.build_settings[
+        "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}#{separator}[sdk=iphoneos*]"
+      ] = "13.0"
+      project.targets << conditional
+      installer = Installer.new([project], nil, [])
+
+      error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+        CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+          installer,
+          minimum_ios_version: "15.0",
+          io: nil
+        )
+      end
+
+      assert_includes error.message, "conditional IPHONEOS_DEPLOYMENT_TARGET"
+      assert_nil deployment_target(conditional)
+      assert_equal 0, project.save_count
+    end
+  end
+
   def test_normalize_fails_before_target_override_can_lower_a_conditional_project_floor
     project = Project.new(Pathname("App.xcodeproj"), [], 0, project_configurations(nil))
     project.build_configurations.first.build_settings[
@@ -167,6 +191,30 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
       CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING
     )
     assert_equal 0, project.save_count
+  end
+
+  def test_normalize_fails_before_target_override_can_lower_whitespace_qualified_project_floors
+    [" ", "\t"].each do |separator|
+      project = Project.new(Pathname("App.xcodeproj"), [], 0, project_configurations(nil))
+      project.build_configurations.first.build_settings[
+        "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}#{separator}[sdk=iphoneos*]"
+      ] = "17.0"
+      app = target(project, "App", nil)
+      project.targets << app
+      installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+      error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+        CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+          installer,
+          minimum_ios_version: "15.0",
+          io: nil
+        )
+      end
+
+      assert_includes error.message, "conditional IPHONEOS_DEPLOYMENT_TARGET"
+      assert_nil deployment_target(app)
+      assert_equal 0, project.save_count
+    end
   end
 
   def test_normalize_preserves_a_higher_inherited_project_floor
@@ -541,6 +589,74 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
       assert_includes error.message, xcconfig_path.to_s
       assert_nil deployment_target(app)
       assert_equal 0, project.save_count
+    end
+  end
+
+  def test_normalize_fails_closed_for_whitespace_qualified_target_xcconfig_floors
+    skip "Xcodeproj is unavailable" unless xcodeproj_available?
+
+    [" ", "\t"].each do |separator|
+      Dir.mktmpdir do |directory|
+        xcconfig_path = Pathname(directory).join("Target.xcconfig")
+        File.write(
+          xcconfig_path,
+          "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}#{separator}[sdk=iphoneos*] = 13.0\n"
+        )
+        project = project_with_floor("App.xcodeproj", "16.0")
+        app = target(project, "App", nil)
+        app.build_configurations.each do |configuration|
+          configuration.base_configuration_reference = ConfigurationReference.new(xcconfig_path)
+        end
+        project.targets << app
+        installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+        error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+          CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+            installer,
+            minimum_ios_version: "15.0",
+            io: nil
+          )
+        end
+
+        assert_includes error.message, "conditional IPHONEOS_DEPLOYMENT_TARGET"
+        assert_nil deployment_target(app)
+        assert_equal 0, project.save_count
+      end
+    end
+  end
+
+  def test_normalize_fails_closed_for_whitespace_qualified_project_xcconfig_floors
+    skip "Xcodeproj is unavailable" unless xcodeproj_available?
+
+    [" ", "\t"].each do |separator|
+      Dir.mktmpdir do |directory|
+        xcconfig_path = Pathname(directory).join("Project.xcconfig")
+        File.write(
+          xcconfig_path,
+          "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}#{separator}[sdk=iphoneos*] = 17.0\n"
+        )
+        project_configuration = OpaqueConfiguration.new(
+          "Debug",
+          {},
+          ConfigurationReference.new(xcconfig_path)
+        )
+        project = Project.new(Pathname("App.xcodeproj"), [], 0, [project_configuration])
+        app = Target.new("App", "App-uuid", project, [Configuration.new("Debug", {})])
+        project.targets << app
+        installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+        error = assert_raises(CustomerIO::CocoaPodsDeploymentTarget::AuditError) do
+          CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+            installer,
+            minimum_ios_version: "15.0",
+            io: nil
+          )
+        end
+
+        assert_includes error.message, "conditional IPHONEOS_DEPLOYMENT_TARGET"
+        assert_nil deployment_target(app)
+        assert_equal 0, project.save_count
+      end
     end
   end
 

--- a/scripts/test_cocoapods_deployment_target.rb
+++ b/scripts/test_cocoapods_deployment_target.rb
@@ -364,6 +364,35 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     assert_equal 0, project.save_count
   end
 
+  def test_explicit_target_setting_skips_a_conditional_lower_precedence_target_xcconfig
+    skip "Xcodeproj is unavailable" unless xcodeproj_available?
+
+    Dir.mktmpdir do |directory|
+      xcconfig_path = Pathname(directory).join("Target.xcconfig")
+      File.write(
+        xcconfig_path,
+        "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}[sdk=iphoneos*] = 13.0\n"
+      )
+      project = Project.new(Pathname("App.xcodeproj"), [], 0)
+      app = target(project, "App", "16.0")
+      app.build_configurations.each do |configuration|
+        configuration.base_configuration_reference = ConfigurationReference.new(xcconfig_path)
+      end
+      project.targets << app
+      installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+      records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: "15.0",
+        io: nil
+      )
+
+      assert_equal %w[16.0 16.0], records.map(&:current)
+      assert_equal 0, records.count(&:changed)
+      assert_equal 0, project.save_count
+    end
+  end
+
   def test_explicit_target_setting_skips_a_synchronized_lower_precedence_xcconfig
     project = project_with_floor("App.xcodeproj", "$(CUSTOM_IOS_FLOOR)")
     configuration = OpaqueSynchronizedConfiguration.new(

--- a/scripts/test_cocoapods_deployment_target.rb
+++ b/scripts/test_cocoapods_deployment_target.rb
@@ -188,6 +188,7 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     end
 
     assert_includes error.message, "conditional IPHONEOS_DEPLOYMENT_TARGET"
+    assert_includes error.message, "project build configuration Debug"
     refute app.build_configurations.first.build_settings.key?(
       CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING
     )

--- a/scripts/test_cocoapods_deployment_target.rb
+++ b/scripts/test_cocoapods_deployment_target.rb
@@ -124,6 +124,9 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     low = target(project, "Low", "13.0")
     conditional = target(project, "Conditional", nil)
     conditional.build_configurations.first.build_settings[
+      CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING
+    ] = "16.0"
+    conditional.build_configurations.first.build_settings[
       "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}[sdk=iphoneos*]"
     ] = "13.0"
     project.targets.concat([low, conditional])
@@ -140,9 +143,7 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     assert_includes error.message, "conditional IPHONEOS_DEPLOYMENT_TARGET"
     assert_includes error.message, "[sdk=iphoneos*]"
     assert_equal "13.0", deployment_target(low)
-    refute conditional.build_configurations.first.build_settings.key?(
-      CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING
-    )
+    assert_equal "16.0", deployment_target(conditional)
   end
 
   def test_normalize_fails_before_mutating_whitespace_qualified_target_settings
@@ -303,6 +304,26 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
 
   def test_normalize_ignores_a_non_numeric_lower_precedence_project_floor
     project = project_with_floor("App.xcodeproj", "$(CUSTOM_IOS_FLOOR)")
+    app = target(project, "App", "16.0")
+    project.targets << app
+    installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
+
+    records = CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+      installer,
+      minimum_ios_version: "15.0",
+      io: nil
+    )
+
+    assert_equal %w[16.0 16.0], records.map(&:current)
+    assert_equal 0, records.count(&:changed)
+    assert_equal 0, project.save_count
+  end
+
+  def test_normalize_ignores_a_conditional_lower_precedence_project_floor
+    project = Project.new(Pathname("App.xcodeproj"), [], 0, project_configurations(nil))
+    project.build_configurations.first.build_settings[
+      "#{CustomerIO::CocoaPodsDeploymentTarget::BUILD_SETTING}[sdk=iphoneos*]"
+    ] = "13.0"
     app = target(project, "App", "16.0")
     project.targets << app
     installer = Installer.new([], nil, [AggregateTarget.new([app], project)])
@@ -625,10 +646,10 @@ class CocoaPodsDeploymentTargetTest < Minitest::Test
     end
   end
 
-  def test_normalize_fails_closed_for_whitespace_qualified_project_xcconfig_floors
+  def test_normalize_fails_closed_for_qualified_project_xcconfig_floors
     skip "Xcodeproj is unavailable" unless xcodeproj_available?
 
-    [" ", "\t"].each do |separator|
+    ["", " ", "\t"].each do |separator|
       Dir.mktmpdir do |directory|
         xcconfig_path = Pathname(directory).join("Project.xcconfig")
         File.write(


### PR DESCRIPTION
## What changed

- Apply the qualified deployment-target fix to Flutter's package-owned helper.
- Fail before mutation for qualified `IPHONEOS_DEPLOYMENT_TARGET[...]` keys.
- Cover target, project, and xcconfig conditional settings and document the required cleanup.

## Why

Xcode can prefer a conditional target value over an unconditional override, or a new target value can lower a higher conditional project floor. The previous audit could therefore report success for the wrong effective floor.

## Validation

- Ruby helper suite: 33 tests, 190 assertions
- Flutter's package-owned helper suite verifies the behavior locally
- diff check

No cross-repository source lock, branch pin, or runtime dependency is introduced. This PR can be reviewed independently of the equivalent native helper correction.

## Release and merge policy

This CI/build-tooling PR must be **squash merged only** under its `ci:` PR title. A merge commit would expose the branch’s `fix:` commit to semantic-release and could trigger an unintended package release. The squashed change does not alter Flutter runtime behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS CocoaPods post-install and CI audit behavior; `pod install` can now fail on projects that previously normalized, but only when conditional deployment targets are present and the fix is intentional.
> 
> **Overview**
> **CocoaPods deployment-target normalization and CI audit now fail closed** when they see qualified `IPHONEOS_DEPLOYMENT_TARGET[...]` keys (including whitespace before `[`) on target build settings, project configurations, or parsed xcconfigs—before any project mutation or audit table output.
> 
> That blocks cases where Xcode could pick a conditional value over an unconditional override, or where adding a numeric target override could look compliant while lowering a higher conditional project floor. Errors tell integrators to replace the matrix with one unconditional numeric floor (Podfile/podspec for generated Pods targets). Docs describe the same rule for `pod install` and the standalone audit script.
> 
> The Flutter-owned helper header no longer claims byte-identical sync with other repos; behavior is covered by an expanded Ruby test suite (target/project/xcconfig, explicit-target skip paths, standalone audit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0767f280517f8538d4897de178bcf2efa1a6797d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



