### PR TITLE
feat(inbox): let apps configure visual inbox accessibility labels

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     // Version can be overridden for local/CI verification via -PcioVersion=<version>
     // (e.g. -PcioVersion=local to build against a mavenLocal build). The committed default
     // tracks the intended published release.
-    def cioVersion = rootProject.findProperty("cioVersion") ?: "4.21.0"
+    def cioVersion = rootProject.findProperty("cioVersion") ?: "4.21.1"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     // Version can be overridden for local/CI verification via -PcioVersion=<version>
     // (e.g. -PcioVersion=local to build against a mavenLocal build). The committed default
     // tracks the intended published release.
-    def cioVersion = rootProject.findProperty("cioVersion") ?: "4.20.2"
+    def cioVersion = rootProject.findProperty("cioVersion") ?: "4.21.0"
     implementation "io.customer.android:datapipelines:$cioVersion"
     implementation "io.customer.android:messaging-push-fcm:$cioVersion"
     implementation "io.customer.android:messaging-in-app:$cioVersion"

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/CustomerIOInAppMessaging.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/CustomerIOInAppMessaging.kt
@@ -17,6 +17,7 @@ import io.customer.messaginginapp.inbox.NotificationInbox
 import io.customer.messaginginapp.type.InAppEventListener
 import io.customer.messaginginapp.type.InAppMessage
 import io.customer.messaginginapp.type.InboxEventListener
