### PR TITLE
feat: route SDK deep links through Flutter scenes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,12 @@ released native URL handler and leaves ordinary links and user activities to Flu
 AppDelegate-only hosts keep the existing manual URL handler described above.
 When UIScene and Flutter deep linking are enabled, the plugin also becomes the native SDK's
 deep-link callback during plugin registration. The native callback is synchronous but Flutter's
-routing result is asynchronous, so the plugin claims the handoff, offers the destination to Flutter,
-and uses `UIApplication.open` only if Flutter declines it or no foreground engine becomes available.
+routing result is asynchronous, so the plugin claims the handoff and offers every SDK destination
+to Flutter, including `http` and `https` URLs. Flutter's standard navigation APIs report a delivered
+route as handled, so the host's Dart router owns unknown-route and browser-opening policy. The plugin
+uses `UIApplication.open` only when the navigation channel reports the route as unhandled or no
+foreground engine becomes available. This plugin callback and a native `SDKConfigBuilder`
+`deepLinkCallback` cannot be combined because the native SDK has one callback slot.
 This replaces the native SDK's AppDelegate continuation fallback only in that UIScene configuration;
 set `FlutterDeepLinkingEnabled` to `false` when the host owns a different scene router.
 Applications that declare UIScene must use Flutter 3.44.8 or newer and use

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ APNs token registration, and the global notification-center delegate. Flutter's 
 UI activation callbacks. In UIScene hosts, the plugin passes Customer.io Live Activity URLs to the
 released native URL handler and leaves ordinary links and user activities to Flutter.
 AppDelegate-only hosts keep the existing manual URL handler described above.
+When UIScene and Flutter deep linking are enabled, the plugin also becomes the native SDK's
+deep-link callback during plugin registration. The native callback is synchronous but Flutter's
+routing result is asynchronous, so the plugin claims the handoff, offers the destination to Flutter,
+and uses `UIApplication.open` only if Flutter declines it or no foreground engine becomes available.
+This replaces the native SDK's AppDelegate continuation fallback only in that UIScene configuration;
+set `FlutterDeepLinkingEnabled` to `false` when the host owns a different scene router.
 Applications that declare UIScene must use Flutter 3.44.8 or newer and use
 `FlutterSceneDelegate`, or forward its lifecycle callbacks through Flutter's scene lifecycle
 provider. Customer.io cannot receive or diagnose callbacks that a custom scene delegate does not

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ AppDelegate-only hosts keep the existing manual URL handler described above.
 Applications that declare UIScene must use Flutter 3.44.8 or newer and use
 `FlutterSceneDelegate`, or forward its lifecycle callbacks through Flutter's scene lifecycle
 provider. Customer.io cannot receive or diagnose callbacks that a custom scene delegate does not
-forward. Flutter requires manual engine registration only when both multiple scenes are enabled
-and the target engine is not represented by the scene's root `FlutterViewController` during
-connection. That registration belongs in the host scene delegate because only it knows the scene
-and engine pairing. Older Flutter registrars log an error and leave scene routing unclaimed.
+forward. This release's compatibility scope is one simultaneous window scene, matching the native
+and Flutter samples' `UIApplicationSupportsMultipleScenes=false` configuration. Multiple
+simultaneous window scenes are not supported. Hosts that enable them retain ownership of Flutter's
+scene-to-engine registration and any window-specific routing. Older Flutter registrars log an error
+and leave scene routing unclaimed.
 
 # Contributing
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -110,8 +110,11 @@ For a UIScene host with Flutter deep linking enabled, the native plugin register
 `deepLinkCallback` as Flutter registers its plugins. This routes SDK-triggered push and in-app
 destinations, plus native-default inbox actions when no Dart inbox listener owns the action,
 through a foreground Flutter scene, including taps delivered before Dart calls
-`CustomerIO.initialize`. If Flutter declines the destination or no foreground engine becomes
-available, the plugin opens it with `UIApplication.open`.
+`CustomerIO.initialize`. This includes `http` and `https` destinations. Flutter's standard
+navigation APIs report delivered routes as handled, so the Dart router owns unknown-route and
+browser-opening policy. The plugin uses `UIApplication.open` only when the navigation channel
+reports the route as unhandled or no foreground engine becomes available. Do not also configure a
+native `SDKConfigBuilder.deepLinkCallback`; the native SDK exposes one callback slot.
 AppDelegate-only hosts keep their existing handoff, and setting `FlutterDeepLinkingEnabled` to
 `false` leaves routing with the host.
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -107,8 +107,9 @@ Customer.io tracking URL with `CustomerIOLiveActivities.handleWidgetUrl` before 
 result to its custom router.
 
 For a UIScene host with Flutter deep linking enabled, the native plugin registers Customer.io's
