### PR TITLE
chore: resolve the published SDK version from the release job and validate before tagging

### DIFF
--- a/.github/workflows/build-sample-app-for-sdk-release.yml
+++ b/.github/workflows/build-sample-app-for-sdk-release.yml
@@ -2,7 +2,19 @@ name: Publish test apps for SDK release
 
 on:
   workflow_dispatch:
+    inputs:
+      sdk_version:
+        description: "Published SDK version to build sample apps with. Falls back to the latest git tag when empty."
+        required: false
+        type: string
+        default: ""
   workflow_call:
+    inputs:
+      sdk_version:
+        description: "Published SDK version to build sample apps with. Falls back to the latest git tag when empty."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build-primary-app:
@@ -12,4 +24,5 @@ jobs:
       sample_app_name: flutter_sample_spm
       cio_workspace_name: "Mobile: Flutter"
       is_primary_app: true
+      sdk_version: ${{ inputs.sdk_version }}
     secrets: inherit

--- a/.github/workflows/reusable-build-sample-apps.yml
+++ b/.github/workflows/reusable-build-sample-apps.yml
@@ -37,6 +37,11 @@ on:
         type: boolean
         required: false
         default: false
+      sdk_version:
+        description: "Published SDK version to build sample apps with. Falls back to the latest git tag when empty."
+        type: string
+        required: false
+        default: ""
     outputs:
       APP_VERSION_NAME:
         description: "The version name of the built app"
@@ -65,11 +70,21 @@ jobs:
       - name: Capture Git Context
         shell: bash
         id: git-context
+        env:
+          SDK_VERSION_INPUT: ${{ inputs.sdk_version }}
         run: |
           echo "BRANCH_NAME=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
           COMMIT_HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
           echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> $GITHUB_ENV
-          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+          # Last tag reachable from this commit. This answers an ancestry question ("how far ahead
+          # of the last release is this build?"), so it always comes from git.
+          LATEST_TAG=$(git describe --tags --abbrev=0 || true)
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          # Published version the sample app is pinned to. The release workflow passes the version
+          # semantic-release just published; `git describe` cannot resolve it, because
+          # semantic-release tags a new child commit and walking ancestors from this run's commit
+          # always returns the previous release.
+          echo "SDK_RELEASE_VERSION=${SDK_VERSION_INPUT:-$LATEST_TAG}" >> $GITHUB_ENV
 
       - name: Set Default Firebase Distribution Groups
         shell: bash
@@ -135,7 +150,7 @@ jobs:
         with:
           subdirectory: apps/${{ inputs.sample_app_name }}
           lane: "update_flutter_android_app_version"
-          options: ${{ inputs.use_latest_sdk_version == true && format('{{"version_name":"{0}"}}', env.LATEST_TAG) || '' }}
+          options: ${{ inputs.use_latest_sdk_version == true && format('{{"version_name":"{0}"}}', env.SDK_RELEASE_VERSION) || '' }}
         env:
           SDK_VERSION_NAME: ${{ env.SDK_VERSION_NAME }}
           APP_VERSION_NAME: ${{ env.APP_VERSION_NAME }}
@@ -155,7 +170,7 @@ jobs:
           COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
           echo "COMMITS_AHEAD_COUNT=$COMMITS_AHEAD" >> "$ENV_FILE"
           if [ "${{ inputs.use_latest_sdk_version }}" == "true" ]; then
-            echo "SDK_VERSION=${{ env.LATEST_TAG }}" >> "$ENV_FILE"
+            echo "SDK_VERSION=${{ env.SDK_RELEASE_VERSION }}" >> "$ENV_FILE"
           fi
 
       # Make sure to fetch dependencies only after updating the version numbers and workspace credentials
@@ -208,7 +223,7 @@ jobs:
         id: determine-sdk-version
         run: |
           if [[ "${{ inputs.use_latest_sdk_version }}" == "true" ]]; then
-            echo "APP_SDK_BUILD_VERSION=${{ env.LATEST_TAG }}" >> $GITHUB_ENV
+            echo "APP_SDK_BUILD_VERSION=${{ env.SDK_RELEASE_VERSION }}" >> $GITHUB_ENV
           else
             echo "APP_SDK_BUILD_VERSION=${{ env.SDK_VERSION_NAME }}" >> $GITHUB_ENV
           fi
@@ -254,11 +269,21 @@ jobs:
       - name: Capture Git Context
         shell: bash
         id: git-context
+        env:
+          SDK_VERSION_INPUT: ${{ inputs.sdk_version }}
         run: |
           echo "BRANCH_NAME=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
           COMMIT_HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
           echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> $GITHUB_ENV