+import io.customer.messaginginapp.type.NotificationInboxAccessibilityLabels
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.core.di.SDKComponent
@@ -28,6 +29,15 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.lang.ref.WeakReference
+
+/** Key of the accessibility labels sub-map inside the Dart `inApp` configuration. */
+private const val ACCESSIBILITY_LABELS_KEY = "notificationInboxAccessibilityLabels"
+
+/**
+ * Replaced with the unread count inside the `bellWithUnreadCount` template. Kept in sync with
+ * `NotificationInboxAccessibilityLabels.countPlaceholder` on the Dart side.
+ */
+private const val COUNT_PLACEHOLDER = "{count}"
 
 /**
  * Flutter module implementation for messaging in-app module in native SDKs. All functionality
@@ -221,9 +231,41 @@ internal class CustomerIOInAppMessaging(
                         flutterCommunicationChannel.invokeMethod(method, args)
                     }
                 })
+                .apply {
+                    inboxAccessibilityLabelsFrom(config)?.let { labels ->
+                        setNotificationInboxAccessibilityLabels(labels)
+                    }
+                }
                 .build(),
         )
         builder.addCustomerIOModule(module)
+    }
+
+    /**
+     * Builds the host's inbox accessibility labels from the Dart configuration, or null when the
+     * app provided none — in which case the SDK keeps its default of emitting no labels at all
+     * rather than falling back to English.
+     *
+     * `bellWithUnreadCount` arrives as a template string because the platform channel carries data
+     * but not functions; it is converted here into the `(Int) -> String` the native SDK expects. A
+     * template without the placeholder is returned verbatim for every count.
+     */
+    private fun inboxAccessibilityLabelsFrom(
+        config: Map<String, Any>
+    ): NotificationInboxAccessibilityLabels? {
+        val labels = config.getAs<Map<String, Any>>(
+            ACCESSIBILITY_LABELS_KEY
+        ) ?: return null
+
+        val unreadCountTemplate = labels.getAs<String>("bellWithUnreadCount")
+        return NotificationInboxAccessibilityLabels(
+            bell = labels.getAs<String>("bell"),
+            bellWithUnreadCount = unreadCountTemplate?.let { template ->
+                { count: Int -> template.replace(COUNT_PLACEHOLDER, count.toString()) }
+            },
+            loadingIndicator = labels.getAs<String>("loadingIndicator"),
+            emptyState = labels.getAs<String>("emptyState")
+        )
     }
 
     /**

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/CustomerIOInAppMessaging.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/CustomerIOInAppMessaging.kt
@@ -17,7 +17,6 @@ import io.customer.messaginginapp.inbox.NotificationInbox
 import io.customer.messaginginapp.type.InAppEventListener
 import io.customer.messaginginapp.type.InAppMessage
 import io.customer.messaginginapp.type.InboxEventListener
-import io.customer.messaginginapp.type.NotificationInboxAccessibilityLabels
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.core.di.SDKComponent
@@ -29,15 +28,6 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.lang.ref.WeakReference
-
-/** Key of the accessibility labels sub-map inside the Dart `inApp` configuration. */
-private const val ACCESSIBILITY_LABELS_KEY = "notificationInboxAccessibilityLabels"
-
-/**
- * Replaced with the unread count inside the `bellWithUnreadCount` template. Kept in sync with
- * `NotificationInboxAccessibilityLabels.countPlaceholder` on the Dart side.
- */
-private const val COUNT_PLACEHOLDER = "{count}"
 
 /**
  * Flutter module implementation for messaging in-app module in native SDKs. All functionality
@@ -239,33 +229,6 @@ internal class CustomerIOInAppMessaging(
                 .build(),
         )
         builder.addCustomerIOModule(module)
-    }
-
-    /**
-     * Builds the host's inbox accessibility labels from the Dart configuration, or null when the
-     * app provided none — in which case the SDK keeps its default of emitting no labels at all
-     * rather than falling back to English.
-     *
-     * `bellWithUnreadCount` arrives as a template string because the platform channel carries data
-     * but not functions; it is converted here into the `(Int) -> String` the native SDK expects. A
-     * template without the placeholder is returned verbatim for every count.
-     */
-    private fun inboxAccessibilityLabelsFrom(
-        config: Map<String, Any>
-    ): NotificationInboxAccessibilityLabels? {
-        val labels = config.getAs<Map<String, Any>>(
-            ACCESSIBILITY_LABELS_KEY
-        ) ?: return null
-
-        val unreadCountTemplate = labels.getAs<String>("bellWithUnreadCount")
-        return NotificationInboxAccessibilityLabels(
-            bell = labels.getAs<String>("bell"),
-            bellWithUnreadCount = unreadCountTemplate?.let { template ->
-                { count: Int -> template.replace(COUNT_PLACEHOLDER, count.toString()) }
-            },
-            loadingIndicator = labels.getAs<String>("loadingIndicator"),
-            emptyState = labels.getAs<String>("emptyState")
-        )
     }
 
     /**

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/InboxAccessibilityLabelsMapper.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/InboxAccessibilityLabelsMapper.kt
@@ -2,6 +2,7 @@ package io.customer.customer_io.messaginginapp
 
 import io.customer.customer_io.utils.getAs
 import io.customer.messaginginapp.type.NotificationInboxAccessibilityLabels
+import io.customer.sdk.core.di.SDKComponent
 
 /** Key of the accessibility labels sub-map inside the Dart `inApp` configuration. */
 internal const val ACCESSIBILITY_LABELS_KEY = "notificationInboxAccessibilityLabels"