-`deepLinkCallback` as Flutter registers its plugins. This routes SDK-triggered push, in-app, and
-inbox destinations through a foreground Flutter scene, including taps delivered before Dart calls
+`deepLinkCallback` as Flutter registers its plugins. This routes SDK-triggered push and in-app
+destinations, plus native-default inbox actions when no Dart inbox listener owns the action,
+through a foreground Flutter scene, including taps delivered before Dart calls
 `CustomerIO.initialize`. If Flutter declines the destination or no foreground engine becomes
 available, the plugin opens it with `UIApplication.open`.
 AppDelegate-only hosts keep their existing handoff, and setting `FlutterDeepLinkingEnabled` to

--- a/apps/README.md
+++ b/apps/README.md
@@ -115,8 +115,7 @@ available, the plugin opens it with `UIApplication.open`.
 AppDelegate-only hosts keep their existing handoff, and setting `FlutterDeepLinkingEnabled` to
 `false` leaves routing with the host.
 
-An SDK-triggered destination does not carry a source `UIScene`. When more than one Flutter scene is
-foregrounded, the plugin prefers an active key window and otherwise makes a deterministic
-best-effort selection to avoid dropping the URL, but that defensive behavior is not a multi-window
-support guarantee. Customer.io cannot guarantee which window receives an SDK-triggered destination
-when the host enables multiple simultaneous window scenes.
+An SDK-triggered destination does not carry a source `UIScene`. Within the supported one-window
+scope, the plugin routes it through the foreground application scene. Hosts that enable multiple
+simultaneous window scenes own scene-to-engine routing; which window receives an SDK-triggered
+destination is unspecified.

--- a/apps/README.md
+++ b/apps/README.md
@@ -105,3 +105,10 @@ Automatic UIScene redirect delivery uses Flutter's standard deep-link handling. 
 sets `FlutterDeepLinkingEnabled` to `false` keeps its existing lifecycle handler and resolves the
 Customer.io tracking URL with `CustomerIOLiveActivities.handleWidgetUrl` before forwarding the
 result to its custom router.
+
+For a UIScene host with Flutter deep linking enabled, the plugin also registers the native
+Customer.io `deepLinkCallback` during SDK initialization. This routes SDK-triggered push, in-app,
+and inbox destinations through a foreground Flutter scene. If Flutter declines the destination or
+no foreground engine becomes available, the plugin opens it with `UIApplication.open`.
+AppDelegate-only hosts keep their existing handoff, and setting `FlutterDeepLinkingEnabled` to
+`false` leaves routing with the host.

--- a/apps/README.md
+++ b/apps/README.md
@@ -91,10 +91,10 @@ topology key is required. `CioAppDelegateWrapper` continues to own SDK initializ
 registration, and notification-center callbacks in both modes. The standard Flutter
 `SceneDelegate` owns the host scene, while the Customer.io plugin registers its own scene adapter
 with each supported Flutter engine. A custom scene delegate must provide the equivalent Flutter
-scene lifecycle forwarding. Flutter requires manual registration only when multiple scenes are
-enabled and the target engine is not represented by the scene's root `FlutterViewController`
-during connection; the host scene delegate owns that scene-to-engine association. Do not add a
-second Customer.io URL handler to the scene delegate. AppDelegate-only samples keep their existing
+scene lifecycle forwarding. This release's compatibility scope is one simultaneous window scene,
+and both scene fixtures set `UIApplicationSupportsMultipleScenes=false`. Multiple simultaneous
+window scenes are not supported and remain host-owned. Do not add a second Customer.io URL handler
+to the scene delegate. AppDelegate-only samples keep their existing
 `application(_:open:options:)` handler unchanged.
 
 When upgrading an existing UIScene app that manually calls
