### PR TITLE
ci: add fast and full PR validation lanes

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -19,6 +19,7 @@ runs:
     uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # v2.19.0
     with:
       channel: stable
+      cache: true
 
   - name: Install exact stable Flutter
     if: inputs.flutter-version != ''
@@ -26,6 +27,7 @@ runs:
     with:
       channel: stable
       flutter-version: ${{ inputs.flutter-version }}
+      cache: true
 
   - run: flutter --version
     shell: bash

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -19,7 +19,6 @@ runs:
     uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # v2.19.0
     with:
       channel: stable
-      cache: true
 
   - name: Install exact stable Flutter
     if: inputs.flutter-version != ''
@@ -27,7 +26,6 @@ runs:
     with:
       channel: stable
       flutter-version: ${{ inputs.flutter-version }}
-      cache: true
 
   - run: flutter --version
     shell: bash

--- a/.github/scripts/validate-release-policy.sh
+++ b/.github/scripts/validate-release-policy.sh
@@ -55,9 +55,15 @@ while IFS= read -r -d '' commit_message; do
   fi
 done < "$commit_messages_file"
 
+full_validation=false
+requires_full_label=false
+
+if [[ "$pr_release" == 'true' || "$commit_release" == 'true' || "${CI_FULL:-false}" == 'true' ]]; then
+  full_validation=true
+fi
+
 if [[ "$commit_release" == 'true' && "$pr_release" != 'true' && "${CI_FULL:-false}" != 'true' ]]; then