-          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+          # Last tag reachable from this commit. This answers an ancestry question ("how far ahead
+          # of the last release is this build?"), so it always comes from git.
+          LATEST_TAG=$(git describe --tags --abbrev=0 || true)
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          # Published version the sample app is pinned to. The release workflow passes the version
+          # semantic-release just published; `git describe` cannot resolve it, because
+          # semantic-release tags a new child commit and walking ancestors from this run's commit
+          # always returns the previous release.
+          echo "SDK_RELEASE_VERSION=${SDK_VERSION_INPUT:-$LATEST_TAG}" >> $GITHUB_ENV
 
       - name: Test iOS lifecycle routing behavior
         if: ${{ inputs.is_primary_app }}
@@ -337,7 +362,7 @@ jobs:
         with:
           subdirectory: apps/${{ inputs.sample_app_name }}
           lane: "update_flutter_ios_app_version"
-          options: ${{ inputs.use_latest_sdk_version == true && format('{{"version_name":"{0}"}}', env.LATEST_TAG) || '' }}
+          options: ${{ inputs.use_latest_sdk_version == true && format('{{"version_name":"{0}"}}', env.SDK_RELEASE_VERSION) || '' }}
         env:
           SDK_VERSION_NAME: ${{ env.SDK_VERSION_NAME }}
           APP_VERSION_NAME: ${{ env.APP_VERSION_NAME }}
@@ -357,7 +382,7 @@ jobs:
           COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
           echo "COMMITS_AHEAD_COUNT=$COMMITS_AHEAD" >> "$ENV_FILE"
           if [ "${{ inputs.use_latest_sdk_version }}" == "true" ]; then
-            echo "SDK_VERSION=${{ env.LATEST_TAG }}" >> "$ENV_FILE"
+            echo "SDK_VERSION=${{ env.SDK_RELEASE_VERSION }}" >> "$ENV_FILE"
           fi
 
       - name: Setup workspace credentials in iOS environment files
@@ -450,7 +475,7 @@ jobs:
         id: determine-sdk-version
         run: |
           if [[ "${{ inputs.use_latest_sdk_version }}" == "true" ]]; then
-            echo "APP_SDK_BUILD_VERSION=${{ env.LATEST_TAG }}" >> $GITHUB_ENV
+            echo "APP_SDK_BUILD_VERSION=${{ env.SDK_RELEASE_VERSION }}" >> $GITHUB_ENV
           else
             echo "APP_SDK_BUILD_VERSION=${{ env.SDK_VERSION_NAME }}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/tag-and-deploy.yml
+++ b/.github/workflows/tag-and-deploy.yml
@@ -31,6 +31,16 @@ jobs:
       - name: Install sd CLI
         uses: kenji-miyake/setup-sd@08c14e27d65a1c215342ef00c81583ae67f4c5ef # v2.0.0
 
+      - uses: ./.github/actions/setup-flutter
+        with:
+          install-sample-dependencies: 'false'
+
+      # Run the same validation pub.dev enforces at publish time *before* the tag is created.
+      # `dart-package-publisher` fails on any dry-run warning, and it only runs after the tag
+      # exists, so a warning used to leave behind a tag for a version that was never published.
+      - name: Validate package can be published
+        run: flutter pub publish --dry-run
+
       - name: Deploy git tag via semantic-release
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0
         id: semantic-release
@@ -103,7 +113,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Flutter SDK failed deployment during step *create git tag*. View <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|CI server logs> to learn why and fix the issue. <https://github.com/customerio/mobile/blob/main/GIT-WORKFLOW.md|Learn more about the deployment process and how to fix errors>."
+                    "text": "Flutter SDK failed deployment during step *validate package & create git tag*. View <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|CI server logs> to learn why and fix the issue. <https://github.com/customerio/mobile/blob/main/GIT-WORKFLOW.md|Learn more about the deployment process and how to fix errors>."
                   }
                 }
               ]
@@ -199,6 +209,8 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   publish-sample-apps-public-builds:
-    needs: deploy-to-pub-dev
+    needs: [deploy-git-tag, deploy-to-pub-dev]
     uses: ./.github/workflows/build-sample-app-for-sdk-release.yml
+    with:
+      sdk_version: ${{ needs.deploy-git-tag.outputs.new_release_version }}
     secrets: inherit


### PR DESCRIPTION
Fixes MBL-2324

## Problem

Two independent defects in the Flutter release pipeline.

**1. Post-release sample-app builds use the *previous* release version.**

`reusable-build-sample-apps.yml` resolved the SDK version with `git describe --tags --abbrev=0`. That step runs on the commit that *triggered* the release, but semantic-release tags a **new child commit** (`chore: prepare for X [skip ci]`). `git describe` only walks ancestors, so it deterministically returns the previous release. Verified in this repo:

| tag | tagged commit | `git describe` from its parent |
| --- | --- | --- |
| 4.3.0 | 137a72c | 4.2.1 |
| 4.3.1 | 2fce824 | 4.3.0 |
| 4.4.0 | 80d89f5 | 4.3.1 |

`apps/scripts/update_sample_app_sdk_version.dart` then writes that stale value into the sample app's `pubspec.yaml` as an exact pin. One cause, three symptoms:

1. iOS Fastlane SPM conflict — `'customer_io-4.3.1' depends on 'customerio-ios' 4.7.5 and root depends on 'customerio-ios' 4.7.6`
2. Android Dart compile failure — `Member not found: 'liveActivities'` (the sample app uses APIs only in the version being released)
3. `flutter pub get` failure when the stale tag was never published (4.3.0 is tagged but is not on pub.dev)

**2. The git tag is cut before publish validation runs.**

`k-paxian/dart-package-publisher` fails on *any* `pub publish` dry-run warning, and it only runs in `deploy-to-pub-dev`, i.e. after `deploy-git-tag` has already created the tag. When #394 added a top-level `docs/` directory, the dry run emitted `Rename the top-level "docs" directory to "doc"` and the publish step aborted with `Dry 🏃 Failed, skip real publishing` — but tag `4.3.0` already existed, and that orphan tag then broke the following release run. The content issue was fixed by #398; the ordering was not.

## What changed

**Version resolution**

`LATEST_TAG` had two jobs conflated into one value, so this splits them rather than redefining it:

- `LATEST_TAG` keeps its current meaning — the last tag reachable from `HEAD`, always from `git describe`. Its one ancestry consumer, `COMMITS_AHEAD_COUNT` (`git rev-list $LAST_TAG..HEAD --count`), is a genuine ancestry question and is untouched on every code path, release included.
- New `SDK_RELEASE_VERSION` is the *published* version the sample app is pinned to: `${SDK_VERSION_INPUT:-$LATEST_TAG}`. It feeds the three consumers that all sit behind `use_latest_sdk_version` — the Fastlane `version_name`, the `.env` `SDK_VERSION` the Dart pin script reads, and the Slack `APP_SDK_BUILD_VERSION`.

Because the fallback triggers on an empty input rather than on event name, PR, push and `workflow_dispatch` builds resolve exactly as they do today; only the release path supplies a value.

- `reusable-build-sample-apps.yml`: new optional `sdk_version` input; both `Capture Git Context` steps (Android and iOS) updated. The two call sites turned out to be symmetric — identical `LATEST_TAG` consumer sets on both.
- `build-sample-app-for-sdk-release.yml`: threads `sdk_version` through from both `workflow_call` and `workflow_dispatch`.
- `tag-and-deploy.yml`: `publish-sample-apps-public-builds` now also `needs` `deploy-git-tag` and passes `sdk_version: ${{ needs.deploy-git-tag.outputs.new_release_version }}`. That output already existed; `needs` only exposes outputs of directly-listed jobs, so growing the `needs` list is the whole change. `deploy-to-pub-dev` already depended on `deploy-git-tag`, so job ordering is unchanged.

The version reaches the build through a nested reusable-workflow `uses:` chain — `tag-and-deploy.yml` → `build-sample-app-for-sdk-release.yml` → `reusable-build-sample-apps.yml` — so the input has to be declared and forwarded at each hop.

**Validate before tagging**

- `tag-and-deploy.yml`: `deploy-git-tag` now runs `flutter pub publish --dry-run` *before* the semantic-release step. A validation failure now fails the job before any tag exists.

Two notes on that choice:

- It is a plain `flutter pub publish --dry-run` rather than `dart-package-publisher` with `dryRunOnly: true`. The action short-circuits on `LOCAL_PACKAGE_VERSION == REMOTE_PACKAGE_VERSION` *before* it reaches the dry run — and on `main` before a release, `pubspec.yaml` still holds the last published version (4.4.0, matching pub.dev today), so the action would skip the dry run entirely and pass vacuously. The bare dry run reproduces the same gate faithfully: reintroducing a top-level `docs/` directory locally makes it exit 65 with the exact warning from the incident.
- The dry run is a step in the existing job rather than a new upstream job, so the job's existing `if: failure()` Slack notification still fires. Its message was updated to `*validate package & create git tag*`.

## Verification

- Both premises reproduced locally: the tag-on-child-commit table above, and `flutter pub publish --dry-run` exiting 65 on the `docs/` warning (0 warnings on `main` as-is).
- All three run shapes simulated against this checkout: release (input set) keeps `LATEST_TAG=4.4.0` with `COMMITS_AHEAD` unchanged while `SDK_RELEASE_VERSION` takes the passed version; PR/push (input empty) resolves both to `4.4.0`, identical to today; a tagless repo survives `bash -eo pipefail`, which is why the `git describe` call carries `|| true`.
- Bash lazy expansion of `${VAR:-...}` confirmed: `git describe` still runs once for `LATEST_TAG`, and the input short-circuits only the `SDK_RELEASE_VERSION` default.
- All workflow YAML re-parses cleanly.
- The release path itself can only be confirmed on the next real release — a PR cannot exercise a `push: [main]` workflow's `uses:` chain.

## Out of scope

The existing orphan tag `4.3.0` is deliberately left in place.