@@ -117,5 +117,6 @@ AppDelegate-only hosts keep their existing handoff, and setting `FlutterDeepLink
 
 An SDK-triggered destination does not carry a source `UIScene`. When more than one Flutter scene is
 foregrounded, the plugin prefers an active key window and otherwise makes a deterministic
-best-effort selection. Hosts that require a specific window to own SDK-triggered navigation should
-set `FlutterDeepLinkingEnabled` to `false` and route the destination themselves.
+best-effort selection to avoid dropping the URL, but that defensive behavior is not a multi-window
+support guarantee. Customer.io cannot guarantee which window receives an SDK-triggered destination
+when the host enables multiple simultaneous window scenes.

--- a/apps/README.md
+++ b/apps/README.md
@@ -106,9 +106,15 @@ sets `FlutterDeepLinkingEnabled` to `false` keeps its existing lifecycle handler
 Customer.io tracking URL with `CustomerIOLiveActivities.handleWidgetUrl` before forwarding the
 result to its custom router.
 
-For a UIScene host with Flutter deep linking enabled, the plugin also registers the native
-Customer.io `deepLinkCallback` during SDK initialization. This routes SDK-triggered push, in-app,
-and inbox destinations through a foreground Flutter scene. If Flutter declines the destination or
-no foreground engine becomes available, the plugin opens it with `UIApplication.open`.
+For a UIScene host with Flutter deep linking enabled, the native plugin registers Customer.io's
+`deepLinkCallback` as Flutter registers its plugins. This routes SDK-triggered push, in-app, and
+inbox destinations through a foreground Flutter scene, including taps delivered before Dart calls
+`CustomerIO.initialize`. If Flutter declines the destination or no foreground engine becomes
+available, the plugin opens it with `UIApplication.open`.
 AppDelegate-only hosts keep their existing handoff, and setting `FlutterDeepLinkingEnabled` to
 `false` leaves routing with the host.
+
+An SDK-triggered destination does not carry a source `UIScene`. When more than one Flutter scene is
+foregrounded, the plugin prefers an active key window and otherwise makes a deterministic
+best-effort selection. Hosts that require a specific window to own SDK-triggered navigation should
+set `FlutterDeepLinkingEnabled` to `false` and route the destination themselves.

--- a/apps/flutter_sample_cocoapods/ios/Podfile
+++ b/apps/flutter_sample_cocoapods/ios/Podfile
@@ -71,7 +71,7 @@ target 'LiveActivityWidget' do
   # A widget extension cannot link the Flutter plugin pod, so it names the rendering pods itself.
   # Keep the version in step with pubspec.yaml's native_sdk_version.
   %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
-    pod cio_pod, '4.7.5'
+    pod cio_pod, '4.7.6'
   end
 end
 

--- a/apps/flutter_sample_cocoapods/ios/Runner/AppDelegate.swift
+++ b/apps/flutter_sample_cocoapods/ios/Runner/AppDelegate.swift
@@ -91,7 +91,7 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
 //        MessagingPush.shared.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
     }
     
-    // IMPORTANT: This method is necessary to have CIO deep linking working!
+    // IMPORTANT: This method is necessary for CIO deep linking in AppDelegate-only mode.
     // Putting `return false` in the body is sufficient, as this is an indicator for the CIO SDK to forward the link to iOS for processing.
     // This will open the browser or the associated app.
     // If this method is not overriden, default Flutter's deep link processing will just discard CIO deep links.

--- a/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
@@ -968,7 +968,7 @@
 			repositoryURL = "https://github.com/customerio/customerio-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 4.7.5;
+				version = 4.7.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/apps/flutter_sample_spm/ios/Runner/AppDelegate.swift
+++ b/apps/flutter_sample_spm/ios/Runner/AppDelegate.swift
@@ -91,7 +91,7 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
 //        MessagingPush.shared.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
     }
     
-    // IMPORTANT: This method is necessary to have CIO deep linking working!
+    // IMPORTANT: This method is necessary for CIO deep linking in AppDelegate-only mode.
     // Putting `return false` in the body is sufficient, as this is an indicator for the CIO SDK to forward the link to iOS for processing.
     // This will open the browser or the associated app.
     // If this method is not overriden, default Flutter's deep link processing will just discard CIO deep links.

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -139,7 +139,7 @@ let package = Package(
     dependencies: [
         // Pinned exactly, matching `native_sdk_version` in pubspec.yaml and the podspec, so one
         // plugin version always resolves one native SDK across every package manager.
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.7.5"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.7.6"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -198,6 +198,13 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
             // Initialize native SDK with provided config
             let sdkConfigBuilder = try SDKConfigBuilder.create(from: params)
 
+            if lifecycleHandler.shouldRegisterSDKDeepLinkCallback {
+                _ = sdkConfigBuilder.deepLinkCallback { [lifecycleHandler] url in
+                    lifecycleHandler.handleSDKDeepLink(url)
+                    return true
+                }
+            }
+
             #if canImport(CioLocation)
             let locationConfig = params["location"] as? [String: AnyHashable]
             #if canImport(CioLocationGeofence)

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -71,6 +71,9 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
 
         DIGraphShared.shared.deepLinkUtil.setDeepLinkCallback { [lifecycleHandler] url in
             lifecycleHandler.handleSDKDeepLink(url)
+            // The native callback is synchronous, while Flutter reports its routing result
+            // asynchronously. Claim this handoff once; the Flutter router owns the final system-
+            // open fallback so the native SDK does not run a second fallback at the same time.
             return true
         }
     }

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -69,6 +69,9 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
         let lifecycleHandler = instance.lifecycleHandler
         guard lifecycleHandler.shouldRegisterSDKDeepLinkCallback else { return }
 
+        DIGraphShared.shared.logger.info(
+            "Customer.io is routing SDK deep links through Flutter"
+        )
         DIGraphShared.shared.deepLinkUtil.setDeepLinkCallback { [lifecycleHandler] url in
             lifecycleHandler.handleSDKDeepLink(url)
             // The native callback is synchronous, while Flutter reports its routing result

--- a/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
+++ b/ios/customer_io/Sources/customer_io/CustomerIOPlugin.swift
@@ -1,5 +1,5 @@
 import CioDataPipelines
-import CioInternalCommon
+@_spi(Internal) import CioInternalCommon
 import CioMessagingInApp
 import Flutter
 import UIKit
@@ -33,6 +33,7 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
         registrar.addMethodCallDelegate(instance, channel: instance.methodChannel)
 
         registerSceneDelegateIfSupported(instance, with: registrar)
+        registerSDKDeepLinkCallbackIfNeeded(instance)
 
         instance.inAppMessagingChannelHandler = CustomerIOInAppMessaging(with: registrar)
         #if canImport(CioLocation)
@@ -60,6 +61,18 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
             return
         }
         _ = registrar.perform(selector, with: instance.lifecycleHandler)
+    }
+
+    /// Install the callback while Flutter registers its native plugins. A cold push tap can reach
+    /// the native SDK before Dart calls `CustomerIO.initialize`, so initialization is too late.
+    private static func registerSDKDeepLinkCallbackIfNeeded(_ instance: CustomerIOPlugin) {
+        let lifecycleHandler = instance.lifecycleHandler
+        guard lifecycleHandler.shouldRegisterSDKDeepLinkCallback else { return }
+
+        DIGraphShared.shared.deepLinkUtil.setDeepLinkCallback { [lifecycleHandler] url in
+            lifecycleHandler.handleSDKDeepLink(url)
+            return true
+        }
     }
 
     deinit {
@@ -197,13 +210,6 @@ public class CustomerIOPlugin: NSObject, FlutterPlugin {
             CustomerIOSdkClient.configure(using: params)
             // Initialize native SDK with provided config
             let sdkConfigBuilder = try SDKConfigBuilder.create(from: params)
-
-            if lifecycleHandler.shouldRegisterSDKDeepLinkCallback {
-                _ = sdkConfigBuilder.deepLinkCallback { [lifecycleHandler] url in
-                    lifecycleHandler.handleSDKDeepLink(url)
-                    return true
-                }
-            }
 
             #if canImport(CioLocation)
             let locationConfig = params["location"] as? [String: AnyHashable]

--- a/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterDeepLinkRouter.swift
+++ b/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterDeepLinkRouter.swift
@@ -21,8 +21,8 @@ final class CustomerIOFlutterDeepLinkRouter {
     /// Delivers an SDK-triggered destination to an eligible foreground Flutter scene. If Flutter
     /// declines it or no scene becomes eligible, the destination is opened through UIKit.
     func routeSDKDeepLink(_ url: URL) {
-        DispatchQueue.main.async { [url] in
-            self.routeSDKDeepLink(url, remainingAttempts: Self.readinessAttempts)
+        DispatchQueue.main.async { [weak self, url] in
+            self?.routeSDKDeepLink(url, remainingAttempts: Self.readinessAttempts)
         }
     }
 
@@ -39,8 +39,8 @@ final class CustomerIOFlutterDeepLinkRouter {
                 openExternally(url)
                 return
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + Self.retryInterval) { [url] in
-                self.routeSDKDeepLink(url, remainingAttempts: remainingAttempts - 1)
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.retryInterval) { [weak self, url] in
+                self?.routeSDKDeepLink(url, remainingAttempts: remainingAttempts - 1)
             }
             return
         }

--- a/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterDeepLinkRouter.swift
+++ b/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterDeepLinkRouter.swift
@@ -21,8 +21,8 @@ final class CustomerIOFlutterDeepLinkRouter {
     /// Delivers an SDK-triggered destination to an eligible foreground Flutter scene. If Flutter
     /// declines it or no scene becomes eligible, the destination is opened through UIKit.
     func routeSDKDeepLink(_ url: URL) {
-        DispatchQueue.main.async { [url] in
-            self.routeSDKDeepLink(url, remainingAttempts: Self.readinessAttempts)
+        DispatchQueue.main.async { [weak self, url] in
+            self?.routeSDKDeepLink(url, remainingAttempts: Self.readinessAttempts)
         }
     }
 
@@ -39,17 +39,17 @@ final class CustomerIOFlutterDeepLinkRouter {
                 openExternally(url)
                 return
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + Self.retryInterval) { [url] in
-                self.routeSDKDeepLink(url, remainingAttempts: remainingAttempts - 1)
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.retryInterval) { [weak self, url] in
+                self?.routeSDKDeepLink(url, remainingAttempts: remainingAttempts - 1)
             }
             return
         }
 
-        deliver(url, to: viewController) {
+        deliver(url, to: viewController) { [weak self] in
             DIGraphShared.shared.logger.info(
                 "Customer.io is opening an SDK deep link externally because Flutter did not handle it"
             )
-            self.openExternally(url)
+            self?.openExternally(url)
         }
     }
 
@@ -94,39 +94,18 @@ final class CustomerIOFlutterDeepLinkRouter {
     private func applicationFlutterViewController(
         useHiddenFallback: Bool
     ) -> FlutterViewController? {
-        let foregroundScenes = UIApplication.shared.connectedScenes
+        let windowScenes = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
-            .filter {
-                $0.activationState == .foregroundActive ||
-                    $0.activationState == .foregroundInactive
-            }
-            .sorted {
-                $0.session.persistentIdentifier < $1.session.persistentIdentifier
+            .filter { $0.session.role == .windowApplication }
+        let candidates = [UIScene.ActivationState.foregroundActive, .foregroundInactive]
+            .flatMap { activationState in
+                windowScenes
+                    .filter { $0.activationState == activationState }
+                    .flatMap(sceneFlutterViewControllers)
             }
 
-        for activationState in [UIScene.ActivationState.foregroundActive, .foregroundInactive] {
-            let candidates = foregroundScenes
-                .filter { $0.activationState == activationState }
-                .flatMap(sceneFlutterViewControllers)
-
-            if let keyController = candidates.first(where: {
-                $0.isDisplayingFlutterUI && $0.viewIfLoaded?.window?.isKeyWindow == true
-            }) {
-                return keyController
-            }
-            if let displayingController = candidates.first(where: \.isDisplayingFlutterUI) {
-                return displayingController
-            }
-            if useHiddenFallback,
-               let hiddenController = candidates.first(where: {
-                   $0.viewIfLoaded?.window?.isKeyWindow == true
-               }) ?? candidates.first
-            {
-                return hiddenController
-            }
-        }
-
-        return nil
+        return candidates.first(where: \.isDisplayingFlutterUI) ??
+            (useHiddenFallback ? candidates.first : nil)
     }
 
     @MainActor

--- a/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterDeepLinkRouter.swift
+++ b/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterDeepLinkRouter.swift
@@ -3,12 +3,12 @@ import Flutter
 import Foundation
 import UIKit
 
-/// Routes a URL through the first Flutter view controller displaying UI in the callback's scene,
-/// falling back to the scene's first Flutter controller after Flutter's first-frame wait expires.
+/// Routes URLs through Flutter view controllers displaying rendered UI. Cold callbacks wait up to
+/// three seconds for a controller; a foreground controller hidden by native UI is then eligible.
 ///
 /// Flutter bounds its own first-frame wait at three seconds when delivering an incoming deep link.
-/// Mirror that behavior because a cold UIScene callback can arrive before Dart has installed the
-/// navigation-channel handler; after that boundary, log rather than retaining a stale activation.
+/// Use the same boundary because a cold callback can arrive before Dart installs its navigation
+/// handler, without retaining a stale activation indefinitely.
 final class CustomerIOFlutterDeepLinkRouter {
     private static let retryInterval = 0.05
     private static let readinessAttempts = 60
@@ -16,6 +16,41 @@ final class CustomerIOFlutterDeepLinkRouter {
     @MainActor
     func route(_ url: URL, in scene: UIScene) {
         route(url, in: scene, remainingAttempts: Self.readinessAttempts)
+    }
+
+    /// Delivers an SDK-triggered destination to an eligible foreground Flutter scene. If Flutter
+    /// declines it or no scene becomes eligible, the destination is opened through UIKit.
+    func routeSDKDeepLink(_ url: URL) {
+        DispatchQueue.main.async { [url] in
+            self.routeSDKDeepLink(url, remainingAttempts: Self.readinessAttempts)
+        }
+    }
+
+    @MainActor
+    private func routeSDKDeepLink(_ url: URL, remainingAttempts: Int) {
+        let useHiddenFallback = remainingAttempts == 0
+        guard let viewController = applicationFlutterViewController(
+            useHiddenFallback: useHiddenFallback
+        ) else {
+            guard remainingAttempts > 0 else {
+                DIGraphShared.shared.logger.error(
+                    "Customer.io could not access a foreground Flutter engine for the SDK deep link"
+                )
+                openExternally(url)
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.retryInterval) { [url] in
+                self.routeSDKDeepLink(url, remainingAttempts: remainingAttempts - 1)
+            }
+            return
+        }
+
+        deliver(url, to: viewController) {
+            DIGraphShared.shared.logger.info(
+                "Customer.io is opening an SDK deep link externally because Flutter did not handle it"
+            )
+            self.openExternally(url)
+        }
     }
 
     @MainActor
@@ -38,12 +73,7 @@ final class CustomerIOFlutterDeepLinkRouter {
             return
         }
 
-        let navigationChannel = viewController.engine.navigationChannel
-        navigationChannel.invokeMethod(
-            "pushRouteInformation",
-            arguments: ["location": url.absoluteString]
-        ) { result in
-            guard (result as? NSNumber)?.boolValue != true else { return }
+        deliver(url, to: viewController) {
             DIGraphShared.shared.logger.error(
                 "Customer.io delivered the Live Activity redirect to Flutter, but the host did not handle it"
             )
@@ -61,10 +91,79 @@ final class CustomerIOFlutterDeepLinkRouter {
     }
 
     @MainActor
+    private func applicationFlutterViewController(
+        useHiddenFallback: Bool
+    ) -> FlutterViewController? {
+        let foregroundScenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter {
+                $0.activationState == .foregroundActive ||
+                    $0.activationState == .foregroundInactive
+            }
+            .sorted {
+                $0.session.persistentIdentifier < $1.session.persistentIdentifier
+            }
+
+        for activationState in [UIScene.ActivationState.foregroundActive, .foregroundInactive] {
+            let candidates = foregroundScenes
+                .filter { $0.activationState == activationState }
+                .flatMap(sceneFlutterViewControllers)
+
+            if let keyController = candidates.first(where: {
+                $0.isDisplayingFlutterUI && $0.viewIfLoaded?.window?.isKeyWindow == true
+            }) {
+                return keyController
+            }
+            if let displayingController = candidates.first(where: \.isDisplayingFlutterUI) {
+                return displayingController
+            }
+            if useHiddenFallback,
+               let hiddenController = candidates.first(where: {
+                    $0.viewIfLoaded?.window?.isKeyWindow == true
+               }) ?? candidates.first
+            {
+                return hiddenController
+            }
+        }
+
+        return nil
+    }
+
+    @MainActor
+    private func deliver(
+        _ url: URL,
+        to viewController: FlutterViewController,
+        onUnhandled: @escaping () -> Void
+    ) {
+        viewController.engine.navigationChannel.invokeMethod(
+            "pushRouteInformation",
+            arguments: ["location": url.absoluteString]
+        ) { result in
+            guard (result as? NSNumber)?.boolValue != true else { return }
+            onUnhandled()
+        }
+    }
+
+    @MainActor
+    private func openExternally(_ url: URL) {
+        UIApplication.shared.open(url) { opened in
+            guard !opened else { return }
+            DIGraphShared.shared.logger.error(
+                "Customer.io could not open the SDK deep link externally"
+            )
+        }
+    }
+
+    @MainActor
     private func sceneFlutterViewControllers(in scene: UIScene) -> [FlutterViewController] {
         guard let windowScene = scene as? UIWindowScene else { return [] }
 
-        var pending = windowScene.windows.compactMap(\.rootViewController)
+        return flutterViewControllers(from: windowScene.windows.compactMap(\.rootViewController))
+    }
+
+    @MainActor
+    private func flutterViewControllers(from roots: [UIViewController]) -> [FlutterViewController] {
+        var pending = roots
         var matches: [FlutterViewController] = []
         while !pending.isEmpty {
             let viewController = pending.removeFirst()

--- a/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterDeepLinkRouter.swift
+++ b/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterDeepLinkRouter.swift
@@ -21,8 +21,8 @@ final class CustomerIOFlutterDeepLinkRouter {
     /// Delivers an SDK-triggered destination to an eligible foreground Flutter scene. If Flutter
     /// declines it or no scene becomes eligible, the destination is opened through UIKit.
     func routeSDKDeepLink(_ url: URL) {
-        DispatchQueue.main.async { [weak self, url] in
-            self?.routeSDKDeepLink(url, remainingAttempts: Self.readinessAttempts)
+        DispatchQueue.main.async { [url] in
+            self.routeSDKDeepLink(url, remainingAttempts: Self.readinessAttempts)
         }
     }
 
@@ -39,8 +39,8 @@ final class CustomerIOFlutterDeepLinkRouter {
                 openExternally(url)
                 return
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + Self.retryInterval) { [weak self, url] in
-                self?.routeSDKDeepLink(url, remainingAttempts: remainingAttempts - 1)
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.retryInterval) { [url] in
+                self.routeSDKDeepLink(url, remainingAttempts: remainingAttempts - 1)
             }
             return
         }

--- a/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterDeepLinkRouter.swift
+++ b/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterDeepLinkRouter.swift
@@ -119,7 +119,7 @@ final class CustomerIOFlutterDeepLinkRouter {
             }
             if useHiddenFallback,
                let hiddenController = candidates.first(where: {
-                    $0.viewIfLoaded?.window?.isKeyWindow == true
+                   $0.viewIfLoaded?.window?.isKeyWindow == true
                }) ?? candidates.first
             {
                 return hiddenController
@@ -139,8 +139,10 @@ final class CustomerIOFlutterDeepLinkRouter {
             "pushRouteInformation",
             arguments: ["location": url.absoluteString]
         ) { result in
-            guard (result as? NSNumber)?.boolValue != true else { return }
-            onUnhandled()
+            guard CustomerIOURLRouting.didFlutterHandle(result) else {
+                onUnhandled()
+                return
+            }
         }
     }
 
@@ -163,18 +165,10 @@ final class CustomerIOFlutterDeepLinkRouter {
 
     @MainActor
     private func flutterViewControllers(from roots: [UIViewController]) -> [FlutterViewController] {
-        var pending = roots
-        var matches: [FlutterViewController] = []
-        while !pending.isEmpty {
-            let viewController = pending.removeFirst()
-            if let flutterViewController = viewController as? FlutterViewController {
-                matches.append(flutterViewController)
-            }
-            if let presented = viewController.presentedViewController {
-                pending.append(presented)
-            }
-            pending.append(contentsOf: viewController.children)
-        }
-        return matches
+        CustomerIOViewControllerTraversal.topmostFirst(
+            roots: roots,
+            presentedViewController: \.presentedViewController,
+            children: \.children
+        ).compactMap { $0 as? FlutterViewController }
     }
 }

--- a/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterLifecycle.swift
+++ b/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOFlutterLifecycle.swift
@@ -21,6 +21,10 @@ final class CustomerIOFlutterLifecycle: NSObject {
         #endif
     }
 
+    var shouldRegisterSDKDeepLinkCallback: Bool {
+        usesUIScene && usesFlutterDeepLinking
+    }
+
     private let deepLinkRouter = CustomerIOFlutterDeepLinkRouter()
 
     override init() {
@@ -32,6 +36,10 @@ final class CustomerIOFlutterLifecycle: NSObject {
         )
         usesFlutterDeepLinking = CustomerIOURLRouting.isFlutterDeepLinkingEnabled(configuredValue)
         super.init()
+    }
+
+    func handleSDKDeepLink(_ url: URL) {
+        deepLinkRouter.routeSDKDeepLink(url)
     }
 
     func reportUnavailableSceneRegistration() {

--- a/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOURLRouting.swift
+++ b/ios/customer_io/Sources/customer_io/Lifecycle/CustomerIOURLRouting.swift
@@ -49,6 +49,36 @@ enum CustomerIOURLRouting {
             !hasShortcut &&
             !hasNotificationResponse
     }
+
+    static func didFlutterHandle(_ result: Any?) -> Bool {
+        (result as? NSNumber)?.boolValue == true
+    }
+}
+
+enum CustomerIOViewControllerTraversal {
+    static func topmostFirst<Node: AnyObject>(
+        roots: [Node],
+        presentedViewController: (Node) -> Node?,
+        children: (Node) -> [Node]
+    ) -> [Node] {
+        var visited = Set<ObjectIdentifier>()
+        var ordered: [Node] = []
+
+        func visit(_ node: Node) {
+            guard visited.insert(ObjectIdentifier(node)).inserted else { return }
+
+            if let presented = presentedViewController(node) {
+                visit(presented)
+            }
+            for child in children(node).reversed() {
+                visit(child)
+            }
+            ordered.append(node)
+        }
+
+        roots.forEach(visit)
+        return ordered
+    }
 }
 
 /// Flutter can forward one UIKit occurrence through more than one engine's plugin chain. Cache the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.7.5
+        native_sdk_version: 4.7.6
         firebase_wrapper_version: 1.0.0

--- a/test/ios27_lifecycle/swift/CustomerIOURLRoutingBehaviorTests.swift
+++ b/test/ios27_lifecycle/swift/CustomerIOURLRoutingBehaviorTests.swift
@@ -2,6 +2,16 @@ import Foundation
 
 private final class Occurrence {}
 
+private final class ViewControllerNode {
+    let name: String
+    var presentedViewController: ViewControllerNode?
+    var children: [ViewControllerNode] = []
+
+    init(_ name: String) {
+        self.name = name
+    }
+}
+
 @main
 enum CustomerIOURLRoutingBehaviorTests {
     @MainActor
@@ -9,6 +19,8 @@ enum CustomerIOURLRoutingBehaviorTests {
         testFlutterDeepLinkingConfiguration()
         testRoutingResolution()
         testColdConnectionOwnership()
+        testFlutterDeliveryResult()
+        testTopmostViewControllerTraversal()
         testOccurrenceDeduplication()
         print("CustomerIOURLRoutingBehaviorTests passed")
     }
@@ -116,6 +128,46 @@ enum CustomerIOURLRoutingBehaviorTests {
                 "mixed or ambiguous connection options must remain unclaimed"
             )
         }
+    }
+
+    private static func testFlutterDeliveryResult() {
+        expect(
+            CustomerIOURLRouting.didFlutterHandle(NSNumber(value: true)),
+            "a true Flutter result must consume the destination"
+        )
+        expect(
+            !CustomerIOURLRouting.didFlutterHandle(NSNumber(value: false)),
+            "a false Flutter result must use the native fallback"
+        )
+        expect(
+            !CustomerIOURLRouting.didFlutterHandle(nil),
+            "a missing Flutter result must use the native fallback"
+        )
+    }
+
+    private static func testTopmostViewControllerTraversal() {
+        let underlyingFlutter = ViewControllerNode("underlying Flutter")
+        let container = ViewControllerNode("container")
+        let presentedFlutter = ViewControllerNode("presented Flutter")
+
+        container.children = [underlyingFlutter]
+        container.presentedViewController = presentedFlutter
+        // UIKit may expose an ancestor's presented controller through its descendants.
+        underlyingFlutter.presentedViewController = presentedFlutter
+
+        let ordered = CustomerIOViewControllerTraversal.topmostFirst(
+            roots: [container],
+            presentedViewController: \.presentedViewController,
+            children: \.children
+        )
+        expect(
+            ordered.map(\.name) == ["presented Flutter", "underlying Flutter", "container"],
+            "the topmost controller must be considered before the underlying Flutter engine"
+        )
+        expect(
+            ordered.filter { $0 === presentedFlutter }.count == 1,
+            "a presented controller reachable through an ancestor and child must be visited once"
+        )
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- register the native SDK deep-link callback during Flutter plugin registration for UIScene hosts using Flutter routing, including cold taps before Dart initialization
- deliver SDK push and in-app destinations, plus native-default inbox destinations when no Dart inbox listener owns the action, to the foreground/topmost Flutter engine
- preserve AppDelegate-only hosts, `FlutterDeepLinkingEnabled=false` custom routing, Live Activity attribution, and APN/FCM coexistence
- bound cold-start readiness to three seconds, use the topmost eligible Flutter UI, and fall back to `UIApplication.open` when Flutter declines or no engine becomes available
- pin every Flutter iOS integration path to the published Customer.io iOS SDK 4.7.6

## Validation

- focused Swift routing behavior tests
- `flutter analyze --no-fatal-infos`
- `flutter test` (111 passed)
- SwiftFormat lint and `git diff --check`
- clean exact-head SwiftPM iOS sample build against 4.7.6
- clean exact-head CocoaPods resolve, deployment-target audit, and iOS sample build against 4.7.6
- hosted exact-head lint, tests, API/publish checks, SwiftPM iOS sample build, and Android sample builds
- hosted CocoaPods iOS sample rerun is queued for a macOS 26 runner; the identical clean local resolve, target audit, and build passed
- fresh exact-head Claude Opus review: APPROVE
- independent exact-head review: APPROVE

Physical-device APNs/FCM delivery and tap evidence remains tracked separately in MBL-2233.

Linear: MBL-2277

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core iOS deep-link and push/in-app navigation handoff for UIScene + Flutter hosts; mis-routing could affect cold-start taps or conflict with hosts that set their own native deep-link callback.
> 
> **Overview**
> For **UIScene apps with Flutter deep linking enabled**, the iOS plugin now installs the native Customer.io **`deepLinkCallback` at plugin registration** (so cold push/in-app taps work before Dart `CustomerIO.initialize`). Destinations—including `http`/`https`—go to the **foreground/topmost Flutter engine** via `pushRouteInformation`; the plugin only falls back to **`UIApplication.open`** when Flutter reports unhandled or no engine appears within the existing ~3s readiness window.
> 
> Routing logic is refactored around shared **delivery + view-controller traversal** (`didFlutterHandle`, topmost-first search). **AppDelegate-only** hosts and **`FlutterDeepLinkingEnabled=false`** are unchanged; docs clarify this path **replaces** the native AppDelegate continuation fallback and **cannot coexist** with a custom `SDKConfigBuilder.deepLinkCallback`. Compatibility is explicitly **single window scene** only.
> 
> Pins the bundled **customerio-ios SDK to 4.7.6** (pubspec, SPM, CocoaPods samples) and adds Swift behavior tests for Flutter handle results and traversal order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9db5dca6fd002bf302d27e1887e0f8259ffe28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->