@@ -29,6 +30,15 @@ internal fun inboxAccessibilityLabelsFrom(
     val labels = config.getAs<Map<String, Any>>(ACCESSIBILITY_LABELS_KEY) ?: return null
 
     val unreadCountTemplate = labels.getAs<String>("bellWithUnreadCount")
+    // A mistyped placeholder (`{COUNT}`, `{{count}}`, `%d`) substitutes nothing and is read aloud
+    // verbatim, braces included, with the count never announced. Nothing else in the stack can
+    // surface that, so say it here.
+    if (unreadCountTemplate != null && !unreadCountTemplate.contains(COUNT_PLACEHOLDER)) {
+        SDKComponent.logger.debug(
+            "Inbox accessibility label 'bellWithUnreadCount' has no '$COUNT_PLACEHOLDER' " +
+                "placeholder, so the unread count will not be announced."
+        )
+    }
     return NotificationInboxAccessibilityLabels(
         bell = labels.getAs<String>("bell"),
         bellWithUnreadCount = unreadCountTemplate?.let { template ->

--- a/android/src/main/kotlin/io/customer/customer_io/messaginginapp/InboxAccessibilityLabelsMapper.kt
+++ b/android/src/main/kotlin/io/customer/customer_io/messaginginapp/InboxAccessibilityLabelsMapper.kt
@@ -1,0 +1,40 @@
+package io.customer.customer_io.messaginginapp
+
+import io.customer.customer_io.utils.getAs
+import io.customer.messaginginapp.type.NotificationInboxAccessibilityLabels
+
+/** Key of the accessibility labels sub-map inside the Dart `inApp` configuration. */
+internal const val ACCESSIBILITY_LABELS_KEY = "notificationInboxAccessibilityLabels"
+
+/**
+ * Replaced with the unread count inside the `bellWithUnreadCount` template. Kept in sync with
+ * `NotificationInboxAccessibilityLabels.countPlaceholder` on the Dart side.
+ */
+internal const val COUNT_PLACEHOLDER = "{count}"
+
+/**
+ * Builds the host's inbox accessibility labels from the Dart configuration, or null when the app
+ * provided none — in which case the SDK keeps its default of emitting no labels at all rather than
+ * falling back to English.
+ *
+ * `bellWithUnreadCount` arrives as a template string because the platform channel carries data but
+ * not functions; it is converted here into the `(Int) -> String` the native SDK expects. A template
+ * without the placeholder is returned verbatim for every count.
+ *
+ * Top-level rather than a method on the plugin so it can be unit-tested without a Flutter binding.
+ */
+internal fun inboxAccessibilityLabelsFrom(
+    config: Map<String, Any>
+): NotificationInboxAccessibilityLabels? {
+    val labels = config.getAs<Map<String, Any>>(ACCESSIBILITY_LABELS_KEY) ?: return null
+
+    val unreadCountTemplate = labels.getAs<String>("bellWithUnreadCount")
+    return NotificationInboxAccessibilityLabels(
+        bell = labels.getAs<String>("bell"),
+        bellWithUnreadCount = unreadCountTemplate?.let { template ->
+            { count: Int -> template.replace(COUNT_PLACEHOLDER, count.toString()) }
+        },
+        loadingIndicator = labels.getAs<String>("loadingIndicator"),
+        emptyState = labels.getAs<String>("emptyState")
+    )
+}

--- a/android/src/test/kotlin/io/customer/customer_io/messaginginapp/InboxAccessibilityLabelsMapperTest.kt
+++ b/android/src/test/kotlin/io/customer/customer_io/messaginginapp/InboxAccessibilityLabelsMapperTest.kt
@@ -1,0 +1,84 @@
+package io.customer.customer_io.messaginginapp
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.Test
+
+/**
+ * The Dart side sends the unread-count label as a template because the platform channel carries
+ * data but not functions, so this mapper is where it becomes the `(Int) -> String` the native SDK
+ * takes. These tests pin that conversion and the absent-means-absent rule — a dropped label is
+ * silent at runtime (the SDK emits no text of its own, so the inbox just goes unlabeled).
+ */
+class InboxAccessibilityLabelsMapperTest {
+
+    private fun config(labels: Map<String, Any>): Map<String, Any> =
+        mapOf(ACCESSIBILITY_LABELS_KEY to labels)
+
+    @Test
+    fun `returns null when the app configured no labels`() {
+        assertNull(inboxAccessibilityLabelsFrom(mapOf("siteId" to "site")))
+    }
+
+    @Test
+    fun `maps every label from the Dart configuration`() {
+        val labels = inboxAccessibilityLabelsFrom(
+            config(
+                mapOf(
+                    "bell" to "Aviseringar",
+                    "loadingIndicator" to "Laddar",
+                    "emptyState" to "Inga aviseringar"
+                )
+            )
+        )
+
+        assertEquals("Aviseringar", labels?.bell)
+        assertEquals("Laddar", labels?.loadingIndicator)
+        assertEquals("Inga aviseringar", labels?.emptyState)
+    }
+
+    @Test
+    fun `substitutes the count into the unread template`() {
+        val labels = inboxAccessibilityLabelsFrom(
+            config(mapOf("bellWithUnreadCount" to "Aviseringar, {count} olasta"))
+        )
+
+        assertEquals("Aviseringar, 3 olasta", labels?.bellWithUnreadCount?.invoke(3))
+        assertEquals("Aviseringar, 0 olasta", labels?.bellWithUnreadCount?.invoke(0))
+    }
+
+    @Test
+    fun `substitutes every occurrence of the placeholder`() {
+        val labels = inboxAccessibilityLabelsFrom(
+            config(mapOf("bellWithUnreadCount" to "{count} av {count}"))
+        )
+
+        assertEquals("2 av 2", labels?.bellWithUnreadCount?.invoke(2))
+    }
+
+    @Test
+    fun `returns a template without the placeholder verbatim for every count`() {
+        val labels = inboxAccessibilityLabelsFrom(
+            config(mapOf("bellWithUnreadCount" to "Olasta aviseringar"))
+        )
+
+        assertEquals("Olasta aviseringar", labels?.bellWithUnreadCount?.invoke(1))
+        assertEquals("Olasta aviseringar", labels?.bellWithUnreadCount?.invoke(9))
+    }
+
+    @Test
+    fun `leaves unset labels null rather than inventing a fallback`() {
+        val labels = inboxAccessibilityLabelsFrom(config(mapOf("emptyState" to "Inga aviseringar")))
+
+        assertEquals("Inga aviseringar", labels?.emptyState)
+        assertNull(labels?.bell)
+        assertNull(labels?.bellWithUnreadCount)
+        assertNull(labels?.loadingIndicator)
+    }
+
+    @Test
+    fun `ignores a labels value that is not a map`() {
+        // Dart is typed, but the channel is not — a malformed payload must not crash initialization.
+        assertNull(inboxAccessibilityLabelsFrom(mapOf(ACCESSIBILITY_LABELS_KEY to "nonsense")))
+    }
+}

--- a/apps/flutter_sample_cocoapods/ios/Podfile
+++ b/apps/flutter_sample_cocoapods/ios/Podfile
@@ -71,7 +71,7 @@ target 'LiveActivityWidget' do
   # A widget extension cannot link the Flutter plugin pod, so it names the rendering pods itself.
   # Keep the version in step with pubspec.yaml's native_sdk_version.
   %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
-    pod cio_pod, '4.7.6'
+    pod cio_pod, '4.8.0'
   end
 end
 

--- a/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/flutter_sample_spm/ios/Runner.xcodeproj/project.pbxproj
@@ -968,7 +968,7 @@
 			repositoryURL = "https://github.com/customerio/customerio-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 4.7.6;
+				version = 4.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/apps/flutter_sample_spm/lib/src/customer_io.dart
+++ b/apps/flutter_sample_spm/lib/src/customer_io.dart
@@ -56,7 +56,18 @@ class CustomerIOSDK extends ChangeNotifier {
       final InAppConfig? inAppConfig;
       final migrationSiteId = _sdkConfig?.migrationSiteId;
       if (migrationSiteId != null) {
-        inAppConfig = InAppConfig(siteId: migrationSiteId);
+        inAppConfig = InAppConfig(
+          siteId: migrationSiteId,
+          // The SDK ships no text of its own in the visual inbox, so these are the only strings
+          // it can announce. A real app would resolve them through its own localizations so they
+          // follow the user's language; hardcoded here to keep the sample self-contained.
+          accessibilityLabels: const NotificationInboxAccessibilityLabels(
+            bell: 'Notifications',
+            bellWithUnreadCount: 'Notifications, {count} unread',
+            loadingIndicator: 'Loading inbox',
+            emptyState: 'No notifications',
+          ),
+        );
       } else {
         inAppConfig = null;
       }

--- a/customerio-flutter.api
+++ b/customerio-flutter.api
@@ -226,8 +226,12 @@ public final class GeofenceLocationMode {
 }
 
 public final class InAppConfig {
-	public fun new(required String siteId): InAppConfig;
+	public fun new(
+		required String siteId,
+		NotificationInboxAccessibilityLabels? accessibilityLabels
+	): InAppConfig;
 	public fun toMap(): Map<String, dynamic>;
+	public val accessibilityLabels: NotificationInboxAccessibilityLabels?;
 	public val siteId: String;
 }
 
@@ -418,6 +422,21 @@ public final class NotificationInbox {
 		InboxMessage message,
 		String? actionName
 	);
+}
+
+public final class NotificationInboxAccessibilityLabels {
+	public fun new(
+		String? bell,
+		String? bellWithUnreadCount,
+		String? loadingIndicator,
+		String? emptyState
+	): NotificationInboxAccessibilityLabels;
+	public fun toMap(): Map<String, dynamic>;
+	public val bell: String?;
+	public val bellWithUnreadCount: String?;
+	static public val countPlaceholder: String;
+	public val emptyState: String?;
+	public val loadingIndicator: String?;
 }
 
 public final class NotificationInboxBell {

--- a/ios/customer_io/Package.swift
+++ b/ios/customer_io/Package.swift
@@ -139,7 +139,7 @@ let package = Package(
     dependencies: [
         // Pinned exactly, matching `native_sdk_version` in pubspec.yaml and the podspec, so one
         // plugin version always resolves one native SDK across every package manager.
-        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.7.6"),
+        .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.8.0"),
         .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
     ],
     targets: [

--- a/lib/config/in_app_config.dart
+++ b/lib/config/in_app_config.dart
@@ -1,11 +1,19 @@
+import 'notification_inbox_accessibility_labels.dart';
+
 class InAppConfig {
   final String siteId;
 
-  InAppConfig({required this.siteId});
+  /// Accessibility labels for the Visual Notification Inbox. Optional; an omitted label leaves
+  /// that element unlabeled rather than falling back to English.
+  final NotificationInboxAccessibilityLabels? accessibilityLabels;
+
+  InAppConfig({required this.siteId, this.accessibilityLabels});
 
   Map<String, dynamic> toMap() {
     return {
       'siteId': siteId,
+      if (accessibilityLabels != null)
+        'notificationInboxAccessibilityLabels': accessibilityLabels!.toMap(),
     };
   }
 }

--- a/lib/config/notification_inbox_accessibility_labels.dart
+++ b/lib/config/notification_inbox_accessibility_labels.dart
@@ -1,0 +1,70 @@
+/// Host-provided accessibility labels for the Visual Notification Inbox UI.
+///
+/// The SDK ships no text of its own in the visual inbox — the empty state is an icon and the
+/// loading state is a spinner — so accessibility labels are the one place a string is still
+/// needed. Because the SDK cannot know your app's language, every label is optional and null by
+/// default, and an omitted label leaves that element unlabeled rather than falling back to
+/// English. Pass strings already localized for the user's language.
+///
+/// ```dart
+/// CustomerIO.initialize(
+///   config: CustomerIOConfig(
+///     cdpApiKey: '...',
+///     inAppConfig: InAppConfig(
+///       siteId: '...',
+///       accessibilityLabels: NotificationInboxAccessibilityLabels(
+///         bell: context.l10n.inboxBell,
+///         bellWithUnreadCount: context.l10n.inboxUnread, // "{count} olasta aviseringar"
+///         loadingIndicator: context.l10n.inboxLoading,
+///         emptyState: context.l10n.inboxEmpty,
+///       ),
+///     ),
+///   ),
+/// );
+/// ```
+class NotificationInboxAccessibilityLabels {
+  /// Label for the inbox bell button. Also used when the bell shows an unread badge but
+  /// [bellWithUnreadCount] is not provided. null → the bell is announced as an unnamed button
+  /// (it stays focusable and tappable; hiding it would leave screen reader users no way in).
+  final String? bell;
+
+  /// Label for the bell while it shows an unread badge. Include [countPlaceholder] where the
+  /// number of unread messages should appear; it is substituted natively at render time.
+  /// null → falls back to [bell].
+  ///
+  /// The badge itself is always hidden from assistive technologies, so the count is announced
+  /// only through this label, never as bare digits appended to the button.
+  ///
+  /// This is a template rather than a callback because configuration crosses the platform
+  /// channel, which carries data but not functions. One template cannot express languages whose
+  /// plural rules need a distinct form per count.
+  final String? bellWithUnreadCount;
+
+  /// Label announced for the loading spinner. null → no label, leaving only the indeterminate
+  /// progress role that the platform describes in the device's own language.
+  final String? loadingIndicator;
+
+  /// Label announced for the empty-state icon. null → the icon is treated as decorative.
+  final String? emptyState;
+
+  /// Replaced with the unread count inside [bellWithUnreadCount].
+  static const String countPlaceholder = '{count}';
+
+  const NotificationInboxAccessibilityLabels({
+    this.bell,
+    this.bellWithUnreadCount,
+    this.loadingIndicator,
+    this.emptyState,
+  });
+
+  /// Only the labels the host actually set are sent, so an unset label stays unset natively
+  /// rather than arriving as an explicit null the parsers would have to distinguish.
+  Map<String, dynamic> toMap() {
+    return {
+      if (bell != null) 'bell': bell,
+      if (bellWithUnreadCount != null) 'bellWithUnreadCount': bellWithUnreadCount,
+      if (loadingIndicator != null) 'loadingIndicator': loadingIndicator,
+      if (emptyState != null) 'emptyState': emptyState,
+    };
+  }
+}

--- a/lib/config/notification_inbox_accessibility_labels.dart
+++ b/lib/config/notification_inbox_accessibility_labels.dart
@@ -40,8 +40,12 @@ class NotificationInboxAccessibilityLabels {
   /// plural rules need a distinct form per count.
   final String? bellWithUnreadCount;
 
-  /// Label announced for the loading spinner. null → no label, leaving only the indeterminate
-  /// progress role that the platform describes in the device's own language.
+  /// Label announced for the loading spinner.
+  ///
+  /// null behaves differently per platform: on Android the spinner keeps its indeterminate
+  /// progress role, which TalkBack describes in the device's own language, while on iOS it is not
+  /// an accessibility element at all, so VoiceOver skips it rather than focusing an unnamed
+  /// control. Set a label if you want the loading state announced on both.
   final String? loadingIndicator;
 
   /// Label announced for the empty-state icon. null → the icon is treated as decorative.

--- a/lib/customer_io_config.dart
+++ b/lib/customer_io_config.dart
@@ -4,4 +4,5 @@ export 'config/in_app_config.dart';
 export 'config/ios_config.dart';
 export 'config/live_activities_config.dart';
 export 'config/location_config.dart';
+export 'config/notification_inbox_accessibility_labels.dart';
 export 'config/push_config.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ flutter:
         pluginClass: CustomerIOPlugin
       ios:
         pluginClass: CustomerIOPlugin
-        native_sdk_version: 4.7.6
+        native_sdk_version: 4.8.0
         firebase_wrapper_version: 1.0.0

--- a/test/notification_inbox_accessibility_labels_test.dart
+++ b/test/notification_inbox_accessibility_labels_test.dart
@@ -1,0 +1,73 @@
+import 'package:customer_io/config/in_app_config.dart';
+import 'package:customer_io/config/notification_inbox_accessibility_labels.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The labels are plain data: Dart hands them to the platform channel and the native side does
+/// the work — iOS parses the dictionary in `MessagingInAppConfigBuilder.build(from:)`, Android
+/// converts the `{count}` template into the `(Int) -> String` closure the SDK takes. What Dart
+/// owns is the contract, so these tests pin the wire keys and the absent-means-absent rule. A
+/// rename on either side silently drops every label rather than failing, because the SDK emits
+/// no text of its own — the inbox would just go unlabeled.
+void main() {
+  group('NotificationInboxAccessibilityLabels', () {
+    test('serializes every label under the keys the native parsers read', () {
+      const labels = NotificationInboxAccessibilityLabels(
+        bell: 'Aviseringar',
+        bellWithUnreadCount: 'Aviseringar, {count} olasta',
+        loadingIndicator: 'Laddar',
+        emptyState: 'Inga aviseringar',
+      );
+
+      expect(labels.toMap(), {
+        'bell': 'Aviseringar',
+        'bellWithUnreadCount': 'Aviseringar, {count} olasta',
+        'loadingIndicator': 'Laddar',
+        'emptyState': 'Inga aviseringar',
+      });
+    });
+
+    test('omits unset labels rather than sending explicit nulls', () {
+      const labels =
+          NotificationInboxAccessibilityLabels(emptyState: 'Inga aviseringar');
+
+      // The native default is "emit no label at all", so an unset label must not reach the
+      // platform channel as a key the parsers would have to distinguish from absent.
+      expect(labels.toMap(), {'emptyState': 'Inga aviseringar'});
+    });
+
+    test('is an empty map when nothing is configured', () {
+      expect(const NotificationInboxAccessibilityLabels().toMap(), isEmpty);
+    });
+
+    test('keeps the count placeholder intact for the native side', () {
+      const labels = NotificationInboxAccessibilityLabels(
+        bellWithUnreadCount: 'Aviseringar, {count} olasta',
+      );
+
+      // Dart must not interpolate: the count is only known natively, at render time.
+      expect(
+        labels.toMap()['bellWithUnreadCount'],
+        contains(NotificationInboxAccessibilityLabels.countPlaceholder),
+      );
+    });
+  });
+
+  group('InAppConfig', () {
+    test('nests the labels under the key shared with the native parsers', () {
+      final config = InAppConfig(
+        siteId: 'siteId',
+        accessibilityLabels:
+            const NotificationInboxAccessibilityLabels(bell: 'Aviseringar'),
+      );
+
+      expect(config.toMap(), {
+        'siteId': 'siteId',
+        'notificationInboxAccessibilityLabels': {'bell': 'Aviseringar'},
+      });
+    });
+
+    test('omits the labels entirely when the app configures none', () {
+      expect(InAppConfig(siteId: 'siteId').toMap(), {'siteId': 'siteId'});
+    });
+  });
+}


### PR DESCRIPTION
Exposes the visual notification inbox accessibility labels through the Flutter config, so host apps supply their own localized strings instead of the SDK shipping English text.

Fixes MBL-2366

## Notes
- iOS needs no native change: the `inApp` map already reaches `MessagingInAppConfigBuilder.build(from:)`, which parses these keys.
- Android builds the labels and converts the `{count}` template into the `(Int) -> String` closure the SDK takes — the channel carries data, not functions.
- `toMap()` omits unset labels rather than sending explicit nulls, and `InAppConfig` omits the labels map entirely when it serializes empty, so "configured nothing" and "configured an empty object" stay distinguishable natively.
- A `bellWithUnreadCount` missing its `{count}` placeholder is announced verbatim with no count. Dart warns about it: Android would log at debug, which the default error level discards, and iOS does not check at all, so neither native layer can report it where the developer would see it.
- Pins bumped to the native releases that added this config: iOS 4.8.0, Android 4.21.1 — `pubspec.yaml`, `android/build.gradle`, `ios/customer_io/Package.swift`, and both sample apps (the SPM sample's pbxproj and the cocoapods sample's Podfile). Both podspecs read `native_sdk_version` from pubspec, so they follow automatically.
- The sample app supplies labels at its single `initialize()` call. No other sample changes: the inbox screens already exist on main, and the empty state is reached by logging in with a profile that has no inbox messages.

## Verification
- `flutter test` — 122 passed (11 new)
- `flutter analyze` — no issues in `lib/` or `test/`
- `./scripts/check_api_changes.sh` — no API changes detected
- `./gradlew :customer_io:testDebugUnitTest` against Android SDK 4.21.1 — 7 tests, 0 failures (confirmed in the JUnit XML, since the plugin's Test tasks do not fail the build on their own)

🤖 Generated with [Claude Code](https://claude.com/claude-code)