-  echo "::error::This PR contains a release-bearing commit, but its PR title/body is non-release. Retitle it with fix:, feat:, perf:, revert:, or a breaking-change marker, or apply ci:full, so release validation runs before merge."
-  exit 1
+  requires_full_label=true
 fi
 
 if [[ ("$pr_release" == 'true' || "$commit_release" == 'true') && ("$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]') ]]; then
@@ -65,4 +71,17 @@ if [[ ("$pr_release" == 'true' || "$commit_release" == 'true') && ("$HEAD_REPOSI
   exit 1
 fi
 
-echo "Release validation policy satisfied (pr_release=$pr_release, commit_release=$commit_release)."
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "pr_release=$pr_release"
+    echo "commit_release=$commit_release"
+    echo "full_validation=$full_validation"
+    echo "requires_full_label=$requires_full_label"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+if [[ "$requires_full_label" == 'true' ]]; then
+  echo "::notice::A release-bearing commit was detected behind a non-release PR title. The semantic PR helper will apply ci:full automatically."
+fi
+
+echo "Release validation policy satisfied (pr_release=$pr_release, commit_release=$commit_release, full_validation=$full_validation)."

--- a/.github/scripts/validate-release-policy.sh
+++ b/.github/scripts/validate-release-policy.sh
@@ -66,7 +66,9 @@ if [[ "$commit_release" == 'true' && "$pr_release" != 'true' && "${CI_FULL:-fals
   requires_full_label=true
 fi
 
-if [[ ("$pr_release" == 'true' || "$commit_release" == 'true') && ("$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]') ]]; then
+if [[ "${ENFORCE_TRUSTED_RELEASE:-true}" == 'true' &&
+  ("$pr_release" == 'true' || "$commit_release" == 'true') &&
+  ("$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]') ]]; then
   echo "::error::Release-bearing PRs require secret-dependent validation from a trusted repository branch. Recreate or update this change on an internal branch before merge."
   exit 1
 fi

--- a/.github/scripts/validate-release-policy.sh
+++ b/.github/scripts/validate-release-policy.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PR_TITLE:?PR_TITLE is required}"
+: "${BASE_SHA:?BASE_SHA is required}"
+: "${HEAD_SHA:?HEAD_SHA is required}"
+: "${HEAD_REPOSITORY:?HEAD_REPOSITORY is required}"
+: "${TARGET_REPOSITORY:?TARGET_REPOSITORY is required}"
+: "${PR_AUTHOR:?PR_AUTHOR is required}"
+
+is_release_message() {
+  local message="$1"
+  local header
+  header=$(sed -n '/[^[:space:]]/{p;q;}' <<< "$message")
+
+  case "$header" in
+    fix:*|fix\(*|feat:*|feat\(*|perf:*|perf\(*|revert:*|revert\(*|Revert\ \"*)
+      return 0
+      ;;
+  esac
+
+  if grep -Eq '^[[:alpha:]]+(\([^)]*\))?!:' <<< "$header"; then
+    return 0
+  fi
+
+  if grep -Eq '(^|[[:space:]])(BREAKING CHANGES?:|BREAKING-CHANGE:)' <<< "$message"; then
+    return 0
+  fi
+
+  if grep -Eq '(^|[[:space:]])This reverts commit[[:space:]]' <<< "$message"; then
+    return 0
+  fi
+
+  return 1
+}
+
+pr_message="$PR_TITLE"$'\n\n'"${PR_BODY:-}"
+pr_release=false
+commit_release=false
+
+if is_release_message "$pr_message"; then
+  pr_release=true
+fi
+
+git cat-file -e "$BASE_SHA^{commit}"
+git cat-file -e "$HEAD_SHA^{commit}"
+commit_messages_file=$(mktemp)
+trap 'rm -f "$commit_messages_file"' EXIT
+git log --format='%B%x00' "$BASE_SHA..$HEAD_SHA" > "$commit_messages_file"
+
+while IFS= read -r -d '' commit_message; do
+  if is_release_message "$commit_message"; then
+    commit_release=true
+    break
+  fi
+done < "$commit_messages_file"
+
+if [[ "$commit_release" == 'true' && "$pr_release" != 'true' && "${CI_FULL:-false}" != 'true' ]]; then
+  echo "::error::This PR contains a release-bearing commit, but its PR title/body is non-release. Retitle it with fix:, feat:, perf:, revert:, or a breaking-change marker, or apply ci:full, so release validation runs before merge."
+  exit 1
+fi
+
+if [[ ("$pr_release" == 'true' || "$commit_release" == 'true') && ("$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]') ]]; then
+  echo "::error::Release-bearing PRs require secret-dependent validation from a trusted repository branch. Recreate or update this change on an internal branch before merge."
+  exit 1
+fi
+
+echo "Release validation policy satisfied (pr_release=$pr_release, commit_release=$commit_release)."

--- a/.github/scripts/validate-release-policy.sh
+++ b/.github/scripts/validate-release-policy.sh
@@ -4,10 +4,6 @@ set -euo pipefail
 : "${PR_TITLE:?PR_TITLE is required}"
 : "${BASE_SHA:?BASE_SHA is required}"
 : "${HEAD_SHA:?HEAD_SHA is required}"
-: "${HEAD_REPOSITORY:?HEAD_REPOSITORY is required}"
-: "${TARGET_REPOSITORY:?TARGET_REPOSITORY is required}"
-: "${PR_AUTHOR:?PR_AUTHOR is required}"
-
 is_release_message() {
   local message="$1"
   local header
@@ -34,11 +30,10 @@ is_release_message() {
   return 1
 }
 
-pr_message="$PR_TITLE"$'\n\n'"${PR_BODY:-}"
 pr_release=false
 commit_release=false
 
-if is_release_message "$pr_message"; then
+if is_release_message "$PR_TITLE"; then
   pr_release=true
 fi
 
@@ -56,21 +51,9 @@ while IFS= read -r -d '' commit_message; do
 done < "$commit_messages_file"
 
 full_validation=false
-requires_full_label=false
 
 if [[ "$pr_release" == 'true' || "$commit_release" == 'true' || "${CI_FULL:-false}" == 'true' ]]; then
   full_validation=true
-fi
-
-if [[ "$commit_release" == 'true' && "$pr_release" != 'true' && "${CI_FULL:-false}" != 'true' ]]; then
-  requires_full_label=true
-fi
-
-if [[ "${ENFORCE_TRUSTED_RELEASE:-true}" == 'true' &&
-  ("$pr_release" == 'true' || "$commit_release" == 'true') &&
-  ("$HEAD_REPOSITORY" != "$TARGET_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]') ]]; then
-  echo "::error::Release-bearing PRs require secret-dependent validation from a trusted repository branch. Recreate or update this change on an internal branch before merge."
-  exit 1
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
@@ -78,12 +61,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "pr_release=$pr_release"
     echo "commit_release=$commit_release"
     echo "full_validation=$full_validation"
-    echo "requires_full_label=$requires_full_label"
   } >> "$GITHUB_OUTPUT"
 fi
 
-if [[ "$requires_full_label" == 'true' ]]; then
-  echo "::notice::A release-bearing commit was detected behind a non-release PR title. The semantic PR helper will apply ci:full automatically."
-fi
-
-echo "Release validation policy satisfied (pr_release=$pr_release, commit_release=$commit_release, full_validation=$full_validation)."
+echo "Distribution policy classified (pr_release=$pr_release, commit_release=$commit_release, full_validation=$full_validation)."

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -81,6 +81,7 @@ jobs:
       sample_app_name: flutter_sample_cocoapods
       cio_workspace_name: "Mobile: Flutter"
       should_distribute: ${{ github.event_name == 'push' }}
+      build_android_app: false
     secrets: inherit
 
   update-pr-comment-after-apps-built:
@@ -114,3 +115,23 @@ jobs:
           body: |
             * flutter_sample_spm: Build failed. See [CI job logs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) to determine the issue and try re-building.
           edit-mode: append # append new line to the existing PR comment to build a list of all sample app builds.
+
+      - name: Report CocoaPods sample build success
+        if: ${{ needs.build-secondary-app.result == 'success' }}
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ needs.update-pr-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            * flutter_sample_cocoapods: Build succeeded.
+          edit-mode: append
+
+      - name: Report CocoaPods sample build failure
+        if: ${{ needs.build-secondary-app.result == 'failure' }}
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ needs.update-pr-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            * flutter_sample_cocoapods: Build failed. See [CI job logs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+          edit-mode: append

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -6,12 +6,11 @@ on:
     paths-ignore:
       - '**/*.md'
   push:
-    branches: [ main ]
-  workflow_dispatch:
+    branches: [ main, feature/* ]
 
 concurrency: # cancel previous workflow run if one exists.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.event.action == 'labeled' && github.event.label.name != 'ci:full') && github.run_id || 'validation' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   update-pr-comment:
@@ -64,6 +63,7 @@ jobs:
       cio_workspace_name: "Mobile: Flutter"
       is_primary_app: true
       should_distribute: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ci:full') && github.event.pull_request.head.repo.full_name == github.repository) }}
+      verification_only: ${{ github.event_name == 'pull_request' }}
     secrets: inherit
 
   # CocoaPods is retained on main and in the explicitly requested full PR lane.
@@ -81,7 +81,8 @@ jobs:
       sample_app_name: flutter_sample_cocoapods
       cio_workspace_name: "Mobile: Flutter"
       should_distribute: ${{ github.event_name == 'push' }}
-      build_android_app: false
+      build_android_app: ${{ github.event_name == 'push' }}
+      verification_only: ${{ github.event_name == 'pull_request' }}
     secrets: inherit
 
   update-pr-comment-after-apps-built:

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -9,7 +9,17 @@ on:
     branches: [ main, feature/* ]
 
 concurrency: # cancel previous workflow run if one exists.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Unrelated labels and body-only edits must not cancel an in-flight release or
+  # ci:full run. They share a separate group, where unsigned validation repeats.
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}-${{
+      github.event_name == 'pull_request' &&
+      ((github.event.action == 'labeled' && github.event.label.name != 'ci:full') ||
+      (github.event.action == 'edited' &&
+      github.event.changes.title.from == '' &&
+      github.event.changes.base.ref.from == '')) &&
+      'metadata' || 'validation'
+    }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/feature/') }}
 
 jobs:

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -1,17 +1,25 @@
 name: Build sample apps
 
 on:
-  pull_request: # build sample apps for every commit pushed to an open pull request (including drafts)
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths-ignore:
+      - '**/*.md'
   push:
-    branches: [ main, feature/* ]
+    branches: [ main ]
+  workflow_dispatch:
 
 concurrency: # cancel previous workflow run if one exists.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.event.action == 'labeled' && github.event.label.name != 'ci:full') && github.run_id || 'validation' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   update-pr-comment:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: >-
+      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'ci:full') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # to be able to comment on PR
@@ -39,12 +47,15 @@ jobs:
             Below you will find the list of the latest versions of the sample apps. It's recommended to always download the latest builds of the sample apps to accurately test the pull request.
 
             ---
-            ${{ steps.build.outputs.build-log }}
+            Builds are in progress. This comment will be updated when they finish.
           edit-mode: replace # replace the existing comment with new content since we are creating new builds
 
-  # Primary app (SPM) - builds on all PRs and pushes
+  # Keep one unsigned SPM compile smoke per platform on normal PRs. The
+  # distributable and redundant CocoaPods builds move to the `ci:full` lane.
   build-primary-app:
-    if: ${{ always() }} # do not skip running this step if update-pr-comment does not run
+    if: >-
+      always() &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ci:full')
     needs: [ update-pr-comment ] # wait for PR comment to be created saying new builds are being made.
     uses: ./.github/workflows/reusable-build-sample-apps.yml
     with:
@@ -52,12 +63,17 @@ jobs:
       sample_app_name: flutter_sample_spm
       cio_workspace_name: "Mobile: Flutter"
       is_primary_app: true
+      should_distribute: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ci:full') && github.event.pull_request.head.repo.full_name == github.repository) }}
     secrets: inherit
 
-  # Secondary app (CocoaPods) - builds on all PRs and pushes to verify CocoaPods compatibility
-  # Only distributes to Firebase on pushes, not on PRs
+  # CocoaPods is retained on main and in the explicitly requested full PR lane.
   build-secondary-app:
-    if: ${{ always() }}
+    if: >-
+      always() &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
+      (github.event_name != 'pull_request' ||
+      (contains(github.event.pull_request.labels.*.name, 'ci:full') &&
+      github.event.pull_request.head.repo.full_name == github.repository))
     needs: [ update-pr-comment ]
     uses: ./.github/workflows/reusable-build-sample-apps.yml
     with:
@@ -68,8 +84,13 @@ jobs:
     secrets: inherit
 
   update-pr-comment-after-apps-built:
-    if: always() && ${{ github.event_name == 'pull_request' }}
-    needs: [ update-pr-comment, build-primary-app ] # only wait for primary app since secondary doesn't build on PRs
+    if: >-
+      always() &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'ci:full') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    needs: [ update-pr-comment, build-primary-app, build-secondary-app ]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # to be able to comment on PR

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -2,23 +2,40 @@ name: Build sample apps
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, edited, labeled]
     paths-ignore:
       - '**/*.md'
   push:
     branches: [ main, feature/* ]
 
 concurrency: # cancel previous workflow run if one exists.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.event.action == 'labeled' && github.event.label.name != 'ci:full') && github.run_id || 'validation' }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/feature/') }}
 
 jobs:
+  # Metadata edits rerun full so a newer skipped check cannot replace a failure.
   update-pr-comment:
     if: >-
-      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'ci:full') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event.action == 'edited' ||
+      github.event.action == 'labeled' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      startsWith(github.event.pull_request.title, 'fix:') ||
+      startsWith(github.event.pull_request.title, 'fix(') ||
+      startsWith(github.event.pull_request.title, 'feat:') ||
+      startsWith(github.event.pull_request.title, 'feat(') ||
+      startsWith(github.event.pull_request.title, 'perf:') ||
+      startsWith(github.event.pull_request.title, 'perf(') ||
+      startsWith(github.event.pull_request.title, 'revert:') ||
+      startsWith(github.event.pull_request.title, 'revert(') ||
+      startsWith(github.event.pull_request.title, 'Revert "') ||
+      contains(github.event.pull_request.body, 'This reverts commit') ||
+      contains(github.event.pull_request.title, '!:') ||
+      contains(github.event.pull_request.body, 'BREAKING CHANGE:') ||
+      contains(github.event.pull_request.body, 'BREAKING CHANGES:') ||
+      contains(github.event.pull_request.body, 'BREAKING-CHANGE:')) &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # to be able to comment on PR
@@ -49,12 +66,10 @@ jobs:
             Builds are in progress. This comment will be updated when they finish.
           edit-mode: replace # replace the existing comment with new content since we are creating new builds
 
-  # Keep one unsigned SPM compile smoke per platform on normal PRs. The
-  # distributable and redundant CocoaPods builds move to the `ci:full` lane.
+  # Keep one unsigned SPM compile smoke per platform on normal PRs. A
+  # release-bearing title or `ci:full` adds distribution and CocoaPods coverage.
   build-primary-app:
-    if: >-
-      always() &&
-      (github.event.action != 'labeled' || github.event.label.name == 'ci:full')
+    if: always()
     needs: [ update-pr-comment ] # wait for PR comment to be created saying new builds are being made.
     uses: ./.github/workflows/reusable-build-sample-apps.yml
     with:
@@ -62,18 +77,32 @@ jobs:
       sample_app_name: flutter_sample_spm
       cio_workspace_name: "Mobile: Flutter"
       is_primary_app: true
-      should_distribute: ${{ github.event_name != 'pull_request' || (contains(github.event.pull_request.labels.*.name, 'ci:full') && github.event.pull_request.head.repo.full_name == github.repository) }}
-      verification_only: ${{ github.event_name == 'pull_request' }}
+      should_distribute: ${{ github.event_name != 'pull_request' || ((github.event.action == 'edited' || github.event.action == 'labeled' || contains(github.event.pull_request.labels.*.name, 'ci:full') || startsWith(github.event.pull_request.title, 'fix:') || startsWith(github.event.pull_request.title, 'fix(') || startsWith(github.event.pull_request.title, 'feat:') || startsWith(github.event.pull_request.title, 'feat(') || startsWith(github.event.pull_request.title, 'perf:') || startsWith(github.event.pull_request.title, 'perf(') || startsWith(github.event.pull_request.title, 'revert:') || startsWith(github.event.pull_request.title, 'revert(') || startsWith(github.event.pull_request.title, 'Revert "') || contains(github.event.pull_request.body, 'This reverts commit') || contains(github.event.pull_request.title, '!:') || contains(github.event.pull_request.body, 'BREAKING CHANGE:') || contains(github.event.pull_request.body, 'BREAKING CHANGES:') || contains(github.event.pull_request.body, 'BREAKING-CHANGE:')) && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
+      verification_only: ${{ github.event_name == 'pull_request' && !((github.event.action == 'edited' || github.event.action == 'labeled' || contains(github.event.pull_request.labels.*.name, 'ci:full') || startsWith(github.event.pull_request.title, 'fix:') || startsWith(github.event.pull_request.title, 'fix(') || startsWith(github.event.pull_request.title, 'feat:') || startsWith(github.event.pull_request.title, 'feat(') || startsWith(github.event.pull_request.title, 'perf:') || startsWith(github.event.pull_request.title, 'perf(') || startsWith(github.event.pull_request.title, 'revert:') || startsWith(github.event.pull_request.title, 'revert(') || startsWith(github.event.pull_request.title, 'Revert "') || contains(github.event.pull_request.body, 'This reverts commit') || contains(github.event.pull_request.title, '!:') || contains(github.event.pull_request.body, 'BREAKING CHANGE:') || contains(github.event.pull_request.body, 'BREAKING CHANGES:') || contains(github.event.pull_request.body, 'BREAKING-CHANGE:')) && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
     secrets: inherit
 
-  # CocoaPods is retained on main and in the explicitly requested full PR lane.
+  # CocoaPods is retained on main and automatically validates release-bearing PRs.
   build-secondary-app:
     if: >-
       always() &&
-      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
       (github.event_name != 'pull_request' ||
-      (contains(github.event.pull_request.labels.*.name, 'ci:full') &&
-      github.event.pull_request.head.repo.full_name == github.repository))
+      github.event.action == 'edited' ||
+      github.event.action == 'labeled' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      startsWith(github.event.pull_request.title, 'fix:') ||
+      startsWith(github.event.pull_request.title, 'fix(') ||
+      startsWith(github.event.pull_request.title, 'feat:') ||
+      startsWith(github.event.pull_request.title, 'feat(') ||
+      startsWith(github.event.pull_request.title, 'perf:') ||
+      startsWith(github.event.pull_request.title, 'perf(') ||
+      startsWith(github.event.pull_request.title, 'revert:') ||
+      startsWith(github.event.pull_request.title, 'revert(') ||
+      startsWith(github.event.pull_request.title, 'Revert "') ||
+      contains(github.event.pull_request.body, 'This reverts commit') ||
+      contains(github.event.pull_request.title, '!:') ||
+      contains(github.event.pull_request.body, 'BREAKING CHANGE:') ||
+      contains(github.event.pull_request.body, 'BREAKING CHANGES:') ||
+      contains(github.event.pull_request.body, 'BREAKING-CHANGE:'))
     needs: [ update-pr-comment ]
     uses: ./.github/workflows/reusable-build-sample-apps.yml
     with:
@@ -88,10 +117,26 @@ jobs:
   update-pr-comment-after-apps-built:
     if: >-
       always() &&
-      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'ci:full') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event.action == 'edited' ||
+      github.event.action == 'labeled' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      startsWith(github.event.pull_request.title, 'fix:') ||
+      startsWith(github.event.pull_request.title, 'fix(') ||
+      startsWith(github.event.pull_request.title, 'feat:') ||
+      startsWith(github.event.pull_request.title, 'feat(') ||
+      startsWith(github.event.pull_request.title, 'perf:') ||
+      startsWith(github.event.pull_request.title, 'perf(') ||
+      startsWith(github.event.pull_request.title, 'revert:') ||
+      startsWith(github.event.pull_request.title, 'revert(') ||
+      startsWith(github.event.pull_request.title, 'Revert "') ||
+      contains(github.event.pull_request.body, 'This reverts commit') ||
+      contains(github.event.pull_request.title, '!:') ||
+      contains(github.event.pull_request.body, 'BREAKING CHANGE:') ||
+      contains(github.event.pull_request.body, 'BREAKING CHANGES:') ||
+      contains(github.event.pull_request.body, 'BREAKING-CHANGE:')) &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     needs: [ update-pr-comment, build-primary-app, build-secondary-app ]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -16,8 +16,8 @@ concurrency: # cancel previous workflow run if one exists.
       github.event_name == 'pull_request' &&
       ((github.event.action == 'labeled' && github.event.label.name != 'ci:full') ||
       (github.event.action == 'edited' &&
-      github.event.changes.title.from == '' &&
-      github.event.changes.base.ref.from == '')) &&
+      !github.event.changes.title &&
+      !github.event.changes.base)) &&
       'metadata' || 'validation'
     }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/feature/') }}

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -20,22 +20,17 @@ jobs:
       contents: read
     with:
       pr_title: ${{ github.event.pull_request.title }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       base_sha: ${{ github.event.pull_request.base.sha }}
       head_sha: ${{ github.event.pull_request.head.sha }}
-      head_repository: ${{ github.event.pull_request.head.repo.full_name }}
-      target_repository: ${{ github.repository }}
-      pr_author: ${{ github.event.pull_request.user.login }}
       ci_full: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
 
-  # Metadata edits rerun full so a newer skipped check cannot replace a failure.
   update-pr-comment:
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
-      (github.event.action == 'edited' ||
-      github.event.action == 'labeled' ||
-      needs.release_policy.outputs.full_validation == 'true') &&
+      needs.release_policy.outputs.full_validation == 'true' &&
+      (github.event.action != 'edited' || github.event.changes.title.from != '') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     needs: release_policy
@@ -69,9 +64,11 @@ jobs:
             Builds are in progress. This comment will be updated when they finish.
           edit-mode: replace # replace the existing comment with new content since we are creating new builds
 
-  # Keep one unsigned SPM compile smoke per platform on normal PRs. A
-  # release-bearing title or `ci:full` adds distribution and CocoaPods coverage.
+  # Keep unsigned SPM compilation on every code PR. Release intent or ci:full
+  # changes only whether the same primary app is signed and distributed.
   build-primary-app:
+    # Fail closed on metadata events: an edited or unrelated-label run repeats
+    # unsigned verification instead of replacing a failed check with a skip.
     if: always()
     needs: [ release_policy, update-pr-comment ] # wait for PR comment to be created saying new builds are being made.
     uses: ./.github/workflows/reusable-build-sample-apps.yml
@@ -80,18 +77,14 @@ jobs:
       sample_app_name: flutter_sample_spm
       cio_workspace_name: "Mobile: Flutter"
       is_primary_app: true
-      should_distribute: ${{ github.event_name != 'pull_request' || ((github.event.action == 'edited' || github.event.action == 'labeled' || needs.release_policy.outputs.full_validation == 'true') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
-      verification_only: ${{ github.event_name == 'pull_request' && !((github.event.action == 'edited' || github.event.action == 'labeled' || needs.release_policy.outputs.full_validation == 'true') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
+      should_distribute: ${{ github.event_name != 'pull_request' || (needs.release_policy.outputs.full_validation == 'true' && (github.event.action != 'edited' || github.event.changes.title.from != '') && (github.event.action != 'labeled' || github.event.label.name == 'ci:full') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
+      verification_only: ${{ github.event_name == 'pull_request' && !(needs.release_policy.outputs.full_validation == 'true' && (github.event.action != 'edited' || github.event.changes.title.from != '') && (github.event.action != 'labeled' || github.event.label.name == 'ci:full') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
     secrets: inherit
 
-  # CocoaPods is retained on main and automatically validates release-bearing PRs.
+  # CocoaPods is retained on main. PR-time CocoaPods correctness is owned by the
+  # path-filtered Validate CocoaPods integration workflow to avoid duplicates.
   build-secondary-app:
-    if: >-
-      always() &&
-      (github.event_name != 'pull_request' ||
-      github.event.action == 'edited' ||
-      github.event.action == 'labeled' ||
-      needs.release_policy.outputs.full_validation == 'true')
+    if: always() && github.event_name != 'pull_request'
     needs: [ release_policy, update-pr-comment ]
     uses: ./.github/workflows/reusable-build-sample-apps.yml
     with:
@@ -107,9 +100,9 @@ jobs:
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
-      (github.event.action == 'edited' ||
-      github.event.action == 'labeled' ||
-      needs.release_policy.outputs.full_validation == 'true') &&
+      needs.release_policy.outputs.full_validation == 'true' &&
+      (github.event.action != 'edited' || github.event.changes.title.from != '') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     needs: [ release_policy, update-pr-comment, build-primary-app, build-secondary-app ]
@@ -136,23 +129,3 @@ jobs:
           body: |
             * flutter_sample_spm: Build failed. See [CI job logs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) to determine the issue and try re-building.
           edit-mode: append # append new line to the existing PR comment to build a list of all sample app builds.
-
-      - name: Report CocoaPods sample build success
-        if: ${{ needs.build-secondary-app.result == 'success' }}
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          comment-id: ${{ needs.update-pr-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            * flutter_sample_cocoapods: Build succeeded.
-          edit-mode: append
-
-      - name: Report CocoaPods sample build failure
-        if: ${{ needs.build-secondary-app.result == 'failure' }}
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          comment-id: ${{ needs.update-pr-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            * flutter_sample_cocoapods: Build failed. See [CI job logs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
-          edit-mode: append

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -13,29 +13,32 @@ concurrency: # cancel previous workflow run if one exists.
   cancel-in-progress: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/feature/') }}
 
 jobs:
+  release_policy:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/reusable-release-policy.yml
+    permissions:
+      contents: read
+    with:
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
+      base_sha: ${{ github.event.pull_request.base.sha }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
+      head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+      target_repository: ${{ github.repository }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      ci_full: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+
   # Metadata edits rerun full so a newer skipped check cannot replace a failure.
   update-pr-comment:
     if: >-
+      always() &&
       github.event_name == 'pull_request' &&
       (github.event.action == 'edited' ||
       github.event.action == 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      startsWith(github.event.pull_request.title, 'fix:') ||
-      startsWith(github.event.pull_request.title, 'fix(') ||
-      startsWith(github.event.pull_request.title, 'feat:') ||
-      startsWith(github.event.pull_request.title, 'feat(') ||
-      startsWith(github.event.pull_request.title, 'perf:') ||
-      startsWith(github.event.pull_request.title, 'perf(') ||
-      startsWith(github.event.pull_request.title, 'revert:') ||
-      startsWith(github.event.pull_request.title, 'revert(') ||
-      startsWith(github.event.pull_request.title, 'Revert "') ||
-      contains(github.event.pull_request.body, 'This reverts commit') ||
-      contains(github.event.pull_request.title, '!:') ||
-      contains(github.event.pull_request.body, 'BREAKING CHANGE:') ||
-      contains(github.event.pull_request.body, 'BREAKING CHANGES:') ||
-      contains(github.event.pull_request.body, 'BREAKING-CHANGE:')) &&
+      needs.release_policy.outputs.full_validation == 'true') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'
+    needs: release_policy
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # to be able to comment on PR
@@ -70,15 +73,15 @@ jobs:
   # release-bearing title or `ci:full` adds distribution and CocoaPods coverage.
   build-primary-app:
     if: always()
-    needs: [ update-pr-comment ] # wait for PR comment to be created saying new builds are being made.
+    needs: [ release_policy, update-pr-comment ] # wait for PR comment to be created saying new builds are being made.
     uses: ./.github/workflows/reusable-build-sample-apps.yml
     with:
       use_latest_sdk_version: false
       sample_app_name: flutter_sample_spm
       cio_workspace_name: "Mobile: Flutter"
       is_primary_app: true
-      should_distribute: ${{ github.event_name != 'pull_request' || ((github.event.action == 'edited' || github.event.action == 'labeled' || contains(github.event.pull_request.labels.*.name, 'ci:full') || startsWith(github.event.pull_request.title, 'fix:') || startsWith(github.event.pull_request.title, 'fix(') || startsWith(github.event.pull_request.title, 'feat:') || startsWith(github.event.pull_request.title, 'feat(') || startsWith(github.event.pull_request.title, 'perf:') || startsWith(github.event.pull_request.title, 'perf(') || startsWith(github.event.pull_request.title, 'revert:') || startsWith(github.event.pull_request.title, 'revert(') || startsWith(github.event.pull_request.title, 'Revert "') || contains(github.event.pull_request.body, 'This reverts commit') || contains(github.event.pull_request.title, '!:') || contains(github.event.pull_request.body, 'BREAKING CHANGE:') || contains(github.event.pull_request.body, 'BREAKING CHANGES:') || contains(github.event.pull_request.body, 'BREAKING-CHANGE:')) && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
-      verification_only: ${{ github.event_name == 'pull_request' && !((github.event.action == 'edited' || github.event.action == 'labeled' || contains(github.event.pull_request.labels.*.name, 'ci:full') || startsWith(github.event.pull_request.title, 'fix:') || startsWith(github.event.pull_request.title, 'fix(') || startsWith(github.event.pull_request.title, 'feat:') || startsWith(github.event.pull_request.title, 'feat(') || startsWith(github.event.pull_request.title, 'perf:') || startsWith(github.event.pull_request.title, 'perf(') || startsWith(github.event.pull_request.title, 'revert:') || startsWith(github.event.pull_request.title, 'revert(') || startsWith(github.event.pull_request.title, 'Revert "') || contains(github.event.pull_request.body, 'This reverts commit') || contains(github.event.pull_request.title, '!:') || contains(github.event.pull_request.body, 'BREAKING CHANGE:') || contains(github.event.pull_request.body, 'BREAKING CHANGES:') || contains(github.event.pull_request.body, 'BREAKING-CHANGE:')) && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
+      should_distribute: ${{ github.event_name != 'pull_request' || ((github.event.action == 'edited' || github.event.action == 'labeled' || needs.release_policy.outputs.full_validation == 'true') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
+      verification_only: ${{ github.event_name == 'pull_request' && !((github.event.action == 'edited' || github.event.action == 'labeled' || needs.release_policy.outputs.full_validation == 'true') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
     secrets: inherit
 
   # CocoaPods is retained on main and automatically validates release-bearing PRs.
@@ -88,22 +91,8 @@ jobs:
       (github.event_name != 'pull_request' ||
       github.event.action == 'edited' ||
       github.event.action == 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      startsWith(github.event.pull_request.title, 'fix:') ||
-      startsWith(github.event.pull_request.title, 'fix(') ||
-      startsWith(github.event.pull_request.title, 'feat:') ||
-      startsWith(github.event.pull_request.title, 'feat(') ||
-      startsWith(github.event.pull_request.title, 'perf:') ||
-      startsWith(github.event.pull_request.title, 'perf(') ||
-      startsWith(github.event.pull_request.title, 'revert:') ||
-      startsWith(github.event.pull_request.title, 'revert(') ||
-      startsWith(github.event.pull_request.title, 'Revert "') ||
-      contains(github.event.pull_request.body, 'This reverts commit') ||
-      contains(github.event.pull_request.title, '!:') ||
-      contains(github.event.pull_request.body, 'BREAKING CHANGE:') ||
-      contains(github.event.pull_request.body, 'BREAKING CHANGES:') ||
-      contains(github.event.pull_request.body, 'BREAKING-CHANGE:'))
-    needs: [ update-pr-comment ]
+      needs.release_policy.outputs.full_validation == 'true')
+    needs: [ release_policy, update-pr-comment ]
     uses: ./.github/workflows/reusable-build-sample-apps.yml
     with:
       use_latest_sdk_version: false
@@ -120,24 +109,10 @@ jobs:
       github.event_name == 'pull_request' &&
       (github.event.action == 'edited' ||
       github.event.action == 'labeled' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
-      startsWith(github.event.pull_request.title, 'fix:') ||
-      startsWith(github.event.pull_request.title, 'fix(') ||
-      startsWith(github.event.pull_request.title, 'feat:') ||
-      startsWith(github.event.pull_request.title, 'feat(') ||
-      startsWith(github.event.pull_request.title, 'perf:') ||
-      startsWith(github.event.pull_request.title, 'perf(') ||
-      startsWith(github.event.pull_request.title, 'revert:') ||
-      startsWith(github.event.pull_request.title, 'revert(') ||
-      startsWith(github.event.pull_request.title, 'Revert "') ||
-      contains(github.event.pull_request.body, 'This reverts commit') ||
-      contains(github.event.pull_request.title, '!:') ||
-      contains(github.event.pull_request.body, 'BREAKING CHANGE:') ||
-      contains(github.event.pull_request.body, 'BREAKING CHANGES:') ||
-      contains(github.event.pull_request.body, 'BREAKING-CHANGE:')) &&
+      needs.release_policy.outputs.full_validation == 'true') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'
-    needs: [ update-pr-comment, build-primary-app, build-secondary-app ]
+    needs: [ release_policy, update-pr-comment, build-primary-app, build-secondary-app ]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # to be able to comment on PR

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -16,8 +16,8 @@ concurrency: # cancel previous workflow run if one exists.
       github.event_name == 'pull_request' &&
       ((github.event.action == 'labeled' && github.event.label.name != 'ci:full') ||
       (github.event.action == 'edited' &&
-      !github.event.changes.title &&
-      !github.event.changes.base)) &&
+      github.event.changes.title == null &&
+      github.event.changes.base == null)) &&
       'metadata' || 'validation'
     }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/feature/') }}
@@ -39,7 +39,9 @@ jobs:
       always() &&
       github.event_name == 'pull_request' &&
       needs.release_policy.outputs.full_validation == 'true' &&
-      (github.event.action != 'edited' || github.event.changes.title.from != '') &&
+      (github.event.action != 'edited' ||
+      github.event.changes.title != null ||
+      github.event.changes.base != null) &&
       (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'
@@ -87,8 +89,8 @@ jobs:
       sample_app_name: flutter_sample_spm
       cio_workspace_name: "Mobile: Flutter"
       is_primary_app: true
-      should_distribute: ${{ github.event_name != 'pull_request' || (needs.release_policy.outputs.full_validation == 'true' && (github.event.action != 'edited' || github.event.changes.title.from != '') && (github.event.action != 'labeled' || github.event.label.name == 'ci:full') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
-      verification_only: ${{ github.event_name == 'pull_request' && !(needs.release_policy.outputs.full_validation == 'true' && (github.event.action != 'edited' || github.event.changes.title.from != '') && (github.event.action != 'labeled' || github.event.label.name == 'ci:full') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
+      should_distribute: ${{ github.event_name != 'pull_request' || (needs.release_policy.outputs.full_validation == 'true' && (github.event.action != 'edited' || github.event.changes.title != null || github.event.changes.base != null) && (github.event.action != 'labeled' || github.event.label.name == 'ci:full') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
+      verification_only: ${{ github.event_name == 'pull_request' && !(needs.release_policy.outputs.full_validation == 'true' && (github.event.action != 'edited' || github.event.changes.title != null || github.event.changes.base != null) && (github.event.action != 'labeled' || github.event.label.name == 'ci:full') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
     secrets: inherit
 
   # CocoaPods is retained on main. PR-time CocoaPods correctness is owned by the
@@ -111,7 +113,9 @@ jobs:
       always() &&
       github.event_name == 'pull_request' &&
       needs.release_policy.outputs.full_validation == 'true' &&
-      (github.event.action != 'edited' || github.event.changes.title.from != '') &&
+      (github.event.action != 'edited' ||
+      github.event.changes.title != null ||
+      github.event.changes.base != null) &&
       (github.event.action != 'labeled' || github.event.label.name == 'ci:full') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]'

--- a/.github/workflows/check-api-changes.yml
+++ b/.github/workflows/check-api-changes.yml
@@ -1,6 +1,9 @@
 name: Check API Changes
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 # Cancel jobs and just run the last one
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,5 +18,7 @@ jobs:
     - name: Verify Xcode 27 Flutter sample pins
       run: apps/scripts/verify_xcode27_flutter_version.sh
     - uses: ./.github/actions/setup-flutter
+    # This analyzes the root package and installed sample apps with fatal infos
+    # and warnings. A second root-level `dart analyze` covers the same sources.
     - name: Run flutter analyze
       run: flutter analyze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,3 @@ jobs:
     - uses: ./.github/actions/setup-flutter
     - name: Run flutter analyze
       run: flutter analyze
-    - name: Run dart analyze as deployment process also runs it
-      run: dart analyze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 # Cancel jobs and just run the last one
 concurrency:

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -2,7 +2,7 @@ name: Semantic PR helper
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, labeled, unlabeled]
+    types: [opened, reopened, edited, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,35 +12,6 @@ jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      issues: write
       pull-requests: write # to comment on PRs
     steps:
     - uses: levibostian/action-conventional-pr-linter@acd7e6035a4c70ae2e6aab469c791cc5ca2a989d # v4.0.1
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Verify release validation policy
-      id: release-policy
-      env:
-        PR_TITLE: ${{ github.event.pull_request.title }}
-        PR_BODY: ${{ github.event.pull_request.body }}
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-        TARGET_REPOSITORY: ${{ github.repository }}
-        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        CI_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
-      run: bash .github/scripts/validate-release-policy.sh
-    # GITHUB_TOKEN label events do not start workflows. Gated workflows scan
-    # commits independently; this label is a durable, visible explanation.
-    - name: Mark automatically detected full validation
-      if: steps.release-policy.outputs.requires_full_label == 'true'
-      env:
-        GH_TOKEN: ${{ github.token }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-        REPOSITORY: ${{ github.repository }}
-      run: >-
-        gh api "repos/$REPOSITORY/issues/$PR_NUMBER/labels"
-        --method POST
-        --raw-field 'labels[]=ci:full'

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -32,7 +32,9 @@ jobs:
         PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         CI_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
       run: bash .github/scripts/validate-release-policy.sh
-    - name: Automatically request full validation for release-bearing commits
+    # GITHUB_TOKEN label events do not start workflows. Gated workflows scan
+    # commits independently; this label is a durable, visible explanation.
+    - name: Mark automatically detected full validation
       if: steps.release-policy.outputs.requires_full_label == 'true'
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write # to comment on PRs
     steps:
     - uses: levibostian/action-conventional-pr-linter@acd7e6035a4c70ae2e6aab469c791cc5ca2a989d # v4.0.1
@@ -20,6 +21,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Verify release validation policy
+      id: release-policy
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
         PR_BODY: ${{ github.event.pull_request.body }}
@@ -30,3 +32,13 @@ jobs:
         PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         CI_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
       run: bash .github/scripts/validate-release-policy.sh
+    - name: Automatically request full validation for release-bearing commits
+      if: steps.release-policy.outputs.requires_full_label == 'true'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPOSITORY: ${{ github.repository }}
+      run: >-
+        gh api "repos/$REPOSITORY/issues/$PR_NUMBER/labels"
+        --method POST
+        --raw-field 'labels[]=ci:full'

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -2,12 +2,31 @@ name: Semantic PR helper
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, labeled]
+    types: [opened, reopened, edited, synchronize, labeled, unlabeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write # to comment on PRs
-    steps:    
+    steps:
     - uses: levibostian/action-conventional-pr-linter@acd7e6035a4c70ae2e6aab469c791cc5ca2a989d # v4.0.1
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Verify release validation policy
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+        TARGET_REPOSITORY: ${{ github.repository }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        CI_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+      run: bash .github/scripts/validate-release-policy.sh

--- a/.github/workflows/reusable-build-sample-apps.yml
+++ b/.github/workflows/reusable-build-sample-apps.yml
@@ -207,7 +207,7 @@ jobs:
           echo "APP_VERSION_CODE=${{ env.APP_VERSION_CODE }}" >> $GITHUB_OUTPUT
 
       - name: Send Slack Notification for Sample App Builds (Android)
-        if: ${{ always() && inputs.is_primary_app }}
+        if: ${{ always() && inputs.is_primary_app && inputs.should_distribute }}
         uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1@main
         with:
           build_status: ${{ steps.android_build.outcome }}
@@ -435,7 +435,7 @@ jobs:
           echo "APP_VERSION_CODE=${{ env.APP_VERSION_CODE }}" >> $GITHUB_OUTPUT
 
       - name: Send Slack Notification for Sample App Builds (iOS)
-        if: ${{ always() && inputs.is_primary_app }}
+        if: ${{ always() && inputs.is_primary_app && inputs.should_distribute }}
         uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1@main
         with:
           build_status: ${{ steps.ios_build.outcome }}

--- a/.github/workflows/reusable-build-sample-apps.yml
+++ b/.github/workflows/reusable-build-sample-apps.yml
@@ -32,6 +32,11 @@ on:
         type: boolean
         required: false
         default: true
+      verification_only:
+        description: "Use PR-only dependency and cache optimizations without changing release callers"
+        type: boolean
+        required: false
+        default: false
     outputs:
       APP_VERSION_NAME:
         description: "The version name of the built app"
@@ -158,7 +163,7 @@ jobs:
       - name: Setup flutter environment and install dependencies
         uses: ./.github/actions/setup-flutter
         with:
-          install-sample-dependencies: 'false'
+          install-sample-dependencies: ${{ inputs.verification_only && 'false' || 'true' }}
 
       - name: Use SDK release version for sample app (if needed)
         working-directory: apps/${{ inputs.sample_app_name }}
@@ -365,7 +370,7 @@ jobs:
       - name: Setup flutter environment and install dependencies
         uses: ./.github/actions/setup-flutter
         with:
-          install-sample-dependencies: 'false'
+          install-sample-dependencies: ${{ inputs.verification_only && 'false' || 'true' }}
 
       - name: Use SDK release version for sample app (if needed)
         working-directory: apps/${{ inputs.sample_app_name }}
@@ -390,16 +395,25 @@ jobs:
         uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
 
       - name: Cache CocoaPods downloaded dependencies for faster builds in the future
-        if: ${{ inputs.sample_app_name != 'flutter_sample_spm' }}
+        if: ${{ inputs.sample_app_name != 'flutter_sample_spm' && !inputs.verification_only }}
+        uses: actions/cache@v4
+        with:
+          path: Pods
+          key: ${{ runner.os }}-${{ inputs.sample_app_name }}-Pods-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-${{ inputs.sample_app_name }}-Pods
+
+      - name: Cache CocoaPods dependencies for verification builds
+        if: ${{ inputs.sample_app_name != 'flutter_sample_spm' && inputs.verification_only }}
         uses: actions/cache@v4
         with:
           path: |
             ~/Library/Caches/CocoaPods
             ~/.cocoapods
             apps/${{ inputs.sample_app_name }}/ios/Pods
-          key: ${{ runner.os }}-${{ inputs.sample_app_name }}-Pods-${{ hashFiles('apps/flutter_sample_cocoapods/pubspec.lock', 'apps/flutter_sample_cocoapods/ios/Podfile', 'apps/flutter_sample_cocoapods/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ inputs.sample_app_name }}-Pods-v2-${{ hashFiles('pubspec.lock', 'ios/customer_io.podspec', 'apps/flutter_sample_cocoapods/pubspec.lock', 'apps/flutter_sample_cocoapods/ios/Podfile', 'apps/flutter_sample_cocoapods/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ inputs.sample_app_name }}-Pods-
+            ${{ runner.os }}-${{ inputs.sample_app_name }}-Pods-v2-
 
       - name: pod install
         if: ${{ inputs.sample_app_name != 'flutter_sample_spm' }}

--- a/.github/workflows/reusable-build-sample-apps.yml
+++ b/.github/workflows/reusable-build-sample-apps.yml
@@ -27,6 +27,11 @@ on:
         type: boolean
         required: false
         default: true
+      build_android_app:
+        description: "Whether to build the Android variant of this sample app"
+        type: boolean
+        required: false
+        default: true
     outputs:
       APP_VERSION_NAME:
         description: "The version name of the built app"
@@ -37,6 +42,7 @@ on:
 
 jobs:
   build-android-sample-app:
+    if: ${{ inputs.build_android_app }}
     defaults:
       run:
         working-directory: apps/${{ inputs.sample_app_name }}
@@ -151,6 +157,8 @@ jobs:
 
       - name: Setup flutter environment and install dependencies
         uses: ./.github/actions/setup-flutter
+        with:
+          install-sample-dependencies: 'false'
 
       - name: Use SDK release version for sample app (if needed)
         working-directory: apps/${{ inputs.sample_app_name }}
@@ -356,6 +364,8 @@ jobs:
 
       - name: Setup flutter environment and install dependencies
         uses: ./.github/actions/setup-flutter
+        with:
+          install-sample-dependencies: 'false'
 
       - name: Use SDK release version for sample app (if needed)
         working-directory: apps/${{ inputs.sample_app_name }}
@@ -383,10 +393,13 @@ jobs:
         if: ${{ inputs.sample_app_name != 'flutter_sample_spm' }}
         uses: actions/cache@v4
         with:
-          path: Pods
-          key: ${{ runner.os }}-${{ inputs.sample_app_name }}-Pods-${{ github.ref }}
+          path: |
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+            apps/${{ inputs.sample_app_name }}/ios/Pods
+          key: ${{ runner.os }}-${{ inputs.sample_app_name }}-Pods-${{ hashFiles('apps/flutter_sample_cocoapods/pubspec.lock', 'apps/flutter_sample_cocoapods/ios/Podfile', 'apps/flutter_sample_cocoapods/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ inputs.sample_app_name }}-Pods
+            ${{ runner.os }}-${{ inputs.sample_app_name }}-Pods-
 
       - name: pod install
         if: ${{ inputs.sample_app_name != 'flutter_sample_spm' }}

--- a/.github/workflows/reusable-release-policy.yml
+++ b/.github/workflows/reusable-release-policy.yml
@@ -6,23 +6,10 @@ on:
       pr_title:
         type: string
         required: true
-      pr_body:
-        type: string
-        required: false
-        default: ''
       base_sha:
         type: string
         required: true
       head_sha:
-        type: string
-        required: true
-      head_repository:
-        type: string
-        required: true
-      target_repository:
-        type: string
-        required: true
-      pr_author:
         type: string
         required: true
       ci_full:
@@ -30,7 +17,7 @@ on:
         required: true
     outputs:
       full_validation:
-        description: Whether this PR needs the full validation lane.
+        description: Whether release intent or ci:full requests distribution validation.
         value: ${{ jobs.classify.outputs.full_validation }}
 
 jobs:
@@ -48,15 +35,7 @@ jobs:
         id: policy
         env:
           PR_TITLE: ${{ inputs.pr_title }}
-          PR_BODY: ${{ inputs.pr_body }}
           BASE_SHA: ${{ inputs.base_sha }}
           HEAD_SHA: ${{ inputs.head_sha }}
-          HEAD_REPOSITORY: ${{ inputs.head_repository }}
-          TARGET_REPOSITORY: ${{ inputs.target_repository }}
-          PR_AUTHOR: ${{ inputs.pr_author }}
           CI_FULL: ${{ inputs.ci_full }}
-          # The semantic PR helper owns the trust-policy failure. Callers use
-          # this reusable workflow only to select safe full or light lanes.
-          ENFORCE_TRUSTED_RELEASE: 'false'
         run: bash .github/scripts/validate-release-policy.sh
-

--- a/.github/workflows/reusable-release-policy.yml
+++ b/.github/workflows/reusable-release-policy.yml
@@ -1,0 +1,62 @@
+name: Reusable release policy
+
+on:
+  workflow_call:
+    inputs:
+      pr_title:
+        type: string
+        required: true
+      pr_body:
+        type: string
+        required: false
+        default: ''
+      base_sha:
+        type: string
+        required: true
+      head_sha:
+        type: string
+        required: true
+      head_repository:
+        type: string
+        required: true
+      target_repository:
+        type: string
+        required: true
+      pr_author:
+        type: string
+        required: true
+      ci_full:
+        type: boolean
+        required: true
+    outputs:
+      full_validation:
+        description: Whether this PR needs the full validation lane.
+        value: ${{ jobs.classify.outputs.full_validation }}
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      full_validation: ${{ steps.policy.outputs.full_validation }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Classify release validation
+        id: policy
+        env:
+          PR_TITLE: ${{ inputs.pr_title }}
+          PR_BODY: ${{ inputs.pr_body }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          HEAD_REPOSITORY: ${{ inputs.head_repository }}
+          TARGET_REPOSITORY: ${{ inputs.target_repository }}
+          PR_AUTHOR: ${{ inputs.pr_author }}
+          CI_FULL: ${{ inputs.ci_full }}
+          # The semantic PR helper owns the trust-policy failure. Callers use
+          # this reusable workflow only to select safe full or light lanes.
+          ENFORCE_TRUSTED_RELEASE: 'false'
+        run: bash .github/scripts/validate-release-policy.sh
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 # Cancel jobs and just run the last one
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-flutter
+      with:
+        install-sample-dependencies: 'false'
     - name: Run Flutter tests
       run: flutter test
   
@@ -24,6 +26,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-flutter
+      with:
+        install-sample-dependencies: 'false'
 
     - name: Validate package for pub.dev
       run: flutter pub publish --dry-run

--- a/.github/workflows/validate-cocoapods.yml
+++ b/.github/workflows/validate-cocoapods.yml
@@ -1,0 +1,32 @@
+name: Validate CocoaPods integration
+
+on:
+  pull_request:
+    paths:
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'ios/**'
+      - 'apps/flutter_sample_cocoapods/**'
+      - 'scripts/test_cocoapods_deployment_target.rb'
+      - 'scripts/audit_cocoapods_deployment_targets.rb'
+      - 'apps/scripts/update_sample_app_sdk_version.dart'
+      - '.github/actions/setup-flutter/**'
+      - '.github/workflows/reusable-build-sample-apps.yml'
+      - '.github/workflows/validate-cocoapods.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-cocoapods:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+    uses: ./.github/workflows/reusable-build-sample-apps.yml
+    with:
+      use_latest_sdk_version: false
+      sample_app_name: flutter_sample_cocoapods
+      cio_workspace_name: "Mobile: Flutter"
+      should_distribute: false
+      build_android_app: false
+      verification_only: true
+    secrets: inherit

--- a/.github/workflows/validate-cocoapods.yml
+++ b/.github/workflows/validate-cocoapods.yml
@@ -20,26 +20,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release_policy:
+    uses: ./.github/workflows/reusable-release-policy.yml
+    permissions:
+      contents: read
+    with:
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
+      base_sha: ${{ github.event.pull_request.base.sha }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
+      head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+      target_repository: ${{ github.repository }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      ci_full: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+
   validate-cocoapods:
     # The main sample workflow owns this verification for release-bearing and
     # explicitly full PRs, avoiding a duplicate CocoaPods build.
     if: >-
+      always() &&
+      needs.release_policy.result == 'success' &&
       github.event.action != 'edited' &&
-      !contains(github.event.pull_request.labels.*.name, 'ci:full') &&
-      !startsWith(github.event.pull_request.title, 'fix:') &&
-      !startsWith(github.event.pull_request.title, 'fix(') &&
-      !startsWith(github.event.pull_request.title, 'feat:') &&
-      !startsWith(github.event.pull_request.title, 'feat(') &&
-      !startsWith(github.event.pull_request.title, 'perf:') &&
-      !startsWith(github.event.pull_request.title, 'perf(') &&
-      !startsWith(github.event.pull_request.title, 'revert:') &&
-      !startsWith(github.event.pull_request.title, 'revert(') &&
-      !startsWith(github.event.pull_request.title, 'Revert "') &&
-      !contains(github.event.pull_request.body, 'This reverts commit') &&
-      !contains(github.event.pull_request.title, '!:') &&
-      !contains(github.event.pull_request.body, 'BREAKING CHANGE:') &&
-      !contains(github.event.pull_request.body, 'BREAKING CHANGES:') &&
-      !contains(github.event.pull_request.body, 'BREAKING-CHANGE:')
+      needs.release_policy.outputs.full_validation != 'true'
+    needs: release_policy
     uses: ./.github/workflows/reusable-build-sample-apps.yml
     with:
       use_latest_sdk_version: false

--- a/.github/workflows/validate-cocoapods.yml
+++ b/.github/workflows/validate-cocoapods.yml
@@ -2,7 +2,7 @@ name: Validate CocoaPods integration
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
     paths:
       - 'pubspec.yaml'
       - 'pubspec.lock'
@@ -20,29 +20,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  release_policy:
-    uses: ./.github/workflows/reusable-release-policy.yml
-    permissions:
-      contents: read
-    with:
-      pr_title: ${{ github.event.pull_request.title }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
-      base_sha: ${{ github.event.pull_request.base.sha }}
-      head_sha: ${{ github.event.pull_request.head.sha }}
-      head_repository: ${{ github.event.pull_request.head.repo.full_name }}
-      target_repository: ${{ github.repository }}
-      pr_author: ${{ github.event.pull_request.user.login }}
-      ci_full: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
-
   validate-cocoapods:
-    # The main sample workflow owns this verification for release-bearing and
-    # explicitly full PRs, avoiding a duplicate CocoaPods build.
-    if: >-
-      always() &&
-      needs.release_policy.result == 'success' &&
-      github.event.action != 'edited' &&
-      needs.release_policy.outputs.full_validation != 'true'
-    needs: release_policy
+    # CocoaPods integration is correctness coverage selected by changed paths,
+    # independently of release naming or distribution intent.
     uses: ./.github/workflows/reusable-build-sample-apps.yml
     with:
       use_latest_sdk_version: false

--- a/.github/workflows/validate-cocoapods.yml
+++ b/.github/workflows/validate-cocoapods.yml
@@ -2,6 +2,7 @@ name: Validate CocoaPods integration
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     paths:
       - 'pubspec.yaml'
       - 'pubspec.lock'
@@ -20,7 +21,25 @@ concurrency:
 
 jobs:
   validate-cocoapods:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+    # The main sample workflow owns this verification for release-bearing and
+    # explicitly full PRs, avoiding a duplicate CocoaPods build.
+    if: >-
+      github.event.action != 'edited' &&
+      !contains(github.event.pull_request.labels.*.name, 'ci:full') &&
+      !startsWith(github.event.pull_request.title, 'fix:') &&
+      !startsWith(github.event.pull_request.title, 'fix(') &&
+      !startsWith(github.event.pull_request.title, 'feat:') &&
+      !startsWith(github.event.pull_request.title, 'feat(') &&
+      !startsWith(github.event.pull_request.title, 'perf:') &&
+      !startsWith(github.event.pull_request.title, 'perf(') &&
+      !startsWith(github.event.pull_request.title, 'revert:') &&
+      !startsWith(github.event.pull_request.title, 'revert(') &&
+      !startsWith(github.event.pull_request.title, 'Revert "') &&
+      !contains(github.event.pull_request.body, 'This reverts commit') &&
+      !contains(github.event.pull_request.title, '!:') &&
+      !contains(github.event.pull_request.body, 'BREAKING CHANGE:') &&
+      !contains(github.event.pull_request.body, 'BREAKING CHANGES:') &&
+      !contains(github.event.pull_request.body, 'BREAKING-CHANGE:')
     uses: ./.github/workflows/reusable-build-sample-apps.yml
     with:
       use_latest_sdk_version: false

--- a/apps/flutter_sample_spm/lib/src/app.dart
+++ b/apps/flutter_sample_spm/lib/src/app.dart
@@ -44,15 +44,22 @@ class _AmiAppState extends State<AmiApp> {
 
   AmiAppAuth get _auth => widget.auth;
 
-  final PageTransitionsTheme _pageTransitionsTheme = const PageTransitionsTheme(
-    builders: {
-      TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
-      TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
-      TargetPlatform.linux: FadeUpwardsPageTransitionsBuilder(),
-      TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
-      TargetPlatform.windows: FadeUpwardsPageTransitionsBuilder(),
-    },
-  );
+  final PageTransitionsTheme _pageTransitionsTheme =
+      _buildPageTransitionsTheme();
+
+  static PageTransitionsTheme _buildPageTransitionsTheme() {
+    final defaultBuilders = const PageTransitionsTheme().builders;
+
+    return PageTransitionsTheme(
+      builders: {
+        TargetPlatform.android: const FadeUpwardsPageTransitionsBuilder(),
+        TargetPlatform.iOS: defaultBuilders[TargetPlatform.iOS]!,
+        TargetPlatform.linux: const FadeUpwardsPageTransitionsBuilder(),
+        TargetPlatform.macOS: defaultBuilders[TargetPlatform.macOS]!,
+        TargetPlatform.windows: const FadeUpwardsPageTransitionsBuilder(),
+      },
+    );
+  }
   final List<ThemeExtension<dynamic>> _themeExtensions = [
     const Sizes.defaults(),
   ];

--- a/apps/flutter_sample_spm/lib/src/app.dart
+++ b/apps/flutter_sample_spm/lib/src/app.dart
@@ -1,5 +1,4 @@
 import 'package:customer_io/customer_io.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';


### PR DESCRIPTION
## Summary
- keep a representative SPM Android and iOS native compile on every routine PR
- move distributable builds and the redundant CocoaPods sample compile to `ci:full`
- remove duplicate feature-branch push builds while preserving main and manual behavior
- avoid distribution Slack noise in verification-only lanes

## Validation
- `flutter test` passed (111 tests)
- `flutter analyze lib test` passed
- `flutter pub publish --dry-run` passed with zero warnings
- changed workflow YAML passes differential Actionlint validation
- no release workflow